### PR TITLE
Add automated dependency installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_store
 *.pyc
 *~
+.vagrant

--- a/AdFisher/README.md
+++ b/AdFisher/README.md
@@ -48,3 +48,12 @@ Architecture
 -----------
 
 AdFisher has two parts - an **examples** folder and a **core** folder. **examples** contains some example scripts to run experiments in addition to some test logs generated from our past experiments. The **core** comprises of several modules which setup the experiments and perform the analyses on the collected data. 
+
+Quick Start
+-----------
+This repository can be used with [Vagrant](https://www.vagrantup.com/) to quickly get a virtual machine with all the necessary dependencies described above installed.  This can be useful for development and testing experiments.
+
+1. git clone https://github.com/tadatitam/info-flow-experiments
+2. vagrant up
+
+This defaults to an Ubuntu Server 14.04 LTS (Trusty Tahr) build and will have the AdFisher source directory synced to /vagrant on the virtual machine

--- a/AdFisher/Vagrantfile
+++ b/AdFisher/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Official Ubuntu Server 14.04 LTS (Trusty Tahr) builds
+  config.vm.box = "ubuntu/trusty64"
+
+  # Provision with AdFisher dependencies
+  config.vm.provision :shell, path: "bootstrap.sh"
+
+end

--- a/AdFisher/Vagrantfile
+++ b/AdFisher/Vagrantfile
@@ -12,4 +12,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Provision with AdFisher dependencies
   config.vm.provision :shell, path: "bootstrap.sh"
 
+  # Give more memory. Firefox needs it.
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+
 end

--- a/AdFisher/bootstrap.sh
+++ b/AdFisher/bootstrap.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+
+### Install os dependencies
+apt-get update
+
+# Required for browsing
+apt-get install -y firefox 
+
+# Required for headless testing
+apt-get install -y xvfb 
+
+# Required for data analysis
+apt-get install -y python-numpy python-scipy python-matplotlib
+
+# Requiured for python dependencies
+apt-get install -y python-pip
+
+### Install python dependencies
+pip install -r /vagrant/requirements.txt
+
+# Fetch nltk stopwords corpus
+python -m nltk.downloader -d /usr/share/nltk_data stopwords

--- a/AdFisher/requirements.txt
+++ b/AdFisher/requirements.txt
@@ -2,7 +2,7 @@
 #
 #   pip install -r requirements.txt
 #
-selenium=
+selenium
 xvfbwrapper
 numpy
 scipy


### PR DESCRIPTION
Currently the requirements and dependencies for using AdFisher are well specified in the Readme, however it would be easier to get started if they were captured programmatically.

This pull request captures the requirements and dependencies into a simple bootstrap script. Also it adds a Vagrantfile to easily build a virtual machine and provision it using this bootstrap script.

This will allow anyone seeking to test, use, or contribute to AdFisher to easily get started in a virtual machine without modifying their machine or having to spend time configuring a suitable virtual machine.