### PR TITLE
Add features to catch price from the Amazon homepage and calculate the mean and std of two groups

### DIFF
--- a/AdFisher/core/adfisher.py
+++ b/AdFisher/core/adfisher.py
@@ -87,10 +87,10 @@ def do_experiment(make_unit, treatments, measurement, end_unit,
                                                    splitfrac=0.2, 
                                                    nfolds=10,
                                                    verbose=True)
-            # use classifier and features here to get top ads
-#             print "Extracting top features\n"
-#             topk0, topk1 = analysis.ml.print_only_top_features(classifier, features, treatment_names, feat_choice="ads")
-#             analysis.statistics.print_frequencies(X, y, features, topk0, topk1)
+            #use classifier and features here to get top ads
+            print "Extracting top features\n"
+            topk0, topk1 = analysis.ml.print_only_top_features(classifier, features, treatment_names, feat_choice="ads")
+            analysis.statistics.print_frequencies(X, y, features, topk0, topk1)
             
             print "Running permutation test\n"
             p_value = analysis.permutation_test.blocked_sampled_test(observed_values, unit_assignments, 
@@ -99,8 +99,11 @@ def do_experiment(make_unit, treatments, measurement, end_unit,
         else:
             observed_values, unit_assignments = X, y
             # use test_stat to get the keyword analysis
-            print "Running permutation test\n"
-            p_value = analysis.permutation_test.blocked_sampled_test(observed_values, unit_assignments, test_stat)
-        print "p-value: ", p_value
+            test_stat(observed_values, unit_assignments)
+            p_value = ""
+            #print "Running permutation test\n"
+            #p_value = analysis.permutation_test.blocked_sampled_test(observed_values, unit_assignments, test_stat)
+        if (p_value):
+          print "p-value: ", p_value
 
 

--- a/AdFisher/core/analysis/statistics.py
+++ b/AdFisher/core/analysis/statistics.py
@@ -1,13 +1,12 @@
 import sys
-
 import numpy as np                                      
 from scipy import stats                     # for chi2 test
 from scipy import spatial                   # for cosine distances
 from datetime import datetime               # counting times for running tests
-
+import math
 from itertools import combinations as comb  # permutations for old permutation test
 import random                               # for random shuffles
-
+from scipy.stats import t
 
 #------------- functions computing Statistics ---------------#
 
@@ -120,6 +119,63 @@ def print_counts(X,y):                                          # check
     print "[treatments] [blocks] [features] [unique-features] :: ", ua, count, counts, ucounts
     print ""
 
+def print_mean(array_ind_ad):
+    array_price_control = []
+    array_price_experimental = []
+    max_value_control = {}
+    max_value_experimental = {}
+    min_value_control = {}
+    min_value_experimental = {}
+    for ad in array_ind_ad:
+        title = ad["title"].translate(None, '|$')
+        body = ad["body"].translate(None, '|$')
+        label = ad["label"].translate(None, '|$')
+        price = ad["price"].translate(None, ' |$')
 
-
-
+        if (float(label) == 0):
+            try:
+                array_price_control.append(float(price))
+            except ValueError,e:
+                print "error",e
+        elif (float(label) == 1):
+            try:
+                array_price_experimental.append(float(price))
+            except ValueError,e:
+                print "error",e
+    std_control = np.std(array_price_control)
+    std_experimental = np.std(array_price_experimental)
+######### calculate difference between two means ref: http://onlinestatbook.com/2/tests_of_means/difference_means.html    
+    SSE = 0
+    df = float(len(array_price_control)-1+len(array_price_experimental)-1)
+    for value in array_price_control:
+        SSE = SSE + (float(value)-np.mean(array_price_control))**2
+    for value in array_price_experimental:
+        SSE = SSE + (float(value)-np.mean(array_price_experimental))**2
+    MSE = SSE/df
+    nh = 1/(1/float(len(array_price_control))+1/float(len(array_price_experimental)))
+    SM1M2 = math.sqrt(float(2*MSE/nh))
+    t_value = (float(np.mean(array_price_control))-float(np.mean(array_price_experimental)))/SM1M2
+    p_value = (1-stats.t.cdf(t_value, df))*2
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "control (chrome): group size = " 
+    print len(array_price_control)
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "control (chrome): mean = " 
+    print np.mean(array_price_control)
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "control (chrome): standard deviation = " 
+    print std_control
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "experimental (firefox): group size = " 
+    print len(array_price_experimental)
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "experimental (firefox): mean = " 
+    print np.mean(array_price_experimental)
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "experimental (firefox): standard deviation = " 
+    print std_experimental
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    print "P-value is"
+    print p_value
+    print "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    

--- a/AdFisher/core/converter/price.py
+++ b/AdFisher/core/converter/price.py
@@ -1,0 +1,121 @@
+import re                                       # regular expressions
+from stemming.porter2 import stem               # for Porter Stemming 
+import common
+from datetime import datetime, timedelta            # to read timestamps reloadtimes
+    
+########### CHOICES FOR THE AD-COMPARISON, AD-IDENTIFICATION #############
+
+# Choices for what to uniquely identify an ad with
+URL = 1
+TITLE_URL = 2
+TITLE_BODY = 3
+
+# Choices for assigning weight to the vector
+NUM = 1
+LOG_NUM = 2
+
+########### AD CLASS #############
+
+class Price:
+
+    def __init__(self, value, treatment_id, separator = '@|'):
+        chunks = re.split(separator, value)
+        self.time = datetime.strptime(chunks[0], "%Y-%m-%d %H:%M:%S.%f")
+        self.title = chunks[1]
+        self.url = chunks[2]
+        self.body = chunks[3]
+        self.label = treatment_id
+
+        
+#     def __init__(self, ad):
+#         self.title = common.strip_tags(ad['Title'])
+#         self.url = common.strip_tags(ad['URL'])
+#         self.body = common.strip_tags(ad['Body'])
+#         self.cat = ad['cat']
+#         self.time = ad['Time']
+    
+
+    
+    def ad_init(self, t, u, b, c, time, lbl):
+        self.title = strip_tags(t)
+        self.url = strip_tags(u)
+        self.body = strip_tags(b)
+        self.cat = c
+        self.time = time
+        self.label = lbl    
+    
+    
+    def printStuff(self, coeff, C, c):
+#       print "\multicolumn{1}{l}{", self.title, "; \url{", self.url, "}} & \multirow{2}{*}{", round(coeff, 3), 
+#       print "} & \multirow{2}{*}{", a, "(", round(100.*a/(a+b), 1), "\%)} & \multirow{2}{*}{", b, "(", round(100.*b/(a+b), 1), "\%)}\\\\"
+#       print "\multicolumn{1}{l}{", self.body, "}\\\\"
+#       print "\hline"
+        
+#       print "\TitleParbox{", self.title, "; \url{", self.url, "}; ", self.body, "} & ",
+#       print round(coeff, 3), " & ", a, "(", round(100.*a/(a+b), 1), "\%) & ", b, "(", round(100.*b/(a+b), 1), "\%) \\\\"
+#       print "\hline \\\\"
+        
+#       print "\multirow{3}{*}{\TitleParbox{", self.title, "; \url{", self.url, "}; ", self.body, "}} & ",
+#       print "\multirow{3}{*}{", round(coeff, 3), "} &\n", int(c[0]), " & ", int(c[1]), " & ", int(C[0]), "& ", int(C[1]), " \\\\"
+#       print " & ", " & $", int(c[2]), "$ & $", int(c[3]), "$ & $", int(C[2]), "$ & $", int(C[3]), "$ \\\\"
+#       print "\cline{3-6}"
+#       print " & ", " & $", int(c[4]), "$ & $", int(c[5]), "$ & $", int(C[4]), "$ & $", int(C[5]), "$ \\\\"
+#       print "\hline \\\\"
+        
+        print self.title, " & \url{", self.url, "} & $", round(coeff, 3), "$ & $", 
+        print int(c[4]), "$ & $", int(c[5]), "$ & & $", int(C[4]), "$ & $", int(C[5]), "$ \\\\"
+        
+
+    
+    def display(self):
+        print ("Title: "+self.title)
+        print ("Price: "+self.url)
+        print ("Body: "+self.body+"\n")
+        
+    def identical_ad(self, ad, choice):
+#the choice should be change to both title and body are the same        
+        if(choice == URL):
+            if(self.body == ad.body and self.title == ad.title):
+                return(True)
+        elif(choice == TITLE_URL):
+            if(self.body == ad.body and self.title == ad.title):
+                return(True)
+        elif(choice == TITLE_BODY):
+            if(self.body == ad.body and self.title == ad.title):
+                return(True)
+        else:
+            return(False)   
+            
+    def contains(self, nonces):
+        for nonce in nonces:
+            if (nonce in self.title.lower() or nonce in self.url.lower() or nonce in self.body.lower()):
+#                 print self.label,
+#                 self.display()
+#                 raw_input("h")
+                return True
+        return False
+                    
+    def ad_to_words(self):                          # returns a list of words from an ad
+        line = self.title+ " " + self.body
+        list = re.split(r'[.(), !<>\/:=?;\-\n]+|', line)
+        for i in range(0,len(list)):
+            list[i] = list[i].replace('\xe2\x80\x8e', '')
+            list[i] = list[i].replace('\xc2\xae', '') 
+            list[i] = list[i].replace('\xe2\x84\xa2', '') 
+            list[i] = list[i].replace('\xc3\xa9', '') 
+            list[i] = list[i].replace('\xc3\xa1', '') 
+        list = [x for x in list if len(x)>1]
+        return list
+        
+    def fit_to_feat(self, word_v, wchoice):         # fits an ad to a feature vector, returns a weight vector
+        vec = []
+        words = self.ad_to_words()
+        stemmed_words = common.stem_low_wvec(words)
+        words = common.strip_vec(words)
+        # print words
+        for word in word_v:
+            if(wchoice == NUM):
+                vec.append(float(words.count(word)))
+            elif(wchoice == LOG_NUM):
+                vec.append(math.log(float(words.count(word))))
+        return vec

--- a/AdFisher/core/web/amazon_prices.py
+++ b/AdFisher/core/web/amazon_prices.py
@@ -29,3 +29,74 @@ class AmazonPricesUnit(google_ads.GoogleAdsUnit):
 
     def __init__(self, browser, log_file, unit_id, treatment_id, headless=False, proxy=None):
         google_ads.GoogleAdsUnit.__init__(self, browser, log_file, unit_id, treatment_id, headless, proxy=proxy)
+
+    def collect_ads(self, reloads, delay, site, file_name=None):
+        if file_name == None:
+            file_name = self.log_file
+        rel = 0
+        while (rel < reloads):  # number of reloads on sites to capture all ads
+            time.sleep(delay)
+            try:
+                s = datetime.now()
+                if(site == 'amazon'):
+                    self.save_ads_amazon(file_name)
+                elif(site == 'bbc'):
+                    self.save_ads_bbc(file_name)
+                else:
+                    raw_input("No such site found: %s!" % site)
+                e = datetime.now()
+                self.log('measurement', 'loadtime', str(e-s))
+            except:
+                self.log('error', 'collecting ads', 'Error')
+            rel = rel + 1
+
+    def save_ads_bbc(self, file):
+        driver = self.driver
+        id = self.unit_id
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        driver.set_page_load_timeout(60)
+        driver.get("http://www.bbc.com/news/")
+        tim = str(datetime.now())
+        els = driver.find_elements_by_css_selector("div.bbccom_adsense_container ul li")
+        for el in els:
+            t = el.find_element_by_css_selector("h4 a").get_attribute('innerHTML')
+            ps = el.find_elements_by_css_selector("p")
+            b = ps[0].get_attribute('innerHTML')
+            l = ps[1].find_element_by_css_selector("a").get_attribute('innerHTML')
+            ad = strip_tags(tim+"@|"+t+"@|"+l+"@|"+b).encode("utf8")
+            self.log('measurement', 'ad', ad)
+
+    def save_ads_amazon(self, file):
+        driver = self.driver
+        
+        id = self.unit_id
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        driver.set_page_load_timeout(60)
+        driver.get("http://www.amazon.com")
+        tim = str(datetime.now())
+        els = driver.find_elements_by_css_selector("div#desktop-7 div div.feed-carousel div ul li")
+        n=0
+####collect the first two ads in the last column
+        for el in els:
+            n=n+1
+            if n >=3:
+                break
+            ActionChains(driver).move_to_element(el).perform()
+            cl = driver.find_element_by_xpath("//span[@id='gw-quick-look-btn']")
+            ActionChains(driver).move_to_element(cl).click(cl).perform()
+            time.sleep(5)
+            t = driver.find_element_by_xpath("//div[@class='byline a-color-tertiary']").get_attribute('innerHTML')
+            b = driver.find_element_by_xpath("//div[@class='details']/a[@class='title']").get_attribute('innerHTML')
+            l = driver.find_element_by_xpath("//span[@class='a-color-price']").get_attribute('innerHTML')
+            ad = strip_tags(tim+"@|"+t+"@|"+l+"@|"+b).encode("utf8")
+            self.log('measurement', 'price', ad)
+            exit = driver.find_element_by_xpath("//i[@id='gw-popover-close']")
+            ActionChains(driver).move_to_element(exit).click(exit).perform()
+            time.sleep(5)
+
+
+
+
+

--- a/AdFisher/core/web/browser_unit.py
+++ b/AdFisher/core/web/browser_unit.py
@@ -42,7 +42,7 @@ class BrowserUnit:
                 print "Unidentified Platform"
                 sys.exit(0)
         elif(browser=='chrome'):
-            print "Expecting chromedriver at path specified in core/web/browser_unit"
+            #print "Expecting chromedriver at path specified in core/web/browser_unit"
             if (platform.system()=='Darwin'):
                 chromedriver = "../core/web/chromedriver/chromedriver_mac"
             elif (platform.system() == 'Linux'):

--- a/AdFisher/examples/amazon.txt
+++ b/AdFisher/examples/amazon.txt
@@ -1,0 +1,5 @@
+irs.gov
+deloitte.com
+pwc.com
+ey.com
+kpmg.com

--- a/AdFisher/examples/demo.txt
+++ b/AdFisher/examples/demo.txt
@@ -1,0 +1,5 @@
+google.com
+facebook.com
+youtube.com
+baidu.com
+yahoo.com

--- a/AdFisher/examples/demo_exp.py
+++ b/AdFisher/examples/demo_exp.py
@@ -23,7 +23,7 @@ def control_treatment(unit):
 
 # Experimental Group treatment
 def exp_treatment(unit):
-    unit.visit_sites(site_file)
+    #unit.visit_sites(site_file)
     pass
 
 

--- a/AdFisher/examples/group.amazon.py
+++ b/AdFisher/examples/group.amazon.py
@@ -1,0 +1,72 @@
+import sys
+sys.path.append("../core")          # files from the core 
+import adfisher                     # adfisher wrapper function
+import web.pre_experiment.alexa     # collecting top sites from alexa
+import web.amazon_prices               # interacting with Google ads and Ad Settings
+import converter.reader             # read log and create feature vectors
+import analysis.statistics          # statistics for significance testing
+
+log_file = 'log.group.amazon.txt'
+site_file = 'amazon.txt'
+
+def make_browser(unit_id, treatment_id):
+    if treatment_id==0:
+        #b = web.amazon_prices.AmazonPricesUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+        #    treatment_id=treatment_id, headless=True, proxy = 'proxy.pdl.cmu.edu:8080')
+        b = web.amazon_prices.AmazonPricesUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+    else:
+        #b = web.amazon_prices.AmazonPricesUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+        #    treatment_id=treatment_id, headless=True, proxy = 'proxy.pdl.cmu.edu:8080')
+        b = web.amazon_prices.AmazonPricesUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+
+
+web.pre_experiment.alexa.collect_sites(make_browser, num_sites=5, output_file=site_file,
+    alexa_link="http://www.alexa.com/topsites/category/Top/Business/Accounting")
+    
+    
+# Control Group treatment
+def control_treatment(unit):
+    unit.visit_sites(site_file)
+
+# Experimental Group treatment
+def exp_treatment(unit):
+    #unit.visit_sites(site_file)
+    unit.visit_sites(site_file)
+
+# Measurement - Collects ads
+def measurement(unit):
+    unit.collect_ads(reloads=20, delay=5, site='amazon')
+
+
+# Shuts down the browser once we are done with it.
+def cleanup_browser(unit):
+    unit.quit()
+
+# Load results reads the log_file, and creates feature vectors
+def load_results():
+    collection, names = converter.reader.read_log(log_file)
+    return converter.reader.get_feature_vectors(collection, feat_choice='ads')
+
+# If you choose to perform ML, then test_stat is redundant. By default, correctly_classified is used,
+# If not, then you can choose something, and that will be used to perform the analysis. 
+
+def test_stat(observed_values, unit_assignments):
+    #return analysis.statistics.difference(observed_values, unit_assignments)
+    collection, names, array_ind_ad = converter.reader.read_log_amazon(log_file)
+    return analysis.statistics.print_mean(array_ind_ad)
+
+    #return analysis.statistics.print_mean(array_ind_ad)
+
+#   return statistics.correctly_classified(observed_values, unit_assignments)
+
+adfisher.do_experiment(make_unit=make_browser, treatments=[control_treatment, exp_treatment], 
+                        measurement=measurement, end_unit=cleanup_browser,
+                        load_results=load_results, test_stat=test_stat, ml_analysis=False, 
+                        num_blocks=25, num_units=6, timeout=2000,
+                        log_file=log_file, exp_flag=True, analysis_flag=True, 
+                        treatment_names=["control (chrome)", "experimental (firefox)"])
+

--- a/AdFisher/examples/group.baseline.amazon.py
+++ b/AdFisher/examples/group.baseline.amazon.py
@@ -1,0 +1,74 @@
+import sys
+sys.path.append("../core")          # files from the core 
+import adfisher                     # adfisher wrapper function
+import web.pre_experiment.alexa     # collecting top sites from alexa
+import web.amazon_prices               # interacting with Google ads and Ad Settings
+import converter.reader             # read log and create feature vectors
+import analysis.statistics          # statistics for significance testing
+
+log_file = 'log.group.baseline.amazon.txt'
+site_file = 'baseline.amazon.txt'
+
+def make_browser(unit_id, treatment_id):
+    if treatment_id==0:
+        #b = web.amazon_prices.AmazonPricesUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+        #    treatment_id=treatment_id, headless=True, proxy = 'proxy.pdl.cmu.edu:8080')
+        b = web.amazon_prices.AmazonPricesUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+    else:
+        #b = web.amazon_prices.AmazonPricesUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+        #    treatment_id=treatment_id, headless=True, proxy = 'proxy.pdl.cmu.edu:8080')
+        b = web.amazon_prices.AmazonPricesUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+
+
+
+#web.pre_experiment.alexa.collect_sites(make_browser, num_sites=5, output_file=site_file,
+#    alexa_link="http://www.alexa.com/topsites/category/Top/Health/Addictions/Substance_Abuse")
+    
+    
+# Control Group treatment
+def control_treatment(unit):
+    pass
+
+# Experimental Group treatment
+def exp_treatment(unit):
+    #unit.visit_sites(site_file)
+    pass
+
+# Measurement - Collects ads
+def measurement(unit):
+    unit.collect_ads(reloads=20, delay=5, site='amazon')
+
+
+# Shuts down the browser once we are done with it.
+def cleanup_browser(unit):
+    unit.quit()
+
+# Load results reads the log_file, and creates feature vectors
+def load_results():
+    collection, names = converter.reader.read_log(log_file)
+    return converter.reader.get_feature_vectors(collection, feat_choice='ads')
+
+# If you choose to perform ML, then test_stat is redundant. By default, correctly_classified is used,
+# If not, then you can choose something, and that will be used to perform the analysis. 
+
+def test_stat(observed_values, unit_assignments):
+    #return analysis.statistics.difference(observed_values, unit_assignments)
+    collection, names, array_ind_ad = converter.reader.read_log_amazon(log_file)
+    
+    return analysis.statistics.print_mean(array_ind_ad)
+
+    #return analysis.statistics.print_mean(array_ind_ad)
+
+#   return statistics.correctly_classified(observed_values, unit_assignments)
+
+adfisher.do_experiment(make_unit=make_browser, treatments=[control_treatment, exp_treatment], 
+                        measurement=measurement, end_unit=cleanup_browser,
+                        load_results=load_results, test_stat=test_stat, ml_analysis=False, 
+                        num_blocks=25, num_units=6, timeout=2000,
+                        log_file=log_file, exp_flag=False, analysis_flag=True, 
+                        treatment_names=["control (chrome)", "experimental (firefox)"])
+

--- a/AdFisher/examples/group.baseline.py
+++ b/AdFisher/examples/group.baseline.py
@@ -1,0 +1,64 @@
+import sys
+sys.path.append("../core")          # files from the core 
+import adfisher                     # adfisher wrapper function
+import web.pre_experiment.alexa     # collecting top sites from alexa
+import web.google_ads               # interacting with Google ads and Ad Settings
+import converter.reader             # read log and create feature vectors
+import analysis.statistics          # statistics for significance testing
+
+log_file = 'log.group_baseline.txt'
+site_file = 'group_baseline.txt'
+
+def make_browser(unit_id, treatment_id):
+    #b = web.google_ads.GoogleAdsUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+    #    treatment_id=treatment_id, headless=False, proxy = None)
+    #return b
+    if treatment_id==0:
+        b = web.google_ads.GoogleAdsUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+    else:
+        b = web.google_ads.GoogleAdsUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+web.pre_experiment.alexa.collect_sites(make_browser, num_sites=5, output_file=site_file,
+    alexa_link="http://www.alexa.com/topsites/category/Top/Business/Accounting")
+    
+    
+# Control Group treatment
+def control_treatment(unit):
+    pass
+    #unit.visit_sites(site_file)
+# Experimental Group treatment
+def exp_treatment(unit):
+    #unit.visit_sites(site_file)
+    pass
+
+# Measurement - Collects ads
+def measurement(unit):
+    unit.collect_ads(reloads=10, delay=5, site='bbc')
+    
+
+# Shuts down the browser once we are done with it.
+def cleanup_browser(unit):
+    unit.quit()
+
+# Load results reads the log_file, and creates feature vectors
+def load_results():
+    collection, names = converter.reader.read_log(log_file)
+    return converter.reader.get_feature_vectors(collection, feat_choice='ads')
+
+# If you choose to perform ML, then test_stat is redundant. By default, correctly_classified is used,
+# If not, then you can choose something, and that will be used to perform the analysis. 
+
+def test_stat(observed_values, unit_assignments):
+    return analysis.statistics.difference(observed_values, unit_assignments)
+#   return statistics.correctly_classified(observed_values, unit_assignments)
+
+adfisher.do_experiment(make_unit=make_browser, treatments=[control_treatment, exp_treatment], 
+                        measurement=measurement, end_unit=cleanup_browser,
+                        load_results=load_results, test_stat=test_stat, ml_analysis=True, 
+                        num_blocks=20, num_units=4, timeout=2000,
+                        log_file=log_file, exp_flag=False, analysis_flag=True, 
+                        treatment_names=["control (chrome)", "experimental (firefox)"])
+

--- a/AdFisher/examples/group_baseline.txt
+++ b/AdFisher/examples/group_baseline.txt
@@ -1,0 +1,5 @@
+irs.gov
+deloitte.com
+pwc.com
+ey.com
+kpmg.com

--- a/AdFisher/examples/group_ex1.py
+++ b/AdFisher/examples/group_ex1.py
@@ -1,0 +1,64 @@
+import sys
+sys.path.append("../core")          # files from the core 
+import adfisher                     # adfisher wrapper function
+import web.pre_experiment.alexa     # collecting top sites from alexa
+import web.google_ads               # interacting with Google ads and Ad Settings
+import converter.reader             # read log and create feature vectors
+import analysis.statistics          # statistics for significance testing
+
+log_file = 'log.group_ex1.txt'
+site_file = 'group_ex1.txt'
+
+def make_browser(unit_id, treatment_id):
+    #b = web.google_ads.GoogleAdsUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+    #    treatment_id=treatment_id, headless=False, proxy = None)
+    #return b
+    if treatment_id==0:
+        b = web.google_ads.GoogleAdsUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+    else:
+        b = web.google_ads.GoogleAdsUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+web.pre_experiment.alexa.collect_sites(make_browser, num_sites=5, output_file=site_file,
+    alexa_link="http://www.alexa.com/topsites/category/Top/Business/Accounting")
+    
+    
+# Control Group treatment
+def control_treatment(unit):
+    #pass
+    unit.visit_sites(site_file)
+# Experimental Group treatment
+def exp_treatment(unit):
+    unit.visit_sites(site_file)
+
+
+# Measurement - Collects ads
+def measurement(unit):
+    unit.collect_ads(reloads=10, delay=5, site='bbc')
+    
+
+# Shuts down the browser once we are done with it.
+def cleanup_browser(unit):
+    unit.quit()
+
+# Load results reads the log_file, and creates feature vectors
+def load_results():
+    collection, names = converter.reader.read_log(log_file)
+    return converter.reader.get_feature_vectors(collection, feat_choice='ads')
+
+# If you choose to perform ML, then test_stat is redundant. By default, correctly_classified is used,
+# If not, then you can choose something, and that will be used to perform the analysis. 
+
+def test_stat(observed_values, unit_assignments):
+    return analysis.statistics.difference(observed_values, unit_assignments)
+#   return statistics.correctly_classified(observed_values, unit_assignments)
+
+adfisher.do_experiment(make_unit=make_browser, treatments=[control_treatment, exp_treatment], 
+                        measurement=measurement, end_unit=cleanup_browser,
+                        load_results=load_results, test_stat=test_stat, ml_analysis=True, 
+                        num_blocks=20, num_units=4, timeout=2000,
+                        log_file=log_file, exp_flag=False, analysis_flag=True, 
+                        treatment_names=["control (chrome)", "experimental (firefox)"])
+

--- a/AdFisher/examples/group_ex1.txt
+++ b/AdFisher/examples/group_ex1.txt
@@ -1,0 +1,5 @@
+irs.gov
+deloitte.com
+pwc.com
+ey.com
+kpmg.com

--- a/AdFisher/examples/group_ex2.py
+++ b/AdFisher/examples/group_ex2.py
@@ -1,0 +1,69 @@
+import sys, os
+sys.path.append("../core")          # files from the core 
+import adfisher                     # adfisher wrapper function
+import web.pre_experiment.alexa     # collecting top sites from alexa
+import web.google_news              # interacting with Google News
+import converter.reader             # read log and create feature vectors
+import analysis.statistics          # statistics for significance testing
+
+log_file = 'log.group_ex2.txt'
+site_file = 'group_ex2.txt'
+
+def make_browser(unit_id, treatment_id):
+    if treatment_id==0:
+        b = web.google_ads.GoogleAdsUnit(browser='chrome', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+    else:
+        b = web.google_ads.GoogleAdsUnit(browser='firefox', log_file=log_file, unit_id=unit_id, 
+            treatment_id=treatment_id, headless=False, proxy = None)
+        return b
+
+
+
+
+##======================== Make changes inside this block ========================##
+
+
+# Control Group treatment
+def control_treatment(unit):
+    unit.search_and_click(query_file = 'group_ex2_queries.txt', clickdelay = 10, clickcount = 3)
+
+# Experimental Group treatment
+def exp_treatment(unit):
+    unit.search_and_click(query_file = 'group_ex2_queries.txt', clickdelay = 10, clickcount = 3)
+
+# Measurement - Collects ads
+def measurement(unit):
+    unit.collect_ads(reloads=10, delay=5, site='toi')
+    #unit.get_news(type='top', reloads=5, delay=10)
+
+# Load results from the log_file and create feature vectors. feat_choice='ads' or 'news'
+def load_results():
+    collection, names = converter.reader.read_log(log_file)
+    return converter.reader.get_feature_vectors(collection, feat_choice='ads')
+    
+
+##======================== Make changes inside this block ========================##
+
+##======================== You may want to make edits to  ========================##
+##======================== num_blocks and num_units when  ========================##
+##======================== calling adfisher.do_experiment()  =====================##
+
+
+
+
+def test_stat(observed_values, unit_assignments):
+    return analysis.statistics.difference(observed_values, unit_assignments)
+
+# Shuts down the browser once we are done with it.
+def cleanup_browser(unit):
+    unit.quit()
+
+adfisher.do_experiment(make_unit=make_browser, treatments=[control_treatment, exp_treatment], 
+                        measurement=measurement, end_unit=cleanup_browser,
+                        load_results=load_results, test_stat=test_stat, ml_analysis=True, 
+                        num_blocks=24, num_units=6, timeout=2000,
+                        log_file=log_file, exp_flag=False, analysis_flag=True, 
+                        treatment_names=["control (chrome)", "experimental (firefox)"])
+

--- a/AdFisher/examples/log.demo.txt
+++ b/AdFisher/examples/log.demo.txt
@@ -1,0 +1,29 @@
+2015-11-22 23:11:20.050505||meta||agents||2
+2015-11-22 23:11:20.050546||meta||treatnames||control@|experimental
+2015-11-22 23:11:20.050718||meta||block_id start||0
+2015-11-22 23:11:20.050747||meta||assignment||0@|1
+2015-11-22 23:11:24.016091||event||progress-marker||training-start||1||1
+2015-11-22 23:11:24.016303||event||progress-marker||training-end||1||1
+2015-11-22 23:11:24.046845||event||progress-marker||training-start||0||0
+2015-11-22 23:11:24.047069||event||progress-marker||training-end||0||0
+2015-11-22 23:11:29.017345||event||progress-marker||measurement-start||1||1
+2015-11-22 23:11:29.048526||event||progress-marker||measurement-start||0||0
+2015-11-22 23:11:41.644771||measurement||ad||2015-11-22 23:11:41.280811@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-22 23:11:41.785110||measurement||ad||2015-11-22 23:11:41.508463@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||0
+2015-11-22 23:11:41.816747||measurement||ad||2015-11-22 23:11:41.280811@|Signs Of Osteoporosis@|everydayhealth.com/Osteoporosis@|Visit Our Osteoporosis Center to Learn Symptoms, Treatments And More||1||1
+2015-11-22 23:11:41.884565||measurement||ad||2015-11-22 23:11:41.280811@|Free Obituary Search@|obituaries.ancestry.com@|Find obituaries, death  cemetery records  view online now.||1||1
+2015-11-22 23:11:41.884918||measurement||loadtime||0:00:07.865966||1||1
+2015-11-22 23:11:42.013885||measurement||ad||2015-11-22 23:11:41.508463@|Signs Of Osteoporosis@|everydayhealth.com/Osteoporosis@|Visit Our Osteoporosis Center to Learn Symptoms, Treatments And More||0||0
+2015-11-22 23:11:42.064175||measurement||ad||2015-11-22 23:11:41.508463@|Free Obituary Search@|obituaries.ancestry.com@|Find obituaries, death  cemetery records  view online now.||0||0
+2015-11-22 23:11:42.064412||measurement||loadtime||0:00:08.014295||0||0
+2015-11-22 23:11:53.925719||measurement||ad||2015-11-22 23:11:53.491131@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-22 23:11:54.082347||measurement||ad||2015-11-22 23:11:53.491131@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-22 23:11:54.213225||measurement||ad||2015-11-22 23:11:53.491131@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-22 23:11:54.213461||measurement||loadtime||0:00:07.327590||1||1
+2015-11-22 23:11:54.213548||event||progress-marker||measurement-end||1||1
+2015-11-22 23:11:55.906629||measurement||ad||2015-11-22 23:11:55.396918@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-22 23:11:55.988347||measurement||ad||2015-11-22 23:11:55.396918@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-22 23:11:56.043860||measurement||ad||2015-11-22 23:11:55.396918@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||0||0
+2015-11-22 23:11:56.044123||measurement||loadtime||0:00:08.978641||0||0
+2015-11-22 23:11:56.044497||event||progress-marker||measurement-end||0||0
+2015-11-22 23:11:56.206710||meta||block_id end||0

--- a/AdFisher/examples/log.group.amazon.txt
+++ b/AdFisher/examples/log.group.amazon.txt
@@ -1,0 +1,6983 @@
+2015-12-01 20:01:25.186642||meta||agents||6
+2015-12-01 20:01:25.186708||meta||treatnames||control (chrome)@|experimental (firefox)
+2015-12-01 20:01:25.186949||meta||block_id start||0
+2015-12-01 20:01:25.186976||meta||assignment||3@|1@|4@|0@|2@|5
+2015-12-01 20:01:26.729838||event||progress-marker||training-start||3||0
+2015-12-01 20:01:26.777076||event||progress-marker||training-start||1||0
+2015-12-01 20:01:33.672042||treatment||visit website||http://irs.gov||1||0
+2015-12-01 20:01:33.725727||treatment||visit website||http://irs.gov||3||0
+2015-12-01 20:01:41.262284||treatment||visit website||http://deloitte.com||3||0
+2015-12-01 20:01:49.725744||treatment||visit website||http://pwc.com||3||0
+2015-12-01 20:01:56.076701||treatment||visit website||http://ey.com||3||0
+2015-12-01 20:02:03.489893||treatment||visit website||http://kpmg.com||3||0
+2015-12-01 20:02:03.490028||event||progress-marker||training-end||3||0
+2015-12-01 20:02:14.037056||error||website timeout||http://deloitte.com||1||0
+2015-12-01 20:02:22.035106||treatment||visit website||http://pwc.com||1||0
+2015-12-01 20:02:27.853419||treatment||visit website||http://ey.com||1||0
+2015-12-01 20:02:34.309823||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 20:02:34.309971||event||progress-marker||training-end||1||0
+2015-12-01 20:02:38.523359||event||progress-marker||measurement-start||3||0
+2015-12-01 20:02:39.315588||event||progress-marker||measurement-start||1||0
+2015-12-01 20:02:48.488660||event||progress-marker||training-start||5||1
+2015-12-01 20:02:51.889549||measurement||price||2015-12-01 20:02:45.759445@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:02:54.076801||measurement||price||2015-12-01 20:02:46.513240@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:02:55.562935||treatment||visit website||http://irs.gov||5||1
+2015-12-01 20:03:03.597037||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 20:03:04.218591||measurement||price||2015-12-01 20:02:45.759445@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:03:06.424287||measurement||price||2015-12-01 20:02:46.513240@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:03:08.702960||event||progress-marker||training-start||2||1
+2015-12-01 20:03:11.327296||measurement||loadtime||0:00:27.798606||3||0
+2015-12-01 20:03:12.719068||treatment||visit website||http://pwc.com||5||1
+2015-12-01 20:03:13.544283||measurement||loadtime||0:00:29.223458||1||0
+2015-12-01 20:03:15.135535||treatment||visit website||http://irs.gov||2||1
+2015-12-01 20:03:18.667127||treatment||visit website||http://ey.com||5||1
+2015-12-01 20:03:22.447464||treatment||visit website||http://deloitte.com||2||1
+2015-12-01 20:03:25.286902||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 20:03:25.287060||event||progress-marker||training-end||5||1
+2015-12-01 20:03:29.740663||event||progress-marker||training-start||0||1
+2015-12-01 20:03:31.189895||treatment||visit website||http://pwc.com||2||1
+2015-12-01 20:03:33.696044||error||collecting ads||Error||3||0
+2015-12-01 20:03:35.890160||error||collecting ads||Error||1||0
+2015-12-01 20:03:36.127773||treatment||visit website||http://irs.gov||0||1
+2015-12-01 20:03:37.033540||treatment||visit website||http://ey.com||2||1
+2015-12-01 20:03:42.467769||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 20:03:44.400459||treatment||visit website||http://kpmg.com||2||1
+2015-12-01 20:03:44.400572||event||progress-marker||training-end||2||1
+2015-12-01 20:03:45.921299||measurement||price||2015-12-01 20:03:40.342955@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:03:48.036208||measurement||price||2015-12-01 20:03:42.454539@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 20:03:51.358758||treatment||visit website||http://pwc.com||0||1
+2015-12-01 20:03:57.237295||treatment||visit website||http://ey.com||0||1
+2015-12-01 20:03:58.253564||measurement||price||2015-12-01 20:03:40.342955@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:04:00.391789||measurement||price||2015-12-01 20:03:42.454539@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 20:04:04.046935||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 20:04:04.047123||event||progress-marker||training-end||0||1
+2015-12-01 20:04:04.420181||event||progress-marker||measurement-start||2||1
+2015-12-01 20:04:05.325348||event||progress-marker||measurement-start||5||1
+2015-12-01 20:04:05.359307||measurement||loadtime||0:00:26.658032||3||0
+2015-12-01 20:04:07.515810||measurement||loadtime||0:00:26.620652||1||0
+2015-12-01 20:04:09.053271||event||progress-marker||measurement-start||0||1
+2015-12-01 20:04:17.699860||measurement||price||2015-12-01 20:04:12.103370@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 20:04:19.879397||measurement||price||2015-12-01 20:04:13.244337@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:04:23.511140||measurement||price||2015-12-01 20:04:16.892204@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 20:04:29.207758||error||collecting ads||Error||2||1
+2015-12-01 20:04:29.883350||error||collecting ads||Error||1||0
+2015-12-01 20:04:30.036148||measurement||price||2015-12-01 20:04:12.103370@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 20:04:32.724767||measurement||price||2015-12-01 20:04:13.244337@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:04:36.384961||measurement||price||2015-12-01 20:04:16.892204@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 20:04:37.148458||measurement||loadtime||0:00:26.785252||3||0
+2015-12-01 20:04:39.944159||measurement||loadtime||0:00:29.613600||5||1
+2015-12-01 20:04:42.235758||measurement||price||2015-12-01 20:04:36.627934@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:04:43.052701||measurement||price||2015-12-01 20:04:36.525192@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 20:04:43.599189||measurement||loadtime||0:00:29.540698||0||1
+2015-12-01 20:04:49.403096||measurement||price||2015-12-01 20:04:43.801388@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 20:04:53.815431||measurement||price||2015-12-01 20:04:47.484968@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:04:54.565898||measurement||price||2015-12-01 20:04:36.627934@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:04:55.986175||measurement||price||2015-12-01 20:04:36.525192@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 20:05:01.664984||measurement||loadtime||0:00:26.777840||1||0
+2015-12-01 20:05:01.758854||measurement||price||2015-12-01 20:04:43.801388@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 20:05:03.320282||measurement||loadtime||0:00:29.107298||2||1
+2015-12-01 20:05:06.718156||measurement||price||2015-12-01 20:04:47.484968@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:05:07.609952||error||collecting ads||Error||0||1
+2015-12-01 20:05:08.868876||measurement||loadtime||0:00:26.715233||3||0
+2015-12-01 20:05:13.939168||measurement||loadtime||0:00:28.993783||5||1
+2015-12-01 20:05:14.325161||measurement||price||2015-12-01 20:05:08.765966@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||1||0
+2015-12-01 20:05:17.384696||measurement||price||2015-12-01 20:05:11.039370@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||1
+2015-12-01 20:05:21.069618||measurement||price||2015-12-01 20:05:15.551325@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 20:05:21.668536||measurement||price||2015-12-01 20:05:14.822553@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 20:05:26.664969||measurement||price||2015-12-01 20:05:08.765966@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||1||0
+2015-12-01 20:05:30.255783||measurement||price||2015-12-01 20:05:11.039370@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||1
+2015-12-01 20:05:33.444355||measurement||price||2015-12-01 20:05:15.551325@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 20:05:33.789774||measurement||loadtime||0:00:27.124122||1||0
+2015-12-01 20:05:34.677391||measurement||price||2015-12-01 20:05:14.822553@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 20:05:37.458423||measurement||loadtime||0:00:29.135266||2||1
+2015-12-01 20:05:37.637329||error||collecting ads||Error||5||1
+2015-12-01 20:05:40.555166||measurement||loadtime||0:00:26.684030||3||0
+2015-12-01 20:05:41.891993||measurement||loadtime||0:00:29.276826||0||1
+2015-12-01 20:05:46.099703||measurement||price||2015-12-01 20:05:40.499366@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:05:51.024710||measurement||price||2015-12-01 20:05:44.831589@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 20:05:53.261906||measurement||price||2015-12-01 20:05:47.668408@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||3||0
+2015-12-01 20:05:55.637933||measurement||price||2015-12-01 20:05:49.252132@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 20:05:58.427078||measurement||price||2015-12-01 20:05:40.499366@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:06:01.583356||error||collecting ads||Error||5||1
+2015-12-01 20:06:03.847684||measurement||price||2015-12-01 20:05:44.831589@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 20:06:05.539236||measurement||loadtime||0:00:26.747027||1||0
+2015-12-01 20:06:05.614329||measurement||price||2015-12-01 20:05:47.668408@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||3||0
+2015-12-01 20:06:08.743560||measurement||price||2015-12-01 20:05:49.252132@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 20:06:11.067751||measurement||loadtime||0:00:28.604022||2||1
+2015-12-01 20:06:12.735735||measurement||loadtime||0:00:27.176572||3||0
+2015-12-01 20:06:15.449232||measurement||price||2015-12-01 20:06:08.757167@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 20:06:15.948349||measurement||loadtime||0:00:29.051139||0||1
+2015-12-01 20:06:17.785556||measurement||price||2015-12-01 20:06:12.256506@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 20:06:28.272271||measurement||price||2015-12-01 20:06:08.757167@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 20:06:30.148375||measurement||price||2015-12-01 20:06:12.256506@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 20:06:34.797328||error||collecting ads||Error||2||1
+2015-12-01 20:06:34.963199||error||collecting ads||Error||3||0
+2015-12-01 20:06:35.495613||measurement||loadtime||0:00:28.907045||5||1
+2015-12-01 20:06:37.258036||measurement||loadtime||0:00:26.714885||1||0
+2015-12-01 20:06:39.835480||error||collecting ads||Error||0||1
+2015-12-01 20:06:47.291432||measurement||price||2015-12-01 20:06:41.672484@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 20:06:48.764518||measurement||price||2015-12-01 20:06:42.193960@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:06:50.004046||measurement||price||2015-12-01 20:06:44.445371@|3M Littmann@|$85.00 - $234.56@|3M Littmann Classic III Stethoscope (Multiple Colors)||1||0
+2015-12-01 20:06:53.560263||measurement||price||2015-12-01 20:06:47.039659@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 20:06:59.624149||measurement||price||2015-12-01 20:06:41.672484@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 20:06:59.713450||error||collecting ads||Error||5||1
+2015-12-01 20:07:01.610265||measurement||price||2015-12-01 20:06:42.193960@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:07:02.339220||measurement||price||2015-12-01 20:06:44.445371@|3M Littmann@|$62.96 - $319.00@|3M Littmann Classic II S.E. Stethoscope (Multiple Colors)||1||0
+2015-12-01 20:07:06.393072||measurement||price||2015-12-01 20:06:47.039659@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 20:07:06.744875||measurement||loadtime||0:00:26.776430||3||0
+2015-12-01 20:07:08.831333||measurement||loadtime||0:00:29.028801||2||1
+2015-12-01 20:07:09.459182||measurement||loadtime||0:00:27.195930||1||0
+2015-12-01 20:07:13.597496||measurement||price||2015-12-01 20:07:07.065155@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 20:07:13.607145||measurement||loadtime||0:00:28.768000||0||1
+2015-12-01 20:07:19.022602||measurement||price||2015-12-01 20:07:13.423928@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 20:07:22.596163||measurement||price||2015-12-01 20:07:17.012991@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:07:22.797218||measurement||price||2015-12-01 20:07:16.380886@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 20:07:26.419964||measurement||price||2015-12-01 20:07:07.065155@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 20:07:27.500121||measurement||price||2015-12-01 20:07:20.883119@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 20:07:31.353823||measurement||price||2015-12-01 20:07:13.423928@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 20:07:33.649103||measurement||loadtime||0:00:28.930423||5||1
+2015-12-01 20:07:34.917160||measurement||price||2015-12-01 20:07:17.012991@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:07:35.710672||measurement||price||2015-12-01 20:07:16.380886@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 20:07:38.459747||measurement||loadtime||0:00:26.709632||3||0
+2015-12-01 20:07:40.366586||measurement||price||2015-12-01 20:07:20.883119@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 20:07:41.991158||measurement||loadtime||0:00:27.526789||1||0
+2015-12-01 20:07:42.945600||measurement||loadtime||0:00:29.110469||2||1
+2015-12-01 20:07:47.577780||measurement||loadtime||0:00:28.966636||0||1
+2015-12-01 20:07:50.730515||measurement||price||2015-12-01 20:07:45.119202@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 20:07:54.137660||measurement||price||2015-12-01 20:07:48.546025@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:07:57.576979||error||collecting ads||Error||5||1
+2015-12-01 20:08:03.080762||measurement||price||2015-12-01 20:07:45.119202@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 20:08:06.413937||measurement||price||2015-12-01 20:07:48.546025@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:08:06.901876||error||collecting ads||Error||2||1
+2015-12-01 20:08:10.155170||measurement||loadtime||0:00:26.692958||3||0
+2015-12-01 20:08:11.427881||error||collecting ads||Error||0||1
+2015-12-01 20:08:13.505540||measurement||loadtime||0:00:26.509202||1||0
+2015-12-01 20:08:21.022145||measurement||price||2015-12-01 20:08:14.248369@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:08:21.275470||error||collecting ads||Error||5||1
+2015-12-01 20:08:22.465441||measurement||price||2015-12-01 20:08:16.839806@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 20:08:25.257805||measurement||price||2015-12-01 20:08:18.815507@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 20:08:25.795513||measurement||price||2015-12-01 20:08:20.158677@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:08:33.893858||measurement||price||2015-12-01 20:08:14.248369@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:08:34.793634||measurement||price||2015-12-01 20:08:16.839806@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 20:08:35.369323||measurement||price||2015-12-01 20:08:28.508064@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:08:38.080755||measurement||price||2015-12-01 20:08:18.815507@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 20:08:38.126037||measurement||price||2015-12-01 20:08:20.158677@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:08:41.142061||measurement||loadtime||0:00:29.236035||2||1
+2015-12-01 20:08:41.902344||measurement||loadtime||0:00:26.741947||3||0
+2015-12-01 20:08:45.235279||measurement||loadtime||0:00:26.724520||1||0
+2015-12-01 20:08:45.318057||measurement||loadtime||0:00:28.884972||0||1
+2015-12-01 20:08:48.281918||measurement||price||2015-12-01 20:08:28.508064@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:08:54.802161||measurement||price||2015-12-01 20:08:48.443685@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 20:08:55.517014||measurement||loadtime||0:00:29.237426||5||1
+2015-12-01 20:08:57.444072||measurement||price||2015-12-01 20:08:51.821347@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:09:04.245858||error||collecting ads||Error||3||0
+2015-12-01 20:09:07.608142||measurement||price||2015-12-01 20:08:48.443685@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 20:09:09.480751||error||collecting ads||Error||0||1
+2015-12-01 20:09:09.649602||measurement||price||2015-12-01 20:09:02.858845@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:09:09.768287||measurement||price||2015-12-01 20:08:51.821347@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:09:14.826912||measurement||loadtime||0:00:28.679546||2||1
+2015-12-01 20:09:16.420518||measurement||price||2015-12-01 20:09:10.879554@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:09:16.887796||measurement||loadtime||0:00:26.647311||1||0
+2015-12-01 20:09:22.450155||measurement||price||2015-12-01 20:09:02.858845@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:09:28.460940||measurement||price||2015-12-01 20:09:22.260954@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 20:09:28.755907||measurement||price||2015-12-01 20:09:10.879554@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:09:29.678306||measurement||loadtime||0:00:29.156067||5||1
+2015-12-01 20:09:33.477753||error||collecting ads||Error||0||1
+2015-12-01 20:09:35.867188||measurement||loadtime||0:00:26.616111||3||0
+2015-12-01 20:09:39.162006||error||collecting ads||Error||1||0
+2015-12-01 20:09:41.305612||measurement||price||2015-12-01 20:09:22.260954@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 20:09:43.774042||measurement||price||2015-12-01 20:09:37.315567@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||5||1
+2015-12-01 20:09:48.103167||measurement||price||2015-12-01 20:09:42.620941@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:09:48.502868||measurement||loadtime||0:00:28.671678||2||1
+2015-12-01 20:09:51.406890||measurement||price||2015-12-01 20:09:45.800218@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:09:56.861164||measurement||price||2015-12-01 20:09:37.315567@|Electronic Arts@| $59.00   @|Star Wars: Battlefront - Standard Edition - Xbox One||5||1
+2015-12-01 20:09:57.323496||error||collecting ads||Error||0||1
+2015-12-01 20:10:00.439718||measurement||price||2015-12-01 20:09:42.620941@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:10:01.984901||measurement||price||2015-12-01 20:09:55.882427@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:10:03.751376||measurement||price||2015-12-01 20:09:45.800218@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:10:04.055199||measurement||loadtime||0:00:29.371660||5||1
+2015-12-01 20:10:07.556882||measurement||loadtime||0:00:26.684403||3||0
+2015-12-01 20:10:10.861204||measurement||loadtime||0:00:26.694043||1||0
+2015-12-01 20:10:11.192200||measurement||price||2015-12-01 20:10:04.604424@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 20:10:14.777269||measurement||price||2015-12-01 20:09:55.882427@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:10:21.991996||measurement||loadtime||0:00:28.483895||2||1
+2015-12-01 20:10:23.086451||measurement||price||2015-12-01 20:10:17.536080@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:10:24.058990||measurement||price||2015-12-01 20:10:04.604424@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 20:10:27.982937||error||collecting ads||Error||5||1
+2015-12-01 20:10:29.710253||error||collecting ads||Error||3||0
+2015-12-01 20:10:31.262173||measurement||loadtime||0:00:28.933428||0||1
+2015-12-01 20:10:35.406084||measurement||price||2015-12-01 20:10:17.536080@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:10:35.680111||measurement||price||2015-12-01 20:10:29.334830@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:10:41.888689||measurement||price||2015-12-01 20:10:35.348793@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:10:42.014491||measurement||price||2015-12-01 20:10:36.424203@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:10:42.518858||measurement||loadtime||0:00:26.652408||1||0
+2015-12-01 20:10:45.090857||measurement||price||2015-12-01 20:10:38.597987@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 20:10:48.505615||measurement||price||2015-12-01 20:10:29.334830@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:10:54.363681||measurement||price||2015-12-01 20:10:36.424203@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:10:54.856496||measurement||price||2015-12-01 20:10:35.348793@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:10:55.224527||measurement||price||2015-12-01 20:10:49.618459@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||0
+2015-12-01 20:10:55.735950||measurement||loadtime||0:00:28.738701||2||1
+2015-12-01 20:10:58.000057||measurement||price||2015-12-01 20:10:38.597987@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 20:11:01.460232||measurement||loadtime||0:00:26.745063||3||0
+2015-12-01 20:11:02.075505||measurement||loadtime||0:00:29.087363||5||1
+2015-12-01 20:11:05.209482||measurement||loadtime||0:00:28.942320||0||1
+2015-12-01 20:11:07.583089||measurement||price||2015-12-01 20:10:49.618459@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||0
+2015-12-01 20:11:09.482257||measurement||price||2015-12-01 20:11:03.094596@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:11:13.686749||measurement||price||2015-12-01 20:11:08.095443@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:11:14.699167||measurement||loadtime||0:00:27.175074||1||0
+2015-12-01 20:11:16.701406||measurement||price||2015-12-01 20:11:10.142573@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:11:22.291765||measurement||price||2015-12-01 20:11:03.094596@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:11:26.024289||measurement||price||2015-12-01 20:11:08.095443@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:11:28.942637||error||collecting ads||Error||0||1
+2015-12-01 20:11:29.512259||measurement||loadtime||0:00:28.770879||2||1
+2015-12-01 20:11:29.787641||measurement||price||2015-12-01 20:11:10.142573@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:11:33.130804||measurement||loadtime||0:00:26.665332||3||0
+2015-12-01 20:11:36.968440||error||collecting ads||Error||1||0
+2015-12-01 20:11:37.003167||measurement||loadtime||0:00:29.922431||5||1
+2015-12-01 20:11:42.814488||measurement||price||2015-12-01 20:11:36.313452@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 20:11:45.584478||measurement||price||2015-12-01 20:11:40.211971@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 20:11:49.298639||measurement||price||2015-12-01 20:11:43.688726@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:11:51.282863||measurement||price||2015-12-01 20:11:44.525611@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:11:53.762898||error||collecting ads||Error||2||1
+2015-12-01 20:11:55.703900||measurement||price||2015-12-01 20:11:36.313452@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 20:11:57.882536||measurement||price||2015-12-01 20:11:40.211971@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 20:12:01.628489||measurement||price||2015-12-01 20:11:43.688726@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:12:02.911181||measurement||loadtime||0:00:28.964032||0||1
+2015-12-01 20:12:04.281619||measurement||price||2015-12-01 20:11:44.525611@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:12:04.957720||measurement||loadtime||0:00:26.821695||3||0
+2015-12-01 20:12:07.521383||measurement||price||2015-12-01 20:12:01.058950@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:12:08.740893||measurement||loadtime||0:00:26.767246||1||0
+2015-12-01 20:12:11.511201||measurement||loadtime||0:00:29.507773||5||1
+2015-12-01 20:12:16.935915||measurement||price||2015-12-01 20:12:10.213544@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 20:12:17.201501||measurement||price||2015-12-01 20:12:11.598335@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 20:12:20.359839||measurement||price||2015-12-01 20:12:01.058950@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:12:21.430334||measurement||price||2015-12-01 20:12:15.862828@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||1||0
+2015-12-01 20:12:25.236252||measurement||price||2015-12-01 20:12:18.719351@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:12:27.587596||measurement||loadtime||0:00:28.820407||2||1
+2015-12-01 20:12:29.481018||measurement||price||2015-12-01 20:12:11.598335@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 20:12:29.835085||measurement||price||2015-12-01 20:12:10.213544@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 20:12:33.759500||measurement||price||2015-12-01 20:12:15.862828@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||1||0
+2015-12-01 20:12:36.563654||measurement||loadtime||0:00:26.604113||3||0
+2015-12-01 20:12:36.563783||event||progress-marker||measurement-end||3||0
+2015-12-01 20:12:37.051159||measurement||loadtime||0:00:29.134770||0||1
+2015-12-01 20:12:38.349631||measurement||price||2015-12-01 20:12:18.719351@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:12:40.871179||measurement||loadtime||0:00:27.125074||1||0
+2015-12-01 20:12:40.871277||event||progress-marker||measurement-end||1||0
+2015-12-01 20:12:41.649939||measurement||price||2015-12-01 20:12:35.404830@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 20:12:45.551571||measurement||loadtime||0:00:29.035149||5||1
+2015-12-01 20:12:50.900715||measurement||price||2015-12-01 20:12:44.319089@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 20:12:54.463197||measurement||price||2015-12-01 20:12:35.404830@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 20:12:59.750419||measurement||price||2015-12-01 20:12:53.354927@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||5||1
+2015-12-01 20:13:01.699456||measurement||loadtime||0:00:29.106610||2||1
+2015-12-01 20:13:03.730655||measurement||price||2015-12-01 20:12:44.319089@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 20:13:10.928289||measurement||loadtime||0:00:28.873401||0||1
+2015-12-01 20:13:12.804521||measurement||price||2015-12-01 20:12:53.354927@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||5||1
+2015-12-01 20:13:15.824278||measurement||price||2015-12-01 20:13:09.522384@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 20:13:20.000666||measurement||loadtime||0:00:29.443931||5||1
+2015-12-01 20:13:28.932936||measurement||price||2015-12-01 20:13:09.522384@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 20:13:33.808962||measurement||price||2015-12-01 20:13:27.375942@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:13:34.686795||error||collecting ads||Error||0||1
+2015-12-01 20:13:36.153427||measurement||loadtime||0:00:29.448742||2||1
+2015-12-01 20:13:46.715430||measurement||price||2015-12-01 20:13:27.375942@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:13:48.574358||measurement||price||2015-12-01 20:13:41.983282@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 20:13:53.948154||measurement||loadtime||0:00:28.944717||5||1
+2015-12-01 20:13:59.806681||error||collecting ads||Error||2||1
+2015-12-01 20:14:01.426017||measurement||price||2015-12-01 20:13:41.983282@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 20:14:08.639209||measurement||loadtime||0:00:28.952049||0||1
+2015-12-01 20:14:08.639316||event||progress-marker||measurement-end||0||1
+2015-12-01 20:14:13.488276||measurement||price||2015-12-01 20:14:07.117709@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 20:14:17.836010||error||collecting ads||Error||5||1
+2015-12-01 20:14:17.836162||event||progress-marker||measurement-end||5||1
+2015-12-01 20:14:26.348136||measurement||price||2015-12-01 20:14:07.117709@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 20:14:33.575117||measurement||loadtime||0:00:28.763165||2||1
+2015-12-01 20:14:33.575262||event||progress-marker||measurement-end||2||1
+2015-12-01 20:14:33.968029||meta||block_id end||0
+2015-12-01 20:14:33.968295||meta||block_id start||1
+2015-12-01 20:14:33.968317||meta||assignment||0@|1@|2@|4@|5@|3
+2015-12-01 20:14:35.574410||event||progress-marker||training-start||0||0
+2015-12-01 20:14:35.618824||event||progress-marker||training-start||1||0
+2015-12-01 20:14:35.634312||event||progress-marker||training-start||2||0
+2015-12-01 20:14:42.094969||treatment||visit website||http://irs.gov||1||0
+2015-12-01 20:14:42.099093||treatment||visit website||http://irs.gov||2||0
+2015-12-01 20:14:42.103113||treatment||visit website||http://irs.gov||0||0
+2015-12-01 20:14:49.270150||treatment||visit website||http://deloitte.com||1||0
+2015-12-01 20:14:49.276786||treatment||visit website||http://deloitte.com||0||0
+2015-12-01 20:14:49.278248||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 20:14:57.425615||treatment||visit website||http://pwc.com||2||0
+2015-12-01 20:14:57.455121||treatment||visit website||http://pwc.com||1||0
+2015-12-01 20:14:57.459096||treatment||visit website||http://pwc.com||0||0
+2015-12-01 20:15:03.948399||treatment||visit website||http://ey.com||0||0
+2015-12-01 20:15:04.261812||treatment||visit website||http://ey.com||2||0
+2015-12-01 20:15:04.471870||treatment||visit website||http://ey.com||1||0
+2015-12-01 20:15:10.765416||treatment||visit website||http://kpmg.com||0||0
+2015-12-01 20:15:10.765560||event||progress-marker||training-end||0||0
+2015-12-01 20:15:11.073633||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 20:15:11.073778||event||progress-marker||training-end||1||0
+2015-12-01 20:15:11.122081||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 20:15:11.122207||event||progress-marker||training-end||2||0
+2015-12-01 20:15:15.774673||event||progress-marker||measurement-start||0||0
+2015-12-01 20:15:16.082737||event||progress-marker||measurement-start||1||0
+2015-12-01 20:15:16.131232||event||progress-marker||measurement-start||2||0
+2015-12-01 20:15:29.690162||measurement||price||2015-12-01 20:15:23.821637@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||1||0
+2015-12-01 20:15:39.211185||error||collecting ads||Error||2||0
+2015-12-01 20:15:39.240783||error||collecting ads||Error||0||0
+2015-12-01 20:15:42.042254||measurement||price||2015-12-01 20:15:23.821637@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||1||0
+2015-12-01 20:15:49.159245||measurement||loadtime||0:00:28.071282||1||0
+2015-12-01 20:15:51.606779||measurement||price||2015-12-01 20:15:45.801637@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:15:51.751996||measurement||price||2015-12-01 20:15:46.340367@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 20:16:02.136908||measurement||price||2015-12-01 20:15:56.832690@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:16:03.983715||measurement||price||2015-12-01 20:15:45.801637@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:16:04.123827||measurement||price||2015-12-01 20:15:46.340367@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 20:16:08.004050||event||progress-marker||training-start||3||1
+2015-12-01 20:16:09.717743||event||progress-marker||training-start||5||1
+2015-12-01 20:16:11.107891||measurement||loadtime||0:00:26.891383||2||0
+2015-12-01 20:16:11.224462||measurement||loadtime||0:00:26.978464||0||0
+2015-12-01 20:16:14.428245||measurement||price||2015-12-01 20:15:56.832690@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:16:14.484915||treatment||visit website||http://irs.gov||3||1
+2015-12-01 20:16:16.135126||treatment||visit website||http://irs.gov||5||1
+2015-12-01 20:16:21.011592||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 20:16:21.511148||measurement||loadtime||0:00:27.346713||1||0
+2015-12-01 20:16:22.725344||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 20:16:23.372324||measurement||price||2015-12-01 20:16:17.734829@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:16:23.975748||measurement||price||2015-12-01 20:16:18.586987@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:16:25.857732||event||progress-marker||training-start||4||1
+2015-12-01 20:16:29.768332||treatment||visit website||http://pwc.com||3||1
+2015-12-01 20:16:31.520915||treatment||visit website||http://pwc.com||5||1
+2015-12-01 20:16:32.239541||treatment||visit website||http://irs.gov||4||1
+2015-12-01 20:16:33.669545||measurement||price||2015-12-01 20:16:28.142718@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:16:35.698322||measurement||price||2015-12-01 20:16:17.734829@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:16:35.780907||treatment||visit website||http://ey.com||3||1
+2015-12-01 20:16:36.313294||measurement||price||2015-12-01 20:16:18.586987@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:16:37.792285||treatment||visit website||http://ey.com||5||1
+2015-12-01 20:16:38.935107||treatment||visit website||http://deloitte.com||4||1
+2015-12-01 20:16:42.811446||measurement||loadtime||0:00:26.700807||2||0
+2015-12-01 20:16:43.433024||measurement||loadtime||0:00:27.205869||0||0
+2015-12-01 20:16:44.091602||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 20:16:44.091741||event||progress-marker||training-end||3||1
+2015-12-01 20:16:45.465770||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 20:16:45.465903||event||progress-marker||training-end||5||1
+2015-12-01 20:16:45.943537||measurement||price||2015-12-01 20:16:28.142718@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:16:47.747420||treatment||visit website||http://pwc.com||4||1
+2015-12-01 20:16:53.024520||measurement||loadtime||0:00:26.508108||1||0
+2015-12-01 20:16:54.049188||treatment||visit website||http://ey.com||4||1
+2015-12-01 20:16:55.224770||measurement||price||2015-12-01 20:16:49.533196@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:16:55.912968||measurement||price||2015-12-01 20:16:50.529052@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:17:01.203144||treatment||visit website||http://kpmg.com||4||1
+2015-12-01 20:17:01.203295||event||progress-marker||training-end||4||1
+2015-12-01 20:17:04.120303||event||progress-marker||measurement-start||3||1
+2015-12-01 20:17:05.491745||event||progress-marker||measurement-start||5||1
+2015-12-01 20:17:05.653395||measurement||price||2015-12-01 20:17:00.096928@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||1||0
+2015-12-01 20:17:06.212834||event||progress-marker||measurement-start||4||1
+2015-12-01 20:17:07.562599||measurement||price||2015-12-01 20:16:49.533196@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:17:08.217655||measurement||price||2015-12-01 20:16:50.529052@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:17:14.675218||measurement||loadtime||0:00:26.860366||2||0
+2015-12-01 20:17:15.325783||measurement||loadtime||0:00:26.890633||0||0
+2015-12-01 20:17:18.811439||measurement||price||2015-12-01 20:17:12.458520@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||1
+2015-12-01 20:17:20.401024||measurement||price||2015-12-01 20:17:13.454126@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:17:21.012722||measurement||price||2015-12-01 20:17:14.256843@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:17:26.892969||measurement||price||2015-12-01 20:17:21.297212@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:17:27.836369||measurement||price||2015-12-01 20:17:21.991694@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:17:27.975206||error||collecting ads||Error||1||0
+2015-12-01 20:17:31.625916||measurement||price||2015-12-01 20:17:12.458520@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||1
+2015-12-01 20:17:33.360370||measurement||price||2015-12-01 20:17:13.454126@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:17:33.893916||measurement||price||2015-12-01 20:17:14.256843@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:17:38.850812||measurement||loadtime||0:00:29.725263||3||1
+2015-12-01 20:17:39.258215||measurement||price||2015-12-01 20:17:21.297212@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:17:40.192970||measurement||price||2015-12-01 20:17:21.991694@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:17:40.342469||measurement||price||2015-12-01 20:17:34.721670@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:17:40.579269||measurement||loadtime||0:00:30.084070||5||1
+2015-12-01 20:17:41.125429||measurement||loadtime||0:00:29.907664||4||1
+2015-12-01 20:17:46.379161||measurement||loadtime||0:00:26.700019||2||0
+2015-12-01 20:17:47.306464||measurement||loadtime||0:00:26.979319||0||0
+2015-12-01 20:17:52.677818||measurement||price||2015-12-01 20:17:34.721670@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:17:55.002486||measurement||price||2015-12-01 20:17:48.580296@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:17:58.658313||measurement||price||2015-12-01 20:17:53.135587@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:17:59.789918||measurement||loadtime||0:00:26.809426||1||0
+2015-12-01 20:18:02.878070||error||collecting ads||Error||3||1
+2015-12-01 20:18:04.515482||error||collecting ads||Error||5||1
+2015-12-01 20:18:08.003768||measurement||price||2015-12-01 20:17:48.580296@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:18:09.927843||error||collecting ads||Error||0||0
+2015-12-01 20:18:10.994518||measurement||price||2015-12-01 20:17:53.135587@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:18:12.151746||measurement||price||2015-12-01 20:18:06.605786@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:18:15.203697||measurement||loadtime||0:00:29.073068||4||1
+2015-12-01 20:18:16.676625||measurement||price||2015-12-01 20:18:10.198493@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:18:18.110153||measurement||loadtime||0:00:26.727018||2||0
+2015-12-01 20:18:18.985847||measurement||price||2015-12-01 20:18:12.575095@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||5||1
+2015-12-01 20:18:22.535291||measurement||price||2015-12-01 20:18:16.717214@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:18:24.471168||measurement||price||2015-12-01 20:18:06.605786@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:18:29.175525||measurement||price||2015-12-01 20:18:22.786274@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:18:29.588379||measurement||price||2015-12-01 20:18:10.198493@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:18:30.872359||measurement||price||2015-12-01 20:18:25.298794@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||0
+2015-12-01 20:18:31.585996||measurement||loadtime||0:00:26.790853||1||0
+2015-12-01 20:18:31.836794||measurement||price||2015-12-01 20:18:12.575095@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||5||1
+2015-12-01 20:18:34.872182||measurement||price||2015-12-01 20:18:16.717214@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:18:36.822344||measurement||loadtime||0:00:28.941333||3||1
+2015-12-01 20:18:39.039962||measurement||loadtime||0:00:29.519237||5||1
+2015-12-01 20:18:41.984061||measurement||loadtime||0:00:27.050995||0||0
+2015-12-01 20:18:42.227927||measurement||price||2015-12-01 20:18:22.786274@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:18:43.203866||measurement||price||2015-12-01 20:18:25.298794@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||0
+2015-12-01 20:18:44.644153||measurement||price||2015-12-01 20:18:38.981247@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:18:49.427153||measurement||loadtime||0:00:29.218270||4||1
+2015-12-01 20:18:50.323794||measurement||loadtime||0:00:27.208452||2||0
+2015-12-01 20:18:50.674149||measurement||price||2015-12-01 20:18:44.148168@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:18:54.567212||measurement||price||2015-12-01 20:18:49.236325@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:18:56.970606||measurement||price||2015-12-01 20:18:38.981247@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:19:02.709571||measurement||price||2015-12-01 20:18:57.060930@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:19:02.744979||error||collecting ads||Error||5||1
+2015-12-01 20:19:03.579246||measurement||price||2015-12-01 20:18:56.812317@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:19:03.663651||measurement||price||2015-12-01 20:18:44.148168@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:19:04.060139||measurement||loadtime||0:00:27.468973||1||0
+2015-12-01 20:19:06.909314||measurement||price||2015-12-01 20:18:49.236325@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:19:10.896473||measurement||loadtime||0:00:29.068938||3||1
+2015-12-01 20:19:14.019157||measurement||loadtime||0:00:27.031991||0||0
+2015-12-01 20:19:15.055714||measurement||price||2015-12-01 20:18:57.060930@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:19:16.585249||measurement||price||2015-12-01 20:18:56.812317@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:19:16.727455||measurement||price||2015-12-01 20:19:10.038722@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 20:19:22.164119||measurement||loadtime||0:00:26.835127||2||0
+2015-12-01 20:19:23.796462||measurement||loadtime||0:00:29.364129||4||1
+2015-12-01 20:19:24.521164||measurement||price||2015-12-01 20:19:18.241928@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:19:26.445891||error||collecting ads||Error||1||0
+2015-12-01 20:19:29.792929||measurement||price||2015-12-01 20:19:10.038722@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 20:19:34.473337||measurement||price||2015-12-01 20:19:28.858937@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:19:36.555806||error||collecting ads||Error||0||0
+2015-12-01 20:19:37.063447||measurement||loadtime||0:00:29.313254||5||1
+2015-12-01 20:19:37.598210||measurement||price||2015-12-01 20:19:18.241928@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:19:38.176558||measurement||price||2015-12-01 20:19:31.665646@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||4||1
+2015-12-01 20:19:44.856036||measurement||loadtime||0:00:28.954339||3||1
+2015-12-01 20:19:46.830776||measurement||price||2015-12-01 20:19:28.858937@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:19:48.785172||error||collecting ads||Error||1||0
+2015-12-01 20:19:49.168287||measurement||price||2015-12-01 20:19:43.737603@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:19:51.033921||measurement||price||2015-12-01 20:19:31.665646@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||4||1
+2015-12-01 20:19:51.158813||measurement||price||2015-12-01 20:19:44.561320@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 20:19:53.907186||measurement||loadtime||0:00:26.737833||2||0
+2015-12-01 20:19:58.218255||measurement||loadtime||0:00:29.419099||4||1
+2015-12-01 20:19:58.509740||measurement||price||2015-12-01 20:19:52.120985@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:20:01.111523||measurement||price||2015-12-01 20:19:55.505892@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:20:01.503743||measurement||price||2015-12-01 20:19:43.737603@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:20:04.062279||measurement||price||2015-12-01 20:19:44.561320@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 20:20:08.603991||measurement||loadtime||0:00:27.042946||0||0
+2015-12-01 20:20:11.290468||measurement||loadtime||0:00:29.221782||5||1
+2015-12-01 20:20:11.325014||measurement||price||2015-12-01 20:19:52.120985@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:20:13.457477||measurement||price||2015-12-01 20:19:55.505892@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:20:16.237376||error||collecting ads||Error||2||0
+2015-12-01 20:20:18.558898||measurement||loadtime||0:00:28.697903||3||1
+2015-12-01 20:20:20.563158||measurement||loadtime||0:00:26.776349||1||0
+2015-12-01 20:20:21.114740||measurement||price||2015-12-01 20:20:15.786162@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:20:22.230843||error||collecting ads||Error||4||1
+2015-12-01 20:20:25.687634||measurement||price||2015-12-01 20:20:19.428491@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:20:28.570721||measurement||price||2015-12-01 20:20:22.942219@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:20:32.323392||measurement||price||2015-12-01 20:20:25.868123@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:20:32.840408||measurement||price||2015-12-01 20:20:27.252063@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:20:33.451163||measurement||price||2015-12-01 20:20:15.786162@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:20:36.288258||measurement||price||2015-12-01 20:20:29.737888@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:20:38.678980||measurement||price||2015-12-01 20:20:19.428491@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:20:40.562763||measurement||loadtime||0:00:26.955582||0||0
+2015-12-01 20:20:40.912163||measurement||price||2015-12-01 20:20:22.942219@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:20:45.116628||measurement||price||2015-12-01 20:20:27.252063@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:20:45.144966||measurement||price||2015-12-01 20:20:25.868123@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:20:45.953297||measurement||loadtime||0:00:29.658131||5||1
+2015-12-01 20:20:48.027193||measurement||loadtime||0:00:26.787981||2||0
+2015-12-01 20:20:49.263571||measurement||price||2015-12-01 20:20:29.737888@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:20:52.236745||measurement||loadtime||0:00:26.668941||1||0
+2015-12-01 20:20:52.379167||measurement||loadtime||0:00:28.815096||3||1
+2015-12-01 20:20:52.946061||measurement||price||2015-12-01 20:20:47.529461@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:20:56.455170||measurement||loadtime||0:00:29.220030||4||1
+2015-12-01 20:20:59.849870||measurement||price||2015-12-01 20:20:53.448034@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 20:21:00.379077||measurement||price||2015-12-01 20:20:54.774235@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:21:04.619824||measurement||price||2015-12-01 20:20:58.978100@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 20:21:05.280120||measurement||price||2015-12-01 20:20:47.529461@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:21:06.429528||measurement||price||2015-12-01 20:20:59.718588@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:21:12.382429||measurement||loadtime||0:00:26.817402||0||0
+2015-12-01 20:21:12.732993||measurement||price||2015-12-01 20:20:54.774235@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:21:12.755262||measurement||price||2015-12-01 20:20:53.448034@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 20:21:16.958020||measurement||price||2015-12-01 20:20:58.978100@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 20:21:19.261984||measurement||price||2015-12-01 20:20:59.718588@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:21:19.843161||measurement||loadtime||0:00:26.812025||2||0
+2015-12-01 20:21:19.974635||measurement||loadtime||0:00:29.018312||5||1
+2015-12-01 20:21:20.247251||error||collecting ads||Error||4||1
+2015-12-01 20:21:24.070372||measurement||loadtime||0:00:26.828405||1||0
+2015-12-01 20:21:24.732065||measurement||price||2015-12-01 20:21:19.393088@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:21:26.479141||measurement||loadtime||0:00:29.095991||3||1
+2015-12-01 20:21:32.163207||measurement||price||2015-12-01 20:21:26.438149@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:21:33.784744||measurement||price||2015-12-01 20:21:27.266623@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 20:21:33.985717||measurement||price||2015-12-01 20:21:27.614357@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:21:36.781113||measurement||price||2015-12-01 20:21:31.201544@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||0
+2015-12-01 20:21:37.086049||measurement||price||2015-12-01 20:21:19.393088@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:21:40.153688||measurement||price||2015-12-01 20:21:33.776918@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:21:44.199166||measurement||loadtime||0:00:26.811511||0||0
+2015-12-01 20:21:44.469392||measurement||price||2015-12-01 20:21:26.438149@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:21:46.833447||measurement||price||2015-12-01 20:21:27.266623@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 20:21:46.844143||measurement||price||2015-12-01 20:21:27.614357@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:21:49.119980||measurement||price||2015-12-01 20:21:31.201544@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||0
+2015-12-01 20:21:51.563155||measurement||loadtime||0:00:26.714802||2||0
+2015-12-01 20:21:53.070441||measurement||price||2015-12-01 20:21:33.776918@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:21:54.048505||measurement||loadtime||0:00:29.069359||5||1
+2015-12-01 20:21:54.056111||measurement||loadtime||0:00:28.807629||4||1
+2015-12-01 20:21:56.240323||measurement||loadtime||0:00:27.165172||1||0
+2015-12-01 20:21:56.685009||measurement||price||2015-12-01 20:21:51.228399@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:22:00.267158||measurement||loadtime||0:00:28.782778||3||1
+2015-12-01 20:22:08.254501||measurement||price||2015-12-01 20:22:01.400921@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:22:08.581646||measurement||price||2015-12-01 20:22:02.948327@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:22:09.033828||measurement||price||2015-12-01 20:21:51.228399@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:22:13.765174||error||collecting ads||Error||2||0
+2015-12-01 20:22:16.155605||measurement||loadtime||0:00:26.951217||0||0
+2015-12-01 20:22:18.579526||error||collecting ads||Error||5||1
+2015-12-01 20:22:20.928888||measurement||price||2015-12-01 20:22:02.948327@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:22:21.342548||measurement||price||2015-12-01 20:22:01.400921@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:22:24.120619||error||collecting ads||Error||3||1
+2015-12-01 20:22:25.953298||measurement||price||2015-12-01 20:22:20.357379@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:22:28.042339||measurement||loadtime||0:00:26.799203||1||0
+2015-12-01 20:22:28.573326||measurement||loadtime||0:00:29.512020||4||1
+2015-12-01 20:22:28.771923||measurement||price||2015-12-01 20:22:23.335634@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:22:32.567697||measurement||price||2015-12-01 20:22:25.909441@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:22:37.704926||measurement||price||2015-12-01 20:22:31.248030@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:22:38.291995||measurement||price||2015-12-01 20:22:20.357379@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:22:40.361767||measurement||price||2015-12-01 20:22:34.732545@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 20:22:41.122827||measurement||price||2015-12-01 20:22:23.335634@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:22:42.577282||measurement||price||2015-12-01 20:22:35.882395@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:22:45.386041||measurement||loadtime||0:00:26.615623||2||0
+2015-12-01 20:22:45.459274||measurement||price||2015-12-01 20:22:25.909441@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:22:48.235209||measurement||loadtime||0:00:27.074367||0||0
+2015-12-01 20:22:50.621363||measurement||price||2015-12-01 20:22:31.248030@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:22:52.660221||measurement||loadtime||0:00:29.075487||5||1
+2015-12-01 20:22:52.723832||measurement||price||2015-12-01 20:22:34.732545@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 20:22:55.660150||measurement||price||2015-12-01 20:22:35.882395@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:22:57.619444||measurement||price||2015-12-01 20:22:52.017379@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:22:57.843143||measurement||loadtime||0:00:28.717280||3||1
+2015-12-01 20:22:59.855419||measurement||loadtime||0:00:26.808280||1||0
+2015-12-01 20:23:02.955149||measurement||loadtime||0:00:29.376607||4||1
+2015-12-01 20:23:06.978950||measurement||price||2015-12-01 20:23:00.537086@|Extech@|$17.75@|Extech MN35 Digital Mini MultiMeter||5||1
+2015-12-01 20:23:09.941237||measurement||price||2015-12-01 20:22:52.017379@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:23:10.612842||error||collecting ads||Error||0||0
+2015-12-01 20:23:12.198527||measurement||price||2015-12-01 20:23:06.511880@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:23:16.965873||measurement||price||2015-12-01 20:23:10.329970@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:23:17.064363||measurement||loadtime||0:00:26.674455||2||0
+2015-12-01 20:23:20.074947||measurement||price||2015-12-01 20:23:00.537086@|Extech@|$39.99@|Extech CB10 Circuit Breaker Finder locates fuses/breakers, t...||5||1
+2015-12-01 20:23:21.735508||error||collecting ads||Error||3||1
+2015-12-01 20:23:24.557813||measurement||price||2015-12-01 20:23:06.511880@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:23:27.304561||measurement||loadtime||0:00:29.642699||5||1
+2015-12-01 20:23:29.257828||measurement||price||2015-12-01 20:23:23.623139@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:23:29.819586||measurement||price||2015-12-01 20:23:10.329970@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:23:31.674128||measurement||loadtime||0:00:26.813505||1||0
+2015-12-01 20:23:34.778082||error||collecting ads||Error||0||0
+2015-12-01 20:23:35.345946||measurement||price||2015-12-01 20:23:28.803979@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:23:37.015166||measurement||loadtime||0:00:29.054805||4||1
+2015-12-01 20:23:41.374711||measurement||price||2015-12-01 20:23:34.589441@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 20:23:41.607731||measurement||price||2015-12-01 20:23:23.623139@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:23:43.936426||measurement||price||2015-12-01 20:23:38.316714@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 20:23:47.269597||measurement||price||2015-12-01 20:23:41.781575@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:23:48.414296||measurement||price||2015-12-01 20:23:28.803979@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:23:48.735201||measurement||loadtime||0:00:26.665587||2||0
+2015-12-01 20:23:50.954781||measurement||price||2015-12-01 20:23:44.335401@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:23:54.487671||measurement||price||2015-12-01 20:23:34.589441@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 20:23:55.627888||measurement||loadtime||0:00:28.890249||3||1
+2015-12-01 20:23:56.281001||measurement||price||2015-12-01 20:23:38.316714@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 20:23:59.552924||measurement||price||2015-12-01 20:23:41.781575@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:24:01.009187||measurement||price||2015-12-01 20:23:55.435283@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:24:01.743172||measurement||loadtime||0:00:29.433410||5||1
+2015-12-01 20:24:03.397252||measurement||loadtime||0:00:26.718096||1||0
+2015-12-01 20:24:03.825400||measurement||price||2015-12-01 20:23:44.335401@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:24:06.650703||measurement||loadtime||0:00:26.867387||0||0
+2015-12-01 20:24:09.375571||measurement||price||2015-12-01 20:24:02.784431@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:24:11.041685||measurement||loadtime||0:00:29.022511||4||1
+2015-12-01 20:24:13.349037||measurement||price||2015-12-01 20:23:55.435283@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:24:15.782033||measurement||price||2015-12-01 20:24:10.144277@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 20:24:19.151940||measurement||price||2015-12-01 20:24:13.756863@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:24:20.458529||measurement||loadtime||0:00:26.718675||2||0
+2015-12-01 20:24:22.408511||measurement||price||2015-12-01 20:24:02.784431@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:24:25.048353||measurement||price||2015-12-01 20:24:18.329714@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:24:26.152964||error||collecting ads||Error||5||1
+2015-12-01 20:24:28.136872||measurement||price||2015-12-01 20:24:10.144277@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 20:24:29.611848||measurement||loadtime||0:00:28.978779||3||1
+2015-12-01 20:24:31.504475||measurement||price||2015-12-01 20:24:13.756863@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:24:32.705041||measurement||price||2015-12-01 20:24:27.079664@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:24:35.259185||measurement||loadtime||0:00:26.856462||1||0
+2015-12-01 20:24:38.111426||measurement||price||2015-12-01 20:24:18.329714@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:24:38.618714||measurement||loadtime||0:00:26.963572||0||0
+2015-12-01 20:24:40.315145||measurement||price||2015-12-01 20:24:33.445475@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:24:45.049681||measurement||price||2015-12-01 20:24:27.079664@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:24:45.327176||measurement||loadtime||0:00:29.280262||4||1
+2015-12-01 20:24:51.021923||measurement||price||2015-12-01 20:24:45.688562@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:24:52.157399||measurement||loadtime||0:00:26.693661||2||0
+2015-12-01 20:24:53.262517||error||collecting ads||Error||3||1
+2015-12-01 20:24:53.449799||measurement||price||2015-12-01 20:24:33.445475@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:24:58.235251||error||collecting ads||Error||1||0
+2015-12-01 20:24:59.450609||measurement||price||2015-12-01 20:24:52.628105@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:25:00.668141||measurement||loadtime||0:00:29.511955||5||1
+2015-12-01 20:25:03.336759||measurement||price||2015-12-01 20:24:45.688562@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:25:04.415630||measurement||price||2015-12-01 20:24:58.757187@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:25:06.926409||measurement||price||2015-12-01 20:25:00.437142@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:25:10.447171||measurement||loadtime||0:00:26.827140||0||0
+2015-12-01 20:25:10.447282||event||progress-marker||measurement-end||0||0
+2015-12-01 20:25:12.303905||measurement||price||2015-12-01 20:24:52.628105@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:25:16.759514||measurement||price||2015-12-01 20:24:58.757187@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:25:19.525058||measurement||loadtime||0:00:29.192679||4||1
+2015-12-01 20:25:19.728488||measurement||price||2015-12-01 20:25:00.437142@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:25:20.416174||error||collecting ads||Error||1||0
+2015-12-01 20:25:20.416269||event||progress-marker||measurement-end||1||0
+2015-12-01 20:25:23.874098||measurement||loadtime||0:00:26.711483||2||0
+2015-12-01 20:25:23.874215||event||progress-marker||measurement-end||2||0
+2015-12-01 20:25:24.882658||error||collecting ads||Error||5||1
+2015-12-01 20:25:26.947165||measurement||loadtime||0:00:28.679999||3||1
+2015-12-01 20:25:33.748995||measurement||price||2015-12-01 20:25:27.807872@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:25:46.660656||measurement||price||2015-12-01 20:25:27.807872@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:25:48.572652||error||collecting ads||Error||5||1
+2015-12-01 20:25:50.725663||error||collecting ads||Error||3||1
+2015-12-01 20:25:53.883147||measurement||loadtime||0:00:29.352868||4||1
+2015-12-01 20:26:04.301415||measurement||price||2015-12-01 20:25:57.874873@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:26:07.993178||measurement||price||2015-12-01 20:26:01.786270@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||4||1
+2015-12-01 20:26:12.276863||error||collecting ads||Error||5||1
+2015-12-01 20:26:17.376046||measurement||price||2015-12-01 20:25:57.874873@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:26:20.837100||measurement||price||2015-12-01 20:26:01.786270@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||4||1
+2015-12-01 20:26:24.600495||measurement||loadtime||0:00:28.873328||3||1
+2015-12-01 20:26:28.037517||measurement||loadtime||0:00:29.153604||4||1
+2015-12-01 20:26:35.976729||error||collecting ads||Error||5||1
+2015-12-01 20:26:38.237555||measurement||price||2015-12-01 20:26:31.937751@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:26:41.801041||measurement||price||2015-12-01 20:26:35.314263@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:26:49.882397||measurement||price||2015-12-01 20:26:43.364233@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 20:26:51.196351||measurement||price||2015-12-01 20:26:31.937751@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:26:54.615973||measurement||price||2015-12-01 20:26:35.314263@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:26:58.412432||measurement||loadtime||0:00:28.806657||3||1
+2015-12-01 20:27:01.810631||measurement||loadtime||0:00:28.769294||4||1
+2015-12-01 20:27:02.690720||measurement||price||2015-12-01 20:26:43.364233@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 20:27:09.879265||measurement||loadtime||0:00:28.897305||5||1
+2015-12-01 20:27:09.879371||event||progress-marker||measurement-end||5||1
+2015-12-01 20:27:12.152477||measurement||price||2015-12-01 20:27:05.649212@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:27:15.763452||measurement||price||2015-12-01 20:27:09.157123@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:27:25.019808||measurement||price||2015-12-01 20:27:05.649212@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:27:28.635985||measurement||price||2015-12-01 20:27:09.157123@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:27:32.236773||measurement||loadtime||0:00:28.820883||3||1
+2015-12-01 20:27:32.236922||event||progress-marker||measurement-end||3||1
+2015-12-01 20:27:35.833273||measurement||loadtime||0:00:29.017424||4||1
+2015-12-01 20:27:49.748186||measurement||price||2015-12-01 20:27:43.010108@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:28:02.750197||measurement||price||2015-12-01 20:27:43.010108@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:28:09.934219||measurement||loadtime||0:00:29.095735||4||1
+2015-12-01 20:28:09.934355||event||progress-marker||measurement-end||4||1
+2015-12-01 20:28:10.384844||meta||block_id end||1
+2015-12-01 20:28:10.385126||meta||block_id start||2
+2015-12-01 20:28:10.385155||meta||assignment||5@|0@|2@|3@|4@|1
+2015-12-01 20:28:11.976310||event||progress-marker||training-start||0||0
+2015-12-01 20:28:11.994863||event||progress-marker||training-start||2||0
+2015-12-01 20:28:12.021562||event||progress-marker||training-start||5||0
+2015-12-01 20:28:18.549400||treatment||visit website||http://irs.gov||2||0
+2015-12-01 20:28:18.591140||treatment||visit website||http://irs.gov||0||0
+2015-12-01 20:28:18.599200||treatment||visit website||http://irs.gov||5||0
+2015-12-01 20:28:25.559381||treatment||visit website||http://deloitte.com||5||0
+2015-12-01 20:28:25.565586||treatment||visit website||http://deloitte.com||0||0
+2015-12-01 20:28:25.603126||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 20:28:33.628972||treatment||visit website||http://pwc.com||0||0
+2015-12-01 20:28:33.679126||treatment||visit website||http://pwc.com||5||0
+2015-12-01 20:28:33.703109||treatment||visit website||http://pwc.com||2||0
+2015-12-01 20:28:39.566374||treatment||visit website||http://ey.com||0||0
+2015-12-01 20:28:39.580925||treatment||visit website||http://ey.com||5||0
+2015-12-01 20:28:39.629393||treatment||visit website||http://ey.com||2||0
+2015-12-01 20:28:46.402288||treatment||visit website||http://kpmg.com||0||0
+2015-12-01 20:28:46.402442||event||progress-marker||training-end||0||0
+2015-12-01 20:28:46.423098||treatment||visit website||http://kpmg.com||5||0
+2015-12-01 20:28:46.423209||event||progress-marker||training-end||5||0
+2015-12-01 20:28:46.460104||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 20:28:46.460233||event||progress-marker||training-end||2||0
+2015-12-01 20:28:51.415691||event||progress-marker||measurement-start||0||0
+2015-12-01 20:28:51.436244||event||progress-marker||measurement-start||5||0
+2015-12-01 20:28:51.473153||event||progress-marker||measurement-start||2||0
+2015-12-01 20:29:04.889830||measurement||price||2015-12-01 20:28:58.980840@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||0||0
+2015-12-01 20:29:05.190532||measurement||price||2015-12-01 20:28:58.763530@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:29:06.465229||measurement||price||2015-12-01 20:28:58.673784@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:29:16.467575||event||progress-marker||training-start||1||1
+2015-12-01 20:29:17.253471||measurement||price||2015-12-01 20:28:58.980840@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-01 20:29:17.545996||measurement||price||2015-12-01 20:28:58.763530@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:29:18.813183||measurement||price||2015-12-01 20:28:58.673784@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:29:24.359177||measurement||loadtime||0:00:27.938289||0||0
+2015-12-01 20:29:24.663912||measurement||loadtime||0:00:28.186829||2||0
+2015-12-01 20:29:25.961768||measurement||loadtime||0:00:29.520301||5||0
+2015-12-01 20:29:34.019124||treatment||visit website||http://irs.gov||1||1
+2015-12-01 20:29:37.552667||measurement||price||2015-12-01 20:29:31.861306@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:29:38.543758||measurement||price||2015-12-01 20:29:32.751632@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:29:39.074342||measurement||price||2015-12-01 20:29:33.099447@|3M Littmann@|$85.00 - $234.56@|3M Littmann Classic III Stethoscope (Multiple Colors)||2||0
+2015-12-01 20:29:40.503884||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 20:29:43.935907||event||progress-marker||training-start||3||1
+2015-12-01 20:29:44.993544||event||progress-marker||training-start||4||1
+2015-12-01 20:29:49.833589||measurement||price||2015-12-01 20:29:31.861306@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:29:50.869908||measurement||price||2015-12-01 20:29:32.751632@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:29:50.914575||treatment||visit website||http://irs.gov||3||1
+2015-12-01 20:29:51.400136||measurement||price||2015-12-01 20:29:33.099447@|3M Littmann@|$62.96 - $319.00@|3M Littmann Classic II S.E. Stethoscope (Multiple Colors)||2||0
+2015-12-01 20:29:51.655105||treatment||visit website||http://irs.gov||4||1
+2015-12-01 20:29:56.944543||measurement||loadtime||0:00:27.581362||0||0
+2015-12-01 20:29:57.988862||measurement||loadtime||0:00:27.025688||5||0
+2015-12-01 20:29:58.520992||measurement||loadtime||0:00:28.851847||2||0
+2015-12-01 20:29:58.533327||treatment||visit website||http://deloitte.com||4||1
+2015-12-01 20:29:59.500599||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 20:30:08.648234||treatment||visit website||http://pwc.com||4||1
+2015-12-01 20:30:09.303712||measurement||price||2015-12-01 20:30:03.642818@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:30:10.413868||measurement||price||2015-12-01 20:30:04.778717@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:30:10.964871||measurement||price||2015-12-01 20:30:05.283786@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:30:11.536082||treatment||visit website||http://pwc.com||1||1
+2015-12-01 20:30:14.835480||treatment||visit website||http://ey.com||4||1
+2015-12-01 20:30:17.139136||treatment||visit website||http://pwc.com||3||1
+2015-12-01 20:30:20.227670||treatment||visit website||http://ey.com||1||1
+2015-12-01 20:30:21.655596||measurement||price||2015-12-01 20:30:03.642818@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:30:21.757081||treatment||visit website||http://kpmg.com||4||1
+2015-12-01 20:30:21.757188||event||progress-marker||training-end||4||1
+2015-12-01 20:30:22.762246||measurement||price||2015-12-01 20:30:04.778717@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:30:23.103109||treatment||visit website||http://ey.com||3||1
+2015-12-01 20:30:23.316215||measurement||price||2015-12-01 20:30:05.283786@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:30:26.728538||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 20:30:26.728662||event||progress-marker||training-end||1||1
+2015-12-01 20:30:28.763154||measurement||loadtime||0:00:26.816008||0||0
+2015-12-01 20:30:29.508389||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 20:30:29.508529||event||progress-marker||training-end||3||1
+2015-12-01 20:30:29.865775||measurement||loadtime||0:00:26.871677||5||0
+2015-12-01 20:30:30.428865||measurement||loadtime||0:00:26.903799||2||0
+2015-12-01 20:30:31.737802||event||progress-marker||measurement-start||1||1
+2015-12-01 20:30:31.775247||event||progress-marker||measurement-start||4||1
+2015-12-01 20:30:34.517700||event||progress-marker||measurement-start||3||1
+2015-12-01 20:30:40.929193||measurement||price||2015-12-01 20:30:35.347488@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:30:42.258393||measurement||price||2015-12-01 20:30:36.564408@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:30:43.229062||measurement||price||2015-12-01 20:30:37.542252@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:30:46.166451||measurement||price||2015-12-01 20:30:39.875736@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:30:46.409348||measurement||price||2015-12-01 20:30:39.654921@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:30:48.918017||measurement||price||2015-12-01 20:30:42.359852@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:30:53.276968||measurement||price||2015-12-01 20:30:35.347488@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:30:54.596138||measurement||price||2015-12-01 20:30:36.564408@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:30:55.554467||measurement||price||2015-12-01 20:30:37.542252@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:30:58.999335||measurement||price||2015-12-01 20:30:39.875736@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:30:59.204524||measurement||price||2015-12-01 20:30:39.654921@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:31:00.391583||measurement||loadtime||0:00:26.624435||0||0
+2015-12-01 20:31:01.703131||measurement||loadtime||0:00:26.832147||5||0
+2015-12-01 20:31:01.745556||measurement||price||2015-12-01 20:30:42.359852@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:31:02.634565||measurement||loadtime||0:00:27.200482||2||0
+2015-12-01 20:31:06.227189||measurement||loadtime||0:00:29.446631||4||1
+2015-12-01 20:31:06.406517||measurement||loadtime||0:00:29.667358||1||1
+2015-12-01 20:31:08.947177||measurement||loadtime||0:00:29.427997||3||1
+2015-12-01 20:31:14.012960||measurement||price||2015-12-01 20:31:08.501676@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:31:15.033911||measurement||price||2015-12-01 20:31:09.353495@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:31:22.639520||error||collecting ads||Error||0||0
+2015-12-01 20:31:23.077556||measurement||price||2015-12-01 20:31:16.803297@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||3||1
+2015-12-01 20:31:26.354265||measurement||price||2015-12-01 20:31:08.501676@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:31:27.383352||measurement||price||2015-12-01 20:31:09.353495@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:31:30.145298||error||collecting ads||Error||4||1
+2015-12-01 20:31:30.734584||error||collecting ads||Error||1||1
+2015-12-01 20:31:33.463174||measurement||loadtime||0:00:26.756026||5||0
+2015-12-01 20:31:34.499579||measurement||loadtime||0:00:26.860415||2||0
+2015-12-01 20:31:35.112919||measurement||price||2015-12-01 20:31:29.519384@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:31:36.135353||measurement||price||2015-12-01 20:31:16.803297@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||3||1
+2015-12-01 20:31:43.352325||measurement||loadtime||0:00:29.399969||3||1
+2015-12-01 20:31:43.868699||measurement||price||2015-12-01 20:31:37.585492@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:31:44.859985||measurement||price||2015-12-01 20:31:38.060914@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 20:31:45.787967||measurement||price||2015-12-01 20:31:40.248096@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:31:47.472769||measurement||price||2015-12-01 20:31:29.519384@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:31:54.596160||measurement||loadtime||0:00:26.952997||0||0
+2015-12-01 20:31:56.805939||error||collecting ads||Error||2||0
+2015-12-01 20:31:56.842993||measurement||price||2015-12-01 20:31:37.585492@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:31:58.007876||measurement||price||2015-12-01 20:31:38.060914@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 20:31:58.134747||measurement||price||2015-12-01 20:31:40.248096@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:32:04.059173||measurement||loadtime||0:00:28.912025||4||1
+2015-12-01 20:32:05.239404||measurement||loadtime||0:00:26.771033||5||0
+2015-12-01 20:32:05.251157||measurement||loadtime||0:00:29.511358||1||1
+2015-12-01 20:32:06.767084||measurement||price||2015-12-01 20:32:01.209804@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 20:32:06.816403||error||collecting ads||Error||3||1
+2015-12-01 20:32:09.229063||measurement||price||2015-12-01 20:32:03.649857@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:32:17.586844||measurement||price||2015-12-01 20:32:11.971150@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:32:17.780445||measurement||price||2015-12-01 20:32:11.418413@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:32:19.103627||measurement||price||2015-12-01 20:32:01.209804@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 20:32:19.437151||measurement||price||2015-12-01 20:32:12.718452@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:32:20.673514||measurement||price||2015-12-01 20:32:14.212228@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:32:21.569340||measurement||price||2015-12-01 20:32:03.649857@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:32:26.219676||measurement||loadtime||0:00:26.619519||0||0
+2015-12-01 20:32:28.679850||measurement||loadtime||0:00:26.872656||2||0
+2015-12-01 20:32:29.932772||measurement||price||2015-12-01 20:32:11.971150@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:32:30.676680||measurement||price||2015-12-01 20:32:11.418413@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:32:32.317852||measurement||price||2015-12-01 20:32:12.718452@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:32:33.498000||measurement||price||2015-12-01 20:32:14.212228@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:32:37.038107||measurement||loadtime||0:00:26.793523||5||0
+2015-12-01 20:32:37.877863||measurement||loadtime||0:00:28.813472||4||1
+2015-12-01 20:32:39.551175||measurement||loadtime||0:00:29.295361||1||1
+2015-12-01 20:32:40.734103||measurement||loadtime||0:00:28.912494||3||1
+2015-12-01 20:32:40.890963||measurement||price||2015-12-01 20:32:35.345480@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:32:48.419344||error||collecting ads||Error||0||0
+2015-12-01 20:32:49.328037||measurement||price||2015-12-01 20:32:43.728190@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:32:51.706440||measurement||price||2015-12-01 20:32:45.217745@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:32:53.231071||measurement||price||2015-12-01 20:32:35.345480@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:32:53.384859||measurement||price||2015-12-01 20:32:46.885302@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 20:33:00.354023||measurement||loadtime||0:00:26.668873||2||0
+2015-12-01 20:33:00.628517||measurement||price||2015-12-01 20:32:55.100817@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:33:01.653654||measurement||price||2015-12-01 20:32:43.728190@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:33:04.513360||error||collecting ads||Error||3||1
+2015-12-01 20:33:04.739790||measurement||price||2015-12-01 20:32:45.217745@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:33:06.234459||measurement||price||2015-12-01 20:32:46.885302@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 20:33:08.767209||measurement||loadtime||0:00:26.723884||5||0
+2015-12-01 20:33:11.955937||measurement||loadtime||0:00:29.076799||4||1
+2015-12-01 20:33:12.551716||measurement||price||2015-12-01 20:33:06.966618@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:33:12.970578||measurement||price||2015-12-01 20:32:55.100817@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:33:13.435365||measurement||loadtime||0:00:28.880916||1||1
+2015-12-01 20:33:18.589945||measurement||price||2015-12-01 20:33:12.335530@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-01 20:33:20.087146||measurement||loadtime||0:00:26.664020||0||0
+2015-12-01 20:33:24.914434||measurement||price||2015-12-01 20:33:06.966618@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:33:25.620061||measurement||price||2015-12-01 20:33:19.382445@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:33:27.338576||measurement||price||2015-12-01 20:33:20.946907@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:33:31.421679||error||collecting ads||Error||5||0
+2015-12-01 20:33:31.618632||measurement||price||2015-12-01 20:33:12.335530@|@|$79.95@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-01 20:33:32.021952||measurement||loadtime||0:00:26.662696||2||0
+2015-12-01 20:33:32.436034||measurement||price||2015-12-01 20:33:27.007433@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:33:38.617471||measurement||price||2015-12-01 20:33:19.382445@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:33:38.815246||measurement||loadtime||0:00:29.297991||3||1
+2015-12-01 20:33:40.302959||measurement||price||2015-12-01 20:33:20.946907@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:33:43.605393||measurement||price||2015-12-01 20:33:38.079923@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:33:44.381821||measurement||price||2015-12-01 20:33:38.757003@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:33:44.784217||measurement||price||2015-12-01 20:33:27.007433@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:33:45.849008||measurement||loadtime||0:00:28.887879||4||1
+2015-12-01 20:33:47.523390||measurement||loadtime||0:00:29.082808||1||1
+2015-12-01 20:33:51.859172||measurement||loadtime||0:00:26.768015||0||0
+2015-12-01 20:33:53.036111||measurement||price||2015-12-01 20:33:46.097661@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:33:55.950748||measurement||price||2015-12-01 20:33:38.079923@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:33:56.714343||measurement||price||2015-12-01 20:33:38.757003@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:33:59.591962||measurement||price||2015-12-01 20:33:53.676597@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:34:01.873493||measurement||price||2015-12-01 20:33:55.207933@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:34:03.061315||measurement||loadtime||0:00:26.634403||5||0
+2015-12-01 20:34:03.826333||measurement||loadtime||0:00:26.799122||2||0
+2015-12-01 20:34:05.953241||measurement||price||2015-12-01 20:33:46.097661@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:34:12.506822||measurement||price||2015-12-01 20:33:53.676597@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:34:13.200861||measurement||loadtime||0:00:29.380382||3||1
+2015-12-01 20:34:14.416323||error||collecting ads||Error||0||0
+2015-12-01 20:34:14.811759||measurement||price||2015-12-01 20:33:55.207933@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:34:15.479074||measurement||price||2015-12-01 20:34:09.832031@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:34:16.730361||measurement||price||2015-12-01 20:34:11.089847@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:34:19.722948||measurement||loadtime||0:00:28.871804||4||1
+2015-12-01 20:34:22.007603||measurement||loadtime||0:00:29.480459||1||1
+2015-12-01 20:34:26.938563||measurement||price||2015-12-01 20:34:20.457919@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:34:27.821952||measurement||price||2015-12-01 20:34:09.832031@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:34:29.047822||measurement||price||2015-12-01 20:34:11.089847@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:34:33.467971||measurement||price||2015-12-01 20:34:26.982374@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:34:34.931181||measurement||loadtime||0:00:26.864653||5||0
+2015-12-01 20:34:36.058105||measurement||price||2015-12-01 20:34:29.247187@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:34:36.164840||measurement||loadtime||0:00:27.333308||2||0
+2015-12-01 20:34:36.637106||error||collecting ads||Error||0||0
+2015-12-01 20:34:39.744370||measurement||price||2015-12-01 20:34:20.457919@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:34:46.347856||measurement||price||2015-12-01 20:34:26.982374@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:34:46.938811||measurement||loadtime||0:00:28.732722||3||1
+2015-12-01 20:34:47.283012||measurement||price||2015-12-01 20:34:41.615600@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:34:48.435250||measurement||price||2015-12-01 20:34:42.822721@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:34:48.991843||measurement||price||2015-12-01 20:34:43.308792@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 20:34:49.001651||measurement||price||2015-12-01 20:34:29.247187@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:34:53.567685||measurement||loadtime||0:00:28.839498||4||1
+2015-12-01 20:34:56.223214||measurement||loadtime||0:00:29.213072||1||1
+2015-12-01 20:34:59.619919||measurement||price||2015-12-01 20:34:41.615600@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:35:00.467766||measurement||price||2015-12-01 20:34:54.171068@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:35:00.788802||measurement||price||2015-12-01 20:34:42.822721@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:35:01.320498||measurement||price||2015-12-01 20:34:43.308792@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 20:35:06.730853||measurement||loadtime||0:00:26.794416||5||0
+2015-12-01 20:35:07.398460||measurement||price||2015-12-01 20:35:00.956224@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:35:07.899150||measurement||loadtime||0:00:26.732023||2||0
+2015-12-01 20:35:08.435216||measurement||loadtime||0:00:26.792898||0||0
+2015-12-01 20:35:10.307148||measurement||price||2015-12-01 20:35:03.534094@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:35:13.234090||measurement||price||2015-12-01 20:34:54.171068@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:35:19.007055||measurement||price||2015-12-01 20:35:13.358318@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:35:20.391113||measurement||price||2015-12-01 20:35:00.956224@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:35:20.472792||measurement||loadtime||0:00:28.528768||3||1
+2015-12-01 20:35:20.751387||measurement||price||2015-12-01 20:35:15.110485@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 20:35:23.190026||measurement||price||2015-12-01 20:35:03.534094@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:35:27.596317||measurement||loadtime||0:00:29.023412||4||1
+2015-12-01 20:35:30.338390||error||collecting ads||Error||2||0
+2015-12-01 20:35:30.438132||measurement||loadtime||0:00:29.209708||1||1
+2015-12-01 20:35:31.343415||measurement||price||2015-12-01 20:35:13.358318@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:35:33.095701||measurement||price||2015-12-01 20:35:15.110485@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 20:35:34.373872||measurement||price||2015-12-01 20:35:27.716967@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:35:38.460545||measurement||loadtime||0:00:26.724495||5||0
+2015-12-01 20:35:40.215151||measurement||loadtime||0:00:26.775996||0||0
+2015-12-01 20:35:44.528330||measurement||price||2015-12-01 20:35:37.902440@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:35:47.239185||measurement||price||2015-12-01 20:35:27.716967@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:35:50.754267||measurement||price||2015-12-01 20:35:45.094056@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:35:51.130176||error||collecting ads||Error||4||1
+2015-12-01 20:35:52.714748||error||collecting ads||Error||2||0
+2015-12-01 20:35:54.451189||measurement||loadtime||0:00:28.973206||3||1
+2015-12-01 20:35:57.562365||measurement||price||2015-12-01 20:35:37.902440@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:36:02.581905||error||collecting ads||Error||0||0
+2015-12-01 20:36:03.101586||measurement||price||2015-12-01 20:35:45.094056@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:36:04.775878||measurement||loadtime||0:00:29.332692||1||1
+2015-12-01 20:36:04.964695||measurement||price||2015-12-01 20:35:59.421749@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:36:05.166253||measurement||price||2015-12-01 20:35:58.767577@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:36:08.099432||measurement||price||2015-12-01 20:36:01.722726@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:36:10.209061||measurement||loadtime||0:00:26.743288||5||0
+2015-12-01 20:36:17.296024||measurement||price||2015-12-01 20:35:59.421749@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:36:17.982880||measurement||price||2015-12-01 20:35:58.767577@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:36:21.051985||measurement||price||2015-12-01 20:36:01.722726@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:36:22.592364||measurement||price||2015-12-01 20:36:16.875322@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:36:24.415130||measurement||loadtime||0:00:26.695952||2||0
+2015-12-01 20:36:24.825731||error||collecting ads||Error||0||0
+2015-12-01 20:36:25.248887||measurement||loadtime||0:00:29.113459||4||1
+2015-12-01 20:36:28.275082||measurement||loadtime||0:00:28.819898||3||1
+2015-12-01 20:36:28.635384||error||collecting ads||Error||1||1
+2015-12-01 20:36:34.929127||measurement||price||2015-12-01 20:36:16.875322@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:36:36.820138||measurement||price||2015-12-01 20:36:31.155018@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:36:37.145334||measurement||price||2015-12-01 20:36:31.524520@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 20:36:39.178632||measurement||price||2015-12-01 20:36:32.586519@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:36:42.043178||measurement||loadtime||0:00:26.828916||5||0
+2015-12-01 20:36:42.168595||measurement||price||2015-12-01 20:36:35.582573@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:36:42.562587||measurement||price||2015-12-01 20:36:35.949167@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:36:49.105570||measurement||price||2015-12-01 20:36:31.155018@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:36:49.475162||measurement||price||2015-12-01 20:36:31.524520@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 20:36:52.020178||measurement||price||2015-12-01 20:36:32.586519@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:36:55.132186||measurement||price||2015-12-01 20:36:35.582573@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:36:55.462477||measurement||price||2015-12-01 20:36:35.949167@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:36:56.188294||measurement||loadtime||0:00:26.769354||2||0
+2015-12-01 20:36:56.580231||measurement||loadtime||0:00:26.749298||0||0
+2015-12-01 20:36:59.247997||measurement||loadtime||0:00:28.996849||4||1
+2015-12-01 20:37:02.341745||measurement||loadtime||0:00:29.061420||3||1
+2015-12-01 20:37:02.667158||measurement||loadtime||0:00:29.028043||1||1
+2015-12-01 20:37:04.261922||error||collecting ads||Error||5||0
+2015-12-01 20:37:08.486944||measurement||price||2015-12-01 20:37:02.828987@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:37:08.876085||measurement||price||2015-12-01 20:37:03.261617@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 20:37:12.791512||measurement||price||2015-12-01 20:37:06.467347@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 20:37:16.649459||measurement||price||2015-12-01 20:37:10.893491@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:37:17.063099||measurement||price||2015-12-01 20:37:10.771441@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:37:20.854173||measurement||price||2015-12-01 20:37:02.828987@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:37:21.226916||measurement||price||2015-12-01 20:37:03.261617@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 20:37:25.801877||measurement||price||2015-12-01 20:37:06.467347@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 20:37:26.067277||error||collecting ads||Error||3||1
+2015-12-01 20:37:27.975167||measurement||loadtime||0:00:26.781658||2||0
+2015-12-01 20:37:28.339010||measurement||loadtime||0:00:26.754199||0||0
+2015-12-01 20:37:29.005285||measurement||price||2015-12-01 20:37:10.893491@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:37:29.921414||measurement||price||2015-12-01 20:37:10.771441@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:37:33.020605||measurement||loadtime||0:00:28.768635||4||1
+2015-12-01 20:37:36.118645||measurement||loadtime||0:00:26.855370||5||0
+2015-12-01 20:37:37.119406||measurement||loadtime||0:00:29.448253||1||1
+2015-12-01 20:37:40.424638||measurement||price||2015-12-01 20:37:34.418693@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||1
+2015-12-01 20:37:40.586657||measurement||price||2015-12-01 20:37:34.985285@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 20:37:48.363925||measurement||price||2015-12-01 20:37:42.749013@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:37:50.391735||error||collecting ads||Error||2||0
+2015-12-01 20:37:51.050970||measurement||price||2015-12-01 20:37:44.273193@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:37:52.924471||measurement||price||2015-12-01 20:37:34.985285@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 20:37:53.400156||measurement||price||2015-12-01 20:37:34.418693@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||1
+2015-12-01 20:37:56.801302||error||collecting ads||Error||4||1
+2015-12-01 20:38:00.043371||measurement||loadtime||0:00:26.700200||0||0
+2015-12-01 20:38:00.692622||measurement||price||2015-12-01 20:37:42.749013@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:38:00.703129||measurement||loadtime||0:00:29.630643||3||1
+2015-12-01 20:38:04.099149||measurement||price||2015-12-01 20:37:44.273193@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:38:07.803176||measurement||loadtime||0:00:26.680023||5||0
+2015-12-01 20:38:10.515354||measurement||price||2015-12-01 20:38:04.152253@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:38:11.312972||measurement||loadtime||0:00:29.189790||1||1
+2015-12-01 20:38:12.302316||measurement||price||2015-12-01 20:38:06.673917@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 20:38:12.631843||error||collecting ads||Error||2||0
+2015-12-01 20:38:14.818582||measurement||price||2015-12-01 20:38:08.472677@|Irwin Tools@|$129.95@|Irwin Tools 1868997 Multiple Tool Set, 13-Piece||3||1
+2015-12-01 20:38:20.049391||measurement||price||2015-12-01 20:38:14.444048@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:38:23.359805||measurement||price||2015-12-01 20:38:04.152253@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:38:24.606918||measurement||price||2015-12-01 20:38:06.673917@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 20:38:24.973572||measurement||price||2015-12-01 20:38:19.304556@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:38:27.641460||measurement||price||2015-12-01 20:38:08.472677@|Irwin Tools@|$11.07@|IRWIN Tools VISE-GRIP Locking Pliers, Fast Release, Curved J...||3||1
+2015-12-01 20:38:30.598980||measurement||loadtime||0:00:28.792467||4||1
+2015-12-01 20:38:31.719273||measurement||loadtime||0:00:26.670662||0||0
+2015-12-01 20:38:31.719408||event||progress-marker||measurement-end||0||0
+2015-12-01 20:38:32.412045||measurement||price||2015-12-01 20:38:14.444048@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:38:34.871612||measurement||loadtime||0:00:29.164453||3||1
+2015-12-01 20:38:35.505877||error||collecting ads||Error||1||1
+2015-12-01 20:38:37.329012||measurement||price||2015-12-01 20:38:19.304556@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:38:39.527673||measurement||loadtime||0:00:26.719299||5||0
+2015-12-01 20:38:44.219407||measurement||price||2015-12-01 20:38:37.904143@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:38:44.451161||measurement||loadtime||0:00:26.814106||2||0
+2015-12-01 20:38:44.451249||event||progress-marker||measurement-end||2||0
+2015-12-01 20:38:49.301112||measurement||price||2015-12-01 20:38:42.730637@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 20:38:51.853536||measurement||price||2015-12-01 20:38:46.229669@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:38:57.041583||measurement||price||2015-12-01 20:38:37.904143@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:38:58.831738||error||collecting ads||Error||3||1
+2015-12-01 20:39:02.104373||measurement||price||2015-12-01 20:38:42.730637@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 20:39:04.192155||measurement||price||2015-12-01 20:38:46.229669@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:39:04.276591||measurement||loadtime||0:00:28.672358||4||1
+2015-12-01 20:39:09.335791||measurement||loadtime||0:00:28.826565||1||1
+2015-12-01 20:39:11.300960||measurement||loadtime||0:00:26.768087||5||0
+2015-12-01 20:39:11.301080||event||progress-marker||measurement-end||5||0
+2015-12-01 20:39:12.338536||measurement||price||2015-12-01 20:39:06.123572@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:39:22.978101||measurement||price||2015-12-01 20:39:16.548243@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 20:39:25.170032||measurement||price||2015-12-01 20:39:06.123572@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:39:27.967379||error||collecting ads||Error||4||1
+2015-12-01 20:39:32.395247||measurement||loadtime||0:00:28.558261||3||1
+2015-12-01 20:39:35.733809||measurement||price||2015-12-01 20:39:16.548243@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 20:39:41.633815||measurement||price||2015-12-01 20:39:35.179114@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 20:39:42.950161||measurement||loadtime||0:00:28.610999||1||1
+2015-12-01 20:39:46.229798||measurement||price||2015-12-01 20:39:39.625686@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:39:54.454864||measurement||price||2015-12-01 20:39:35.179114@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 20:39:56.952851||measurement||price||2015-12-01 20:39:50.552904@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:39:59.013975||measurement||price||2015-12-01 20:39:39.625686@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:40:01.685193||measurement||loadtime||0:00:28.712572||4||1
+2015-12-01 20:40:06.221163||measurement||loadtime||0:00:28.820690||3||1
+2015-12-01 20:40:09.796660||measurement||price||2015-12-01 20:39:50.552904@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:40:16.998799||measurement||loadtime||0:00:29.044105||1||1
+2015-12-01 20:40:19.962789||measurement||price||2015-12-01 20:40:13.653255@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:40:25.496718||error||collecting ads||Error||4||1
+2015-12-01 20:40:30.954843||measurement||price||2015-12-01 20:40:24.180368@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:40:32.821745||measurement||price||2015-12-01 20:40:13.653255@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:40:39.210083||measurement||price||2015-12-01 20:40:32.846058@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 20:40:40.027572||measurement||loadtime||0:00:28.804419||3||1
+2015-12-01 20:40:43.860144||measurement||price||2015-12-01 20:40:24.180368@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:40:51.056794||measurement||loadtime||0:00:29.052735||1||1
+2015-12-01 20:40:52.205932||measurement||price||2015-12-01 20:40:32.846058@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 20:40:53.759736||measurement||price||2015-12-01 20:40:47.288311@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:40:59.403971||measurement||loadtime||0:00:28.902003||4||1
+2015-12-01 20:40:59.404104||event||progress-marker||measurement-end||4||1
+2015-12-01 20:41:04.957258||measurement||price||2015-12-01 20:40:58.267612@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:41:06.556366||measurement||price||2015-12-01 20:40:47.288311@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:41:13.771019||measurement||loadtime||0:00:28.738207||3||1
+2015-12-01 20:41:13.771185||event||progress-marker||measurement-end||3||1
+2015-12-01 20:41:18.035360||measurement||price||2015-12-01 20:40:58.267612@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:41:25.235874||measurement||loadtime||0:00:29.173841||1||1
+2015-12-01 20:41:25.236010||event||progress-marker||measurement-end||1||1
+2015-12-01 20:41:25.671467||meta||block_id end||2
+2015-12-01 20:41:25.671757||meta||block_id start||3
+2015-12-01 20:41:25.671786||meta||assignment||2@|4@|5@|0@|1@|3
+2015-12-01 20:41:27.230149||event||progress-marker||training-start||2||0
+2015-12-01 20:41:27.263206||event||progress-marker||training-start||5||0
+2015-12-01 20:41:33.688048||treatment||visit website||http://irs.gov||2||0
+2015-12-01 20:41:33.696116||treatment||visit website||http://irs.gov||5||0
+2015-12-01 20:41:41.308540||treatment||visit website||http://deloitte.com||5||0
+2015-12-01 20:41:41.309148||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 20:42:21.462926||error||website timeout||http://pwc.com||2||0
+2015-12-01 20:42:21.481872||error||website timeout||http://pwc.com||5||0
+2015-12-01 20:42:27.475193||treatment||visit website||http://ey.com||2||0
+2015-12-01 20:42:27.480520||treatment||visit website||http://ey.com||5||0
+2015-12-01 20:42:34.361281||treatment||visit website||http://kpmg.com||5||0
+2015-12-01 20:42:34.361399||event||progress-marker||training-end||5||0
+2015-12-01 20:42:34.542148||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 20:42:34.542288||event||progress-marker||training-end||2||0
+2015-12-01 20:42:39.373795||event||progress-marker||measurement-start||5||0
+2015-12-01 20:42:39.559449||event||progress-marker||measurement-start||2||0
+2015-12-01 20:43:02.438540||error||collecting ads||Error||5||0
+2015-12-01 20:43:02.549005||error||collecting ads||Error||2||0
+2015-12-01 20:43:14.934841||measurement||price||2015-12-01 20:43:09.157606@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:43:24.700145||error||collecting ads||Error||5||0
+2015-12-01 20:43:27.278485||measurement||price||2015-12-01 20:43:09.157606@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:43:34.366931||measurement||loadtime||0:00:26.813618||2||0
+2015-12-01 20:43:37.041405||measurement||price||2015-12-01 20:43:31.500591@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:43:49.377911||measurement||price||2015-12-01 20:43:31.500591@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:43:56.483141||measurement||loadtime||0:00:26.777812||5||0
+2015-12-01 20:43:56.716325||error||collecting ads||Error||2||0
+2015-12-01 20:43:57.451075||event||progress-marker||training-start||3||1
+2015-12-01 20:44:03.536862||event||progress-marker||training-start||1||1
+2015-12-01 20:44:04.331122||treatment||visit website||http://irs.gov||3||1
+2015-12-01 20:44:08.871224||measurement||price||2015-12-01 20:44:03.076057@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:44:09.090436||measurement||price||2015-12-01 20:44:03.545216@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:44:10.540308||treatment||visit website||http://irs.gov||1||1
+2015-12-01 20:44:11.294807||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 20:44:17.160903||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 20:44:20.048110||treatment||visit website||http://pwc.com||3||1
+2015-12-01 20:44:21.191798||measurement||price||2015-12-01 20:44:03.076057@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:44:21.417788||measurement||price||2015-12-01 20:44:03.545216@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:44:25.771136||treatment||visit website||http://pwc.com||1||1
+2015-12-01 20:44:25.938009||treatment||visit website||http://ey.com||3||1
+2015-12-01 20:44:28.304233||measurement||loadtime||0:00:26.817114||5||0
+2015-12-01 20:44:28.534074||measurement||loadtime||0:00:26.814918||2||0
+2015-12-01 20:44:31.622162||treatment||visit website||http://ey.com||1||1
+2015-12-01 20:44:33.140261||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 20:44:33.140352||event||progress-marker||training-end||3||1
+2015-12-01 20:44:38.974758||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 20:44:38.974871||event||progress-marker||training-end||1||1
+2015-12-01 20:44:40.666572||measurement||price||2015-12-01 20:44:35.021991@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:44:40.745800||measurement||price||2015-12-01 20:44:35.156006@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:44:43.161561||event||progress-marker||measurement-start||3||1
+2015-12-01 20:44:43.987308||event||progress-marker||measurement-start||1||1
+2015-12-01 20:44:52.992763||measurement||price||2015-12-01 20:44:35.021991@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:44:53.079245||measurement||price||2015-12-01 20:44:35.156006@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:44:57.356847||measurement||price||2015-12-01 20:44:51.038407@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:44:58.786126||measurement||price||2015-12-01 20:44:51.952739@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:45:00.095718||measurement||loadtime||0:00:26.788543||5||0
+2015-12-01 20:45:00.201869||measurement||loadtime||0:00:26.662590||2||0
+2015-12-01 20:45:10.119348||measurement||price||2015-12-01 20:44:51.038407@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:45:11.685626||measurement||price||2015-12-01 20:44:51.952739@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:45:12.437825||measurement||price||2015-12-01 20:45:06.787667@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:45:13.249791||measurement||price||2015-12-01 20:45:07.638954@|Irwin Tools@|$129.95@|Irwin Tools 1868997 Multiple Tool Set, 13-Piece||5||0
+2015-12-01 20:45:17.327108||measurement||loadtime||0:00:29.163892||3||1
+2015-12-01 20:45:18.933131||measurement||loadtime||0:00:29.940987||1||1
+2015-12-01 20:45:24.748833||measurement||price||2015-12-01 20:45:06.787667@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:45:25.581464||measurement||price||2015-12-01 20:45:07.638954@|Irwin Tools@|$11.07@|IRWIN Tools VISE-GRIP Locking Pliers, Fast Release, Curved J...||5||0
+2015-12-01 20:45:31.094518||measurement||price||2015-12-01 20:45:24.698763@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:45:31.858376||measurement||loadtime||0:00:26.655220||2||0
+2015-12-01 20:45:32.694006||measurement||loadtime||0:00:27.594847||5||0
+2015-12-01 20:45:42.927878||error||collecting ads||Error||1||1
+2015-12-01 20:45:44.016606||measurement||price||2015-12-01 20:45:24.698763@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:45:45.057174||measurement||price||2015-12-01 20:45:39.369993@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:45:51.228110||measurement||loadtime||0:00:28.895785||3||1
+2015-12-01 20:45:54.703719||error||collecting ads||Error||2||0
+2015-12-01 20:45:57.230303||measurement||price||2015-12-01 20:45:50.549772@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 20:45:57.394168||measurement||price||2015-12-01 20:45:39.369993@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:46:04.516941||measurement||loadtime||0:00:26.817796||5||0
+2015-12-01 20:46:06.927278||measurement||price||2015-12-01 20:46:01.358266@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:46:10.270804||measurement||price||2015-12-01 20:45:50.549772@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 20:46:14.935427||error||collecting ads||Error||3||1
+2015-12-01 20:46:16.781450||measurement||price||2015-12-01 20:46:11.225886@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:46:17.560664||measurement||loadtime||0:00:29.629516||1||1
+2015-12-01 20:46:19.266027||measurement||price||2015-12-01 20:46:01.358266@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:46:26.383170||measurement||loadtime||0:00:26.676041||2||0
+2015-12-01 20:46:28.626790||measurement||price||2015-12-01 20:46:22.041923@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:46:29.116962||measurement||price||2015-12-01 20:46:11.225886@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:46:31.427454||measurement||price||2015-12-01 20:46:24.907787@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:46:36.227152||measurement||loadtime||0:00:26.708023||5||0
+2015-12-01 20:46:38.618266||measurement||price||2015-12-01 20:46:32.990465@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:46:41.508697||measurement||price||2015-12-01 20:46:22.041923@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:46:44.286529||measurement||price||2015-12-01 20:46:24.907787@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:46:48.458630||measurement||price||2015-12-01 20:46:42.837883@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:46:48.743159||measurement||loadtime||0:00:28.802501||3||1
+2015-12-01 20:46:50.924882||measurement||price||2015-12-01 20:46:32.990465@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:46:51.487930||measurement||loadtime||0:00:28.923078||1||1
+2015-12-01 20:46:58.027162||measurement||loadtime||0:00:26.638794||2||0
+2015-12-01 20:47:00.792890||measurement||price||2015-12-01 20:46:42.837883@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:47:02.436030||measurement||price||2015-12-01 20:46:55.996094@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:47:07.905991||measurement||loadtime||0:00:26.673659||5||0
+2015-12-01 20:47:15.227020||measurement||price||2015-12-01 20:46:55.996094@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:47:15.506136||error||collecting ads||Error||1||1
+2015-12-01 20:47:20.219256||measurement||price||2015-12-01 20:47:14.591247@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:47:20.264560||error||collecting ads||Error||2||0
+2015-12-01 20:47:22.445438||measurement||loadtime||0:00:28.697083||3||1
+2015-12-01 20:47:29.487938||measurement||price||2015-12-01 20:47:22.697272@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:47:32.561742||measurement||price||2015-12-01 20:47:14.591247@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:47:32.884606||measurement||price||2015-12-01 20:47:27.171167@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||2||0
+2015-12-01 20:47:35.861932||measurement||price||2015-12-01 20:47:29.751784@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:47:39.673199||measurement||loadtime||0:00:26.762001||5||0
+2015-12-01 20:47:42.279264||measurement||price||2015-12-01 20:47:22.697272@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:47:45.223479||measurement||price||2015-12-01 20:47:27.171167@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 20:47:48.660886||measurement||price||2015-12-01 20:47:29.751784@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:47:49.490076||measurement||loadtime||0:00:28.978715||1||1
+2015-12-01 20:47:52.327152||measurement||loadtime||0:00:27.057786||2||0
+2015-12-01 20:47:55.873600||measurement||loadtime||0:00:28.422967||3||1
+2015-12-01 20:48:01.988602||error||collecting ads||Error||5||0
+2015-12-01 20:48:03.269811||measurement||price||2015-12-01 20:47:56.882750@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:48:04.634388||measurement||price||2015-12-01 20:47:59.008981@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 20:48:09.473350||measurement||price||2015-12-01 20:48:03.176988@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:48:14.156192||measurement||price||2015-12-01 20:48:08.735803@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:48:16.038265||measurement||price||2015-12-01 20:47:56.882750@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:48:16.951322||measurement||price||2015-12-01 20:47:59.008981@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 20:48:22.285803||measurement||price||2015-12-01 20:48:03.176988@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:48:23.232193||measurement||loadtime||0:00:28.736903||1||1
+2015-12-01 20:48:24.061959||measurement||loadtime||0:00:26.729604||2||0
+2015-12-01 20:48:26.478867||measurement||price||2015-12-01 20:48:08.735803@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:48:29.514178||measurement||loadtime||0:00:28.635392||3||1
+2015-12-01 20:48:33.584834||measurement||loadtime||0:00:26.590998||5||0
+2015-12-01 20:48:37.179378||measurement||price||2015-12-01 20:48:30.640389@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:48:42.995465||measurement||price||2015-12-01 20:48:36.635938@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:48:45.763580||measurement||price||2015-12-01 20:48:40.187612@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:48:46.268738||error||collecting ads||Error||2||0
+2015-12-01 20:48:50.056690||measurement||price||2015-12-01 20:48:30.640389@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:48:55.768441||measurement||price||2015-12-01 20:48:36.635938@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:48:57.232341||measurement||loadtime||0:00:28.997221||1||1
+2015-12-01 20:48:58.079088||measurement||price||2015-12-01 20:48:40.187612@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:49:02.979161||measurement||loadtime||0:00:28.459809||3||1
+2015-12-01 20:49:05.184091||measurement||loadtime||0:00:26.596773||5||0
+2015-12-01 20:49:08.615245||error||collecting ads||Error||2||0
+2015-12-01 20:49:11.227783||measurement||price||2015-12-01 20:49:04.587149@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:49:16.710737||measurement||price||2015-12-01 20:49:10.105055@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:49:17.442941||measurement||price||2015-12-01 20:49:11.795260@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:49:24.259784||measurement||price||2015-12-01 20:49:04.587149@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:49:29.464952||measurement||price||2015-12-01 20:49:10.105055@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:49:29.774185||measurement||price||2015-12-01 20:49:11.795260@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:49:31.050817||error||collecting ads||Error||2||0
+2015-12-01 20:49:31.464118||measurement||loadtime||0:00:29.228897||1||1
+2015-12-01 20:49:36.679160||measurement||loadtime||0:00:28.694808||3||1
+2015-12-01 20:49:36.887143||measurement||loadtime||0:00:26.697832||5||0
+2015-12-01 20:49:43.204141||measurement||price||2015-12-01 20:49:37.634314@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:49:45.562863||measurement||price||2015-12-01 20:49:38.753824@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:49:49.952977||measurement||price||2015-12-01 20:49:44.546004@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:49:50.386527||measurement||price||2015-12-01 20:49:43.818982@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:49:55.522173||measurement||price||2015-12-01 20:49:37.634314@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:49:58.475390||measurement||price||2015-12-01 20:49:38.753824@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:50:02.288306||measurement||price||2015-12-01 20:49:44.546004@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:50:02.632677||measurement||loadtime||0:00:26.580379||2||0
+2015-12-01 20:50:03.445322||measurement||price||2015-12-01 20:49:43.818982@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:50:05.663149||measurement||loadtime||0:00:29.193822||1||1
+2015-12-01 20:50:09.391152||measurement||loadtime||0:00:27.500020||5||0
+2015-12-01 20:50:10.639149||measurement||loadtime||0:00:28.954775||3||1
+2015-12-01 20:50:14.882597||measurement||price||2015-12-01 20:50:09.369895@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:50:19.848384||measurement||price||2015-12-01 20:50:13.560685@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||1||1
+2015-12-01 20:50:21.933845||measurement||price||2015-12-01 20:50:16.339086@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||5||0
+2015-12-01 20:50:24.297233||measurement||price||2015-12-01 20:50:17.829689@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:50:27.159455||measurement||price||2015-12-01 20:50:09.369895@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:50:32.652275||measurement||price||2015-12-01 20:50:13.560685@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||1||1
+2015-12-01 20:50:34.239810||measurement||loadtime||0:00:26.601933||2||0
+2015-12-01 20:50:34.280287||measurement||price||2015-12-01 20:50:16.339086@|Electronic Arts@| $59.00   @|Star Wars: Battlefront - Standard Edition - Xbox One||5||0
+2015-12-01 20:50:37.257149||measurement||price||2015-12-01 20:50:17.829689@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:50:39.829061||measurement||loadtime||0:00:29.160699||1||1
+2015-12-01 20:50:41.391197||measurement||loadtime||0:00:26.994784||5||0
+2015-12-01 20:50:44.471736||measurement||loadtime||0:00:28.828576||3||1
+2015-12-01 20:50:46.291239||measurement||price||2015-12-01 20:50:40.778257@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:50:53.700077||measurement||price||2015-12-01 20:50:48.063755@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:50:53.730107||measurement||price||2015-12-01 20:50:47.361333@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 20:50:57.898453||measurement||price||2015-12-01 20:50:51.596167@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:50:58.612152||measurement||price||2015-12-01 20:50:40.778257@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:51:05.718259||measurement||loadtime||0:00:26.473252||2||0
+2015-12-01 20:51:06.044301||measurement||price||2015-12-01 20:50:48.063755@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:51:06.882078||measurement||price||2015-12-01 20:50:47.361333@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 20:51:10.614510||measurement||price||2015-12-01 20:50:51.596167@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:51:13.147141||measurement||loadtime||0:00:26.752010||5||0
+2015-12-01 20:51:14.098063||measurement||loadtime||0:00:29.263803||1||1
+2015-12-01 20:51:17.808637||measurement||loadtime||0:00:28.331638||3||1
+2015-12-01 20:51:17.907478||measurement||price||2015-12-01 20:51:12.369220@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 20:51:25.403959||measurement||price||2015-12-01 20:51:19.711737@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 20:51:30.211097||measurement||price||2015-12-01 20:51:12.369220@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 20:51:31.475515||measurement||price||2015-12-01 20:51:25.275857@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:51:37.323138||measurement||loadtime||0:00:26.600003||2||0
+2015-12-01 20:51:37.737207||measurement||price||2015-12-01 20:51:19.711737@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 20:51:38.153794||error||collecting ads||Error||1||1
+2015-12-01 20:51:44.269977||measurement||price||2015-12-01 20:51:25.275857@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:51:44.846590||measurement||loadtime||0:00:26.694251||5||0
+2015-12-01 20:51:49.546462||measurement||price||2015-12-01 20:51:44.014619@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 20:51:51.491175||measurement||loadtime||0:00:28.677327||3||1
+2015-12-01 20:51:52.933064||measurement||price||2015-12-01 20:51:46.689076@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:51:57.785081||measurement||price||2015-12-01 20:51:52.223177@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 20:52:01.867648||measurement||price||2015-12-01 20:51:44.014619@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 20:52:05.048189||measurement||price||2015-12-01 20:51:58.658491@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:52:06.240176||measurement||price||2015-12-01 20:51:46.689076@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:52:08.975433||measurement||loadtime||0:00:26.647066||2||0
+2015-12-01 20:52:08.975542||event||progress-marker||measurement-end||2||0
+2015-12-01 20:52:10.078383||measurement||price||2015-12-01 20:51:52.223177@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 20:52:13.467326||measurement||loadtime||0:00:30.312189||1||1
+2015-12-01 20:52:17.159153||measurement||loadtime||0:00:27.307363||5||0
+2015-12-01 20:52:18.081131||measurement||price||2015-12-01 20:51:58.658491@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:52:25.295192||measurement||loadtime||0:00:28.798796||3||1
+2015-12-01 20:52:27.382896||measurement||price||2015-12-01 20:52:20.739110@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:52:29.241765||measurement||price||2015-12-01 20:52:23.707425@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 20:52:38.933404||measurement||price||2015-12-01 20:52:32.469396@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:52:40.325083||measurement||price||2015-12-01 20:52:20.739110@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:52:41.513881||measurement||price||2015-12-01 20:52:23.707425@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 20:52:47.576371||measurement||loadtime||0:00:29.103853||1||1
+2015-12-01 20:52:48.594346||measurement||loadtime||0:00:26.429982||5||0
+2015-12-01 20:52:48.594448||event||progress-marker||measurement-end||5||0
+2015-12-01 20:52:51.787287||measurement||price||2015-12-01 20:52:32.469396@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:52:58.979144||measurement||loadtime||0:00:28.678766||3||1
+2015-12-01 20:53:11.204572||error||collecting ads||Error||1||1
+2015-12-01 20:53:12.478735||measurement||price||2015-12-01 20:53:06.074473@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:53:24.819646||measurement||price||2015-12-01 20:53:18.410976@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:53:25.331575||measurement||price||2015-12-01 20:53:06.074473@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:53:32.545628||measurement||loadtime||0:00:28.561266||3||1
+2015-12-01 20:53:37.604303||measurement||price||2015-12-01 20:53:18.410976@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:53:44.800308||measurement||loadtime||0:00:28.590536||1||1
+2015-12-01 20:53:46.063949||measurement||price||2015-12-01 20:53:39.850224@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:53:58.836323||measurement||price||2015-12-01 20:53:39.850224@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:53:58.910858||measurement||price||2015-12-01 20:53:52.950892@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 20:54:06.050438||measurement||loadtime||0:00:28.503297||3||1
+2015-12-01 20:54:11.917174||measurement||price||2015-12-01 20:53:52.950892@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 20:54:19.126781||measurement||loadtime||0:00:29.324096||1||1
+2015-12-01 20:54:19.600032||measurement||price||2015-12-01 20:54:13.220591@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 20:54:32.422863||measurement||price||2015-12-01 20:54:13.220591@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 20:54:32.716294||measurement||price||2015-12-01 20:54:26.263562@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 20:54:39.619865||measurement||loadtime||0:00:28.564189||3||1
+2015-12-01 20:54:45.705427||measurement||price||2015-12-01 20:54:26.263562@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 20:54:52.898181||measurement||loadtime||0:00:28.766134||1||1
+2015-12-01 20:54:53.188163||measurement||price||2015-12-01 20:54:46.733411@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 20:55:05.925735||measurement||price||2015-12-01 20:54:46.733411@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 20:55:13.121155||measurement||loadtime||0:00:28.498503||3||1
+2015-12-01 20:55:16.809565||error||collecting ads||Error||1||1
+2015-12-01 20:55:16.809704||event||progress-marker||measurement-end||1||1
+2015-12-01 20:55:26.599729||measurement||price||2015-12-01 20:55:20.226088@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 20:55:39.367845||measurement||price||2015-12-01 20:55:20.226088@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 20:55:46.563001||measurement||loadtime||0:00:28.439882||3||1
+2015-12-01 20:55:46.563117||event||progress-marker||measurement-end||3||1
+2015-12-01 21:14:45.676654||error||block timeout||Error||1||0
+2015-12-01 21:14:45.714797||meta||block_id end||3
+2015-12-01 21:14:45.715111||meta||block_id start||4
+2015-12-01 21:14:45.715130||meta||assignment||3@|2@|0@|1@|4@|5
+2015-12-01 21:14:47.341867||event||progress-marker||training-start||3||0
+2015-12-01 21:14:47.371047||event||progress-marker||training-start||0||0
+2015-12-01 21:14:47.380540||event||progress-marker||training-start||2||0
+2015-12-01 21:14:53.979114||treatment||visit website||http://irs.gov||2||0
+2015-12-01 21:14:54.011115||treatment||visit website||http://irs.gov||3||0
+2015-12-01 21:14:54.731092||treatment||visit website||http://irs.gov||0||0
+2015-12-01 21:15:06.068769||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 21:15:06.069733||treatment||visit website||http://deloitte.com||3||0
+2015-12-01 21:15:06.071115||treatment||visit website||http://deloitte.com||0||0
+2015-12-01 21:15:14.202409||treatment||visit website||http://pwc.com||2||0
+2015-12-01 21:15:14.501902||treatment||visit website||http://pwc.com||0||0
+2015-12-01 21:15:14.519099||treatment||visit website||http://pwc.com||3||0
+2015-12-01 21:15:20.252257||treatment||visit website||http://ey.com||2||0
+2015-12-01 21:15:20.349900||treatment||visit website||http://ey.com||3||0
+2015-12-01 21:15:20.379106||treatment||visit website||http://ey.com||0||0
+2015-12-01 21:15:27.619132||treatment||visit website||http://kpmg.com||0||0
+2015-12-01 21:15:27.619282||event||progress-marker||training-end||0||0
+2015-12-01 21:15:27.671101||treatment||visit website||http://kpmg.com||3||0
+2015-12-01 21:15:27.671202||event||progress-marker||training-end||3||0
+2015-12-01 21:15:28.818028||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 21:15:28.818160||event||progress-marker||training-end||2||0
+2015-12-01 21:15:32.638413||event||progress-marker||measurement-start||0||0
+2015-12-01 21:15:32.690299||event||progress-marker||measurement-start||3||0
+2015-12-01 21:15:33.837901||event||progress-marker||measurement-start||2||0
+2015-12-01 21:15:46.308827||measurement||price||2015-12-01 21:15:41.000799@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:15:55.928831||error||collecting ads||Error||0||0
+2015-12-01 21:15:57.443244||error||collecting ads||Error||2||0
+2015-12-01 21:15:58.642516||measurement||price||2015-12-01 21:15:41.000799@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:15:59.021426||event||progress-marker||training-start||4||1
+2015-12-01 21:16:05.755152||measurement||loadtime||0:00:28.060009||3||0
+2015-12-01 21:16:11.693303||treatment||visit website||http://irs.gov||4||1
+2015-12-01 21:16:12.291225||measurement||price||2015-12-01 21:16:06.465107@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:16:19.304142||event||progress-marker||training-start||5||1
+2015-12-01 21:16:20.913472||measurement||price||2015-12-01 21:16:15.343109@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:16:21.439198||error||collecting ads||Error||0||0
+2015-12-01 21:16:23.659110||treatment||visit website||http://deloitte.com||4||1
+2015-12-01 21:16:24.614842||measurement||price||2015-12-01 21:16:06.465107@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:16:25.743104||treatment||visit website||http://irs.gov||5||1
+2015-12-01 21:16:29.517894||event||progress-marker||training-start||1||1
+2015-12-01 21:16:31.723116||measurement||loadtime||0:00:29.274658||2||0
+2015-12-01 21:16:32.435970||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 21:16:33.224413||measurement||price||2015-12-01 21:16:15.343109@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:16:33.251107||treatment||visit website||http://pwc.com||4||1
+2015-12-01 21:16:34.035580||measurement||price||2015-12-01 21:16:28.504789@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:16:35.954629||treatment||visit website||http://irs.gov||1||1
+2015-12-01 21:16:39.265296||treatment||visit website||http://ey.com||4||1
+2015-12-01 21:16:40.343587||measurement||loadtime||0:00:29.583235||3||0
+2015-12-01 21:16:41.255114||treatment||visit website||http://pwc.com||5||1
+2015-12-01 21:16:42.790125||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 21:16:44.013157||measurement||price||2015-12-01 21:16:38.411993@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:16:46.325553||measurement||price||2015-12-01 21:16:28.504789@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:16:47.139107||treatment||visit website||http://kpmg.com||4||1
+2015-12-01 21:16:47.139220||event||progress-marker||training-end||4||1
+2015-12-01 21:16:47.251107||treatment||visit website||http://ey.com||5||1
+2015-12-01 21:16:51.655139||treatment||visit website||http://pwc.com||1||1
+2015-12-01 21:16:53.443980||measurement||loadtime||0:00:27.000846||0||0
+2015-12-01 21:16:53.475172||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 21:16:53.475245||event||progress-marker||training-end||5||1
+2015-12-01 21:16:56.322716||measurement||price||2015-12-01 21:16:38.411993@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:16:57.631110||treatment||visit website||http://ey.com||1||1
+2015-12-01 21:17:02.595818||error||collecting ads||Error||3||0
+2015-12-01 21:17:03.430367||measurement||loadtime||0:00:26.702038||2||0
+2015-12-01 21:17:04.116039||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 21:17:04.116181||event||progress-marker||training-end||1||1
+2015-12-01 21:17:05.844145||measurement||price||2015-12-01 21:17:00.470479@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:17:07.184409||event||progress-marker||measurement-start||4||1
+2015-12-01 21:17:08.503745||event||progress-marker||measurement-start||5||1
+2015-12-01 21:17:09.131608||event||progress-marker||measurement-start||1||1
+2015-12-01 21:17:14.850506||measurement||price||2015-12-01 21:17:09.231832@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:17:15.798798||measurement||price||2015-12-01 21:17:10.212700@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:17:18.174725||measurement||price||2015-12-01 21:17:00.470479@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:17:21.598185||measurement||price||2015-12-01 21:17:15.207751@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 21:17:23.305082||measurement||price||2015-12-01 21:17:16.449981@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:17:24.435688||measurement||price||2015-12-01 21:17:18.146938@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:17:25.287161||measurement||loadtime||0:00:26.840015||0||0
+2015-12-01 21:17:27.166857||measurement||price||2015-12-01 21:17:09.231832@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:17:28.129444||measurement||price||2015-12-01 21:17:10.212700@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:17:34.273151||measurement||loadtime||0:00:26.672151||3||0
+2015-12-01 21:17:34.395341||measurement||price||2015-12-01 21:17:15.207751@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 21:17:35.235347||measurement||loadtime||0:00:26.800213||2||0
+2015-12-01 21:17:36.204852||measurement||price||2015-12-01 21:17:16.449981@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:17:37.335675||measurement||price||2015-12-01 21:17:18.146938@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:17:37.768747||measurement||price||2015-12-01 21:17:32.345606@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:17:41.623162||measurement||loadtime||0:00:29.433539||4||1
+2015-12-01 21:17:43.404927||measurement||loadtime||0:00:29.899118||5||1
+2015-12-01 21:17:44.570675||measurement||loadtime||0:00:30.433891||1||1
+2015-12-01 21:17:46.515818||measurement||price||2015-12-01 21:17:40.950403@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:17:47.556414||measurement||price||2015-12-01 21:17:41.977815@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:17:50.108332||measurement||price||2015-12-01 21:17:32.345606@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:17:55.410044||measurement||price||2015-12-01 21:17:49.195816@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 21:17:57.226461||measurement||loadtime||0:00:26.935348||0||0
+2015-12-01 21:17:57.445821||measurement||price||2015-12-01 21:17:48.443822@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:17:58.820894||measurement||price||2015-12-01 21:17:40.950403@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:17:59.094127||measurement||price||2015-12-01 21:17:52.979596@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:17:59.869994||measurement||price||2015-12-01 21:17:41.977815@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:18:05.922795||measurement||loadtime||0:00:26.644477||3||0
+2015-12-01 21:18:06.975105||measurement||loadtime||0:00:26.735956||2||0
+2015-12-01 21:18:08.272876||measurement||price||2015-12-01 21:17:49.195816@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 21:18:10.036312||measurement||price||2015-12-01 21:18:04.603821@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:18:10.415087||measurement||price||2015-12-01 21:17:48.443822@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:18:12.338156||measurement||price||2015-12-01 21:17:52.979596@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:18:15.467334||measurement||loadtime||0:00:28.838978||4||1
+2015-12-01 21:18:17.610762||measurement||loadtime||0:00:29.204558||5||1
+2015-12-01 21:18:18.260536||measurement||price||2015-12-01 21:18:12.676623@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:18:19.357646||measurement||price||2015-12-01 21:18:13.750068@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:18:19.587203||measurement||loadtime||0:00:30.011343||1||1
+2015-12-01 21:18:22.349286||measurement||price||2015-12-01 21:18:04.603821@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:18:29.313698||measurement||price||2015-12-01 21:18:23.168025@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 21:18:29.471151||measurement||loadtime||0:00:27.239524||0||0
+2015-12-01 21:18:30.595588||measurement||price||2015-12-01 21:18:12.676623@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:18:31.609964||measurement||price||2015-12-01 21:18:25.120427@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:18:31.679226||measurement||price||2015-12-01 21:18:13.750068@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:18:33.985612||measurement||price||2015-12-01 21:18:27.654898@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:18:37.704071||measurement||loadtime||0:00:26.780993||3||0
+2015-12-01 21:18:38.785086||measurement||loadtime||0:00:26.805956||2||0
+2015-12-01 21:18:41.894961||measurement||price||2015-12-01 21:18:36.472269@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:18:42.216361||measurement||price||2015-12-01 21:18:23.168025@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 21:18:44.614610||measurement||price||2015-12-01 21:18:25.120427@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:18:46.952694||measurement||price||2015-12-01 21:18:27.654898@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:18:49.415194||measurement||loadtime||0:00:28.942653||4||1
+2015-12-01 21:18:51.282126||measurement||price||2015-12-01 21:18:45.675376@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:18:51.827164||measurement||loadtime||0:00:29.211607||5||1
+2015-12-01 21:18:54.202292||measurement||price||2015-12-01 21:18:36.472269@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:18:54.211122||measurement||loadtime||0:00:29.619970||1||1
+2015-12-01 21:19:00.096359||error||collecting ads||Error||3||0
+2015-12-01 21:19:01.287147||measurement||loadtime||0:00:26.810829||0||0
+2015-12-01 21:19:03.615774||measurement||price||2015-12-01 21:18:45.675376@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:19:08.010788||measurement||price||2015-12-01 21:19:02.031974@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:19:10.699149||measurement||loadtime||0:00:26.908889||2||0
+2015-12-01 21:19:12.425735||measurement||price||2015-12-01 21:19:06.837399@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:19:13.003883||error||collecting ads||Error||4||1
+2015-12-01 21:19:16.104853||error||collecting ads||Error||5||1
+2015-12-01 21:19:20.846262||measurement||price||2015-12-01 21:19:02.031974@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:19:23.028658||measurement||price||2015-12-01 21:19:17.374822@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:19:23.855331||error||collecting ads||Error||0||0
+2015-12-01 21:19:24.755940||measurement||price||2015-12-01 21:19:06.837399@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:19:26.797367||measurement||price||2015-12-01 21:19:20.646120@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 21:19:28.080677||measurement||loadtime||0:00:28.865489||1||1
+2015-12-01 21:19:30.131657||measurement||price||2015-12-01 21:19:23.518074@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:19:31.858810||measurement||loadtime||0:00:26.757279||3||0
+2015-12-01 21:19:35.385701||measurement||price||2015-12-01 21:19:17.374822@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:19:36.397003||measurement||price||2015-12-01 21:19:31.059228@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:19:39.769263||measurement||price||2015-12-01 21:19:20.646120@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 21:19:41.906816||measurement||price||2015-12-01 21:19:35.735938@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:19:42.491424||measurement||loadtime||0:00:26.788263||2||0
+2015-12-01 21:19:43.060326||measurement||price||2015-12-01 21:19:23.518074@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:19:44.148478||measurement||price||2015-12-01 21:19:38.643946@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:19:47.000675||measurement||loadtime||0:00:28.993550||4||1
+2015-12-01 21:19:48.723857||measurement||price||2015-12-01 21:19:31.059228@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:19:50.245247||measurement||loadtime||0:00:29.138093||5||1
+2015-12-01 21:19:54.904703||measurement||price||2015-12-01 21:19:35.735938@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:19:55.827238||measurement||loadtime||0:00:26.970760||0||0
+2015-12-01 21:19:56.463814||measurement||price||2015-12-01 21:19:38.643946@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:20:02.138822||measurement||loadtime||0:00:29.052915||1||1
+2015-12-01 21:20:03.571151||measurement||loadtime||0:00:26.707964||3||0
+2015-12-01 21:20:04.069011||measurement||price||2015-12-01 21:19:57.641751@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:20:04.752963||error||collecting ads||Error||2||0
+2015-12-01 21:20:08.383675||measurement||price||2015-12-01 21:20:02.963897@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:20:10.681265||error||collecting ads||Error||4||1
+2015-12-01 21:20:15.987349||measurement||price||2015-12-01 21:20:09.745989@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:20:16.340051||measurement||price||2015-12-01 21:20:10.547889@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:20:16.925039||measurement||price||2015-12-01 21:19:57.641751@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:20:17.308958||measurement||price||2015-12-01 21:20:11.588800@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:20:20.680366||measurement||price||2015-12-01 21:20:02.963897@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:20:24.126511||measurement||loadtime||0:00:28.876069||5||1
+2015-12-01 21:20:27.779135||measurement||loadtime||0:00:26.946708||0||0
+2015-12-01 21:20:28.657677||measurement||price||2015-12-01 21:20:10.547889@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:20:28.851163||measurement||price||2015-12-01 21:20:09.745989@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:20:29.616152||measurement||price||2015-12-01 21:20:11.588800@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:20:34.281532||error||collecting ads||Error||4||1
+2015-12-01 21:20:35.774968||measurement||loadtime||0:00:27.199770||3||0
+2015-12-01 21:20:36.083308||measurement||loadtime||0:00:28.939261||1||1
+2015-12-01 21:20:36.723170||measurement||loadtime||0:00:26.969821||2||0
+2015-12-01 21:20:38.274638||measurement||price||2015-12-01 21:20:31.521283@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:20:40.246220||measurement||price||2015-12-01 21:20:34.844602@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:20:48.108652||measurement||price||2015-12-01 21:20:41.938344@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 21:20:48.280160||measurement||price||2015-12-01 21:20:42.464001@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:20:49.636766||measurement||price||2015-12-01 21:20:44.087783@|Makita@|$549.00@|Makita XT601 18-volt LXT Lithium-Ion Cordless Combo Kit, 6-P...||2||0
+2015-12-01 21:20:51.271863||measurement||price||2015-12-01 21:20:31.521283@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:20:52.580721||measurement||price||2015-12-01 21:20:34.844602@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:20:58.449623||measurement||loadtime||0:00:29.317856||5||1
+2015-12-01 21:20:59.688646||measurement||loadtime||0:00:26.904339||0||0
+2015-12-01 21:21:00.186595||error||collecting ads||Error||1||1
+2015-12-01 21:21:00.603978||measurement||price||2015-12-01 21:20:42.464001@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:21:01.009636||measurement||price||2015-12-01 21:20:41.938344@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 21:21:01.954203||measurement||price||2015-12-01 21:20:44.087783@|Makita@|$469.00@|Makita BBX7600N 75.6 CC 4-Stroke Backpack Blower||2||0
+2015-12-01 21:21:07.708266||measurement||loadtime||0:00:26.928067||3||0
+2015-12-01 21:21:08.224487||measurement||loadtime||0:00:28.937760||4||1
+2015-12-01 21:21:09.062987||measurement||loadtime||0:00:27.335839||2||0
+2015-12-01 21:21:12.345926||measurement||price||2015-12-01 21:21:05.865925@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 21:21:13.949285||measurement||price||2015-12-01 21:21:07.871807@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:21:19.997478||measurement||price||2015-12-01 21:21:14.366486@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:21:21.450943||measurement||price||2015-12-01 21:21:15.862778@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:21:22.135787||error||collecting ads||Error||0||0
+2015-12-01 21:21:22.195515||measurement||price||2015-12-01 21:21:16.038839@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 21:21:25.279015||measurement||price||2015-12-01 21:21:05.865925@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 21:21:26.808981||measurement||price||2015-12-01 21:21:07.871807@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:21:32.308302||measurement||price||2015-12-01 21:21:14.366486@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:21:32.480113||measurement||loadtime||0:00:29.028986||5||1
+2015-12-01 21:21:33.783937||measurement||price||2015-12-01 21:21:15.862778@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:21:34.039433||measurement||loadtime||0:00:28.849666||1||1
+2015-12-01 21:21:34.528339||measurement||price||2015-12-01 21:21:29.168130@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:21:35.042111||measurement||price||2015-12-01 21:21:16.038839@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 21:21:39.381856||measurement||loadtime||0:00:26.668325||3||0
+2015-12-01 21:21:40.886655||measurement||loadtime||0:00:26.819528||2||0
+2015-12-01 21:21:42.259162||measurement||loadtime||0:00:29.029451||4||1
+2015-12-01 21:21:46.851916||measurement||price||2015-12-01 21:21:29.168130@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:21:47.771856||measurement||price||2015-12-01 21:21:41.692726@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:21:51.634566||measurement||price||2015-12-01 21:21:45.975399@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:21:53.220955||measurement||price||2015-12-01 21:21:47.619333@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:21:53.970143||measurement||loadtime||0:00:26.830995||0||0
+2015-12-01 21:21:56.229777||measurement||price||2015-12-01 21:21:50.110955@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||4||1
+2015-12-01 21:21:56.280114||error||collecting ads||Error||5||1
+2015-12-01 21:22:00.558501||measurement||price||2015-12-01 21:21:41.692726@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:22:03.970734||measurement||price||2015-12-01 21:21:45.975399@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:22:05.550621||measurement||price||2015-12-01 21:21:47.619333@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:22:06.517206||measurement||price||2015-12-01 21:22:01.120425@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:22:07.796147||measurement||loadtime||0:00:28.755535||1||1
+2015-12-01 21:22:09.069398||measurement||price||2015-12-01 21:21:50.110955@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||4||1
+2015-12-01 21:22:11.092600||measurement||loadtime||0:00:26.705560||3||0
+2015-12-01 21:22:12.661386||measurement||loadtime||0:00:26.770258||2||0
+2015-12-01 21:22:16.279156||measurement||loadtime||0:00:29.016016||4||1
+2015-12-01 21:22:18.842871||measurement||price||2015-12-01 21:22:01.120425@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:22:20.112487||error||collecting ads||Error||5||1
+2015-12-01 21:22:21.566208||measurement||price||2015-12-01 21:22:15.450683@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:22:23.220361||measurement||price||2015-12-01 21:22:17.665553@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:22:25.952879||measurement||loadtime||0:00:26.977525||0||0
+2015-12-01 21:22:34.096963||measurement||price||2015-12-01 21:22:27.410425@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:22:34.412843||measurement||price||2015-12-01 21:22:15.450683@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:22:34.944881||error||collecting ads||Error||2||0
+2015-12-01 21:22:35.538724||measurement||price||2015-12-01 21:22:17.665553@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:22:38.718257||measurement||price||2015-12-01 21:22:33.308971@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-01 21:22:39.823484||error||collecting ads||Error||4||1
+2015-12-01 21:22:41.615150||measurement||loadtime||0:00:28.813844||1||1
+2015-12-01 21:22:42.651142||measurement||loadtime||0:00:26.556014||3||0
+2015-12-01 21:22:47.031163||measurement||price||2015-12-01 21:22:27.410425@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:22:47.307273||measurement||price||2015-12-01 21:22:41.624045@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:22:51.049825||measurement||price||2015-12-01 21:22:33.308971@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-01 21:22:53.706820||measurement||price||2015-12-01 21:22:47.426799@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 21:22:54.222757||measurement||loadtime||0:00:29.105061||5||1
+2015-12-01 21:22:54.953415||measurement||price||2015-12-01 21:22:49.380212@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:22:55.306345||measurement||price||2015-12-01 21:22:49.269818@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:22:58.156808||measurement||loadtime||0:00:27.201675||0||0
+2015-12-01 21:22:59.644762||measurement||price||2015-12-01 21:22:41.624045@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:23:06.543077||measurement||price||2015-12-01 21:22:47.426799@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 21:23:06.759145||measurement||loadtime||0:00:26.812028||2||0
+2015-12-01 21:23:07.256188||measurement||price||2015-12-01 21:22:49.380212@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:23:08.225503||measurement||price||2015-12-01 21:22:49.269818@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:23:10.537947||measurement||price||2015-12-01 21:23:05.175337@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:23:13.777177||measurement||loadtime||0:00:28.948494||4||1
+2015-12-01 21:23:14.367580||measurement||loadtime||0:00:26.712443||3||0
+2015-12-01 21:23:15.422540||measurement||loadtime||0:00:28.803411||1||1
+2015-12-01 21:23:17.764805||error||collecting ads||Error||5||1
+2015-12-01 21:23:18.966330||measurement||price||2015-12-01 21:23:13.428776@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:23:22.863603||measurement||price||2015-12-01 21:23:05.175337@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:23:26.652753||measurement||price||2015-12-01 21:23:21.048375@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:23:27.521431||measurement||price||2015-12-01 21:23:21.450759@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 21:23:29.175964||measurement||price||2015-12-01 21:23:23.138628@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:23:29.980401||measurement||loadtime||0:00:26.822803||0||0
+2015-12-01 21:23:31.269389||measurement||price||2015-12-01 21:23:13.428776@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:23:38.375892||measurement||loadtime||0:00:26.611572||2||0
+2015-12-01 21:23:38.996099||measurement||price||2015-12-01 21:23:21.048375@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:23:40.334544||measurement||price||2015-12-01 21:23:21.450759@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 21:23:41.643963||error||collecting ads||Error||5||1
+2015-12-01 21:23:42.077734||measurement||price||2015-12-01 21:23:23.138628@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:23:46.099167||measurement||loadtime||0:00:26.726389||3||0
+2015-12-01 21:23:47.551513||measurement||loadtime||0:00:28.769139||4||1
+2015-12-01 21:23:49.287111||measurement||loadtime||0:00:28.859935||1||1
+2015-12-01 21:23:50.653745||measurement||price||2015-12-01 21:23:45.020322@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:23:52.457407||error||collecting ads||Error||0||0
+2015-12-01 21:23:55.563910||measurement||price||2015-12-01 21:23:48.847060@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:24:02.992822||measurement||price||2015-12-01 21:23:45.020322@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:24:03.066916||measurement||price||2015-12-01 21:23:56.857691@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:24:04.877996||measurement||price||2015-12-01 21:23:59.524257@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:24:08.368191||error||collecting ads||Error||3||0
+2015-12-01 21:24:08.469891||measurement||price||2015-12-01 21:23:48.847060@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:24:10.104078||measurement||loadtime||0:00:26.724923||2||0
+2015-12-01 21:24:11.189672||error||collecting ads||Error||4||1
+2015-12-01 21:24:15.647972||measurement||loadtime||0:00:28.999350||5||1
+2015-12-01 21:24:15.950548||measurement||price||2015-12-01 21:23:56.857691@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:24:17.202958||measurement||price||2015-12-01 21:23:59.524257@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:24:20.553861||measurement||price||2015-12-01 21:24:14.944416@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:24:22.379638||measurement||price||2015-12-01 21:24:16.792742@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:24:23.164587||measurement||loadtime||0:00:28.873437||1||1
+2015-12-01 21:24:24.317008||measurement||loadtime||0:00:26.855180||0||0
+2015-12-01 21:24:24.790556||measurement||price||2015-12-01 21:24:18.724656@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 21:24:29.592719||measurement||price||2015-12-01 21:24:23.016756@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:24:32.880735||measurement||price||2015-12-01 21:24:14.944416@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:24:34.752778||measurement||price||2015-12-01 21:24:16.792742@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:24:36.749742||measurement||price||2015-12-01 21:24:31.398401@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:24:36.760004||measurement||price||2015-12-01 21:24:30.759144@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:24:37.674906||measurement||price||2015-12-01 21:24:18.724656@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 21:24:40.007134||measurement||loadtime||0:00:26.636013||3||0
+2015-12-01 21:24:41.867126||measurement||loadtime||0:00:26.760006||2||0
+2015-12-01 21:24:42.439824||measurement||price||2015-12-01 21:24:23.016756@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:24:44.891157||measurement||loadtime||0:00:28.700014||4||1
+2015-12-01 21:24:49.055303||measurement||price||2015-12-01 21:24:31.398401@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:24:49.639149||measurement||loadtime||0:00:28.988027||5||1
+2015-12-01 21:24:49.656819||measurement||price||2015-12-01 21:24:30.759144@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:24:52.226288||measurement||price||2015-12-01 21:24:46.647428@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:24:54.116078||measurement||price||2015-12-01 21:24:48.507204@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:24:56.162504||measurement||loadtime||0:00:26.843373||0||0
+2015-12-01 21:24:56.883141||measurement||loadtime||0:00:28.713333||1||1
+2015-12-01 21:25:04.555818||measurement||price||2015-12-01 21:24:46.647428@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:25:06.445994||measurement||price||2015-12-01 21:24:48.507204@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:25:08.604217||error||collecting ads||Error||4||1
+2015-12-01 21:25:09.102839||measurement||price||2015-12-01 21:25:03.652976@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:25:11.673208||measurement||loadtime||0:00:26.662061||3||0
+2015-12-01 21:25:13.556178||measurement||loadtime||0:00:26.685056||2||0
+2015-12-01 21:25:13.703899||error||collecting ads||Error||5||1
+2015-12-01 21:25:20.701381||error||collecting ads||Error||1||1
+2015-12-01 21:25:21.424598||measurement||price||2015-12-01 21:25:03.652976@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:25:22.322899||measurement||price||2015-12-01 21:25:16.139961@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 21:25:23.965287||measurement||price||2015-12-01 21:25:18.376144@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:25:25.846379||measurement||price||2015-12-01 21:25:20.249475@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:25:27.945226||measurement||price||2015-12-01 21:25:21.205336@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:25:28.535164||measurement||loadtime||0:00:27.368011||0||0
+2015-12-01 21:25:28.535270||event||progress-marker||measurement-end||0||0
+2015-12-01 21:25:34.241347||measurement||price||2015-12-01 21:25:28.206134@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:25:35.088660||measurement||price||2015-12-01 21:25:16.139961@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 21:25:36.314482||measurement||price||2015-12-01 21:25:18.376144@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:25:38.180340||measurement||price||2015-12-01 21:25:20.249475@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:25:40.801386||measurement||price||2015-12-01 21:25:21.205336@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:25:42.286209||measurement||loadtime||0:00:28.679083||4||1
+2015-12-01 21:25:43.421668||measurement||loadtime||0:00:26.743227||3||0
+2015-12-01 21:25:43.421792||event||progress-marker||measurement-end||3||0
+2015-12-01 21:25:45.293038||measurement||loadtime||0:00:26.733858||2||0
+2015-12-01 21:25:45.293135||event||progress-marker||measurement-end||2||0
+2015-12-01 21:25:47.033189||measurement||price||2015-12-01 21:25:28.206134@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:25:48.011169||measurement||loadtime||0:00:29.304029||5||1
+2015-12-01 21:25:54.250892||measurement||loadtime||0:00:28.544245||1||1
+2015-12-01 21:25:55.659859||measurement||price||2015-12-01 21:25:49.694536@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 21:26:02.048397||measurement||price||2015-12-01 21:25:55.443450@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:26:08.431585||measurement||price||2015-12-01 21:25:49.694536@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 21:26:14.866130||measurement||price||2015-12-01 21:25:55.443450@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:26:15.628714||measurement||loadtime||0:00:28.337282||4||1
+2015-12-01 21:26:17.818717||error||collecting ads||Error||1||1
+2015-12-01 21:26:22.058934||measurement||loadtime||0:00:29.043695||5||1
+2015-12-01 21:26:29.241517||measurement||price||2015-12-01 21:26:23.170792@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 21:26:31.328518||measurement||price||2015-12-01 21:26:25.419725@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:26:35.784466||measurement||price||2015-12-01 21:26:29.392673@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 21:26:42.020963||measurement||price||2015-12-01 21:26:23.170792@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 21:26:44.097507||measurement||price||2015-12-01 21:26:25.419725@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:26:48.520569||measurement||price||2015-12-01 21:26:29.392673@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 21:26:49.219278||measurement||loadtime||0:00:28.588107||4||1
+2015-12-01 21:26:51.328715||measurement||loadtime||0:00:28.505556||1||1
+2015-12-01 21:26:55.702277||measurement||loadtime||0:00:28.638125||5||1
+2015-12-01 21:27:02.635505||measurement||price||2015-12-01 21:26:56.628884@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 21:27:05.000099||measurement||price||2015-12-01 21:26:58.940362@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:27:15.415673||measurement||price||2015-12-01 21:26:56.628884@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 21:27:17.757111||measurement||price||2015-12-01 21:26:58.940362@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:27:19.147915||error||collecting ads||Error||5||1
+2015-12-01 21:27:19.148016||event||progress-marker||measurement-end||5||1
+2015-12-01 21:27:22.618320||measurement||loadtime||0:00:28.393787||4||1
+2015-12-01 21:27:22.618411||event||progress-marker||measurement-end||4||1
+2015-12-01 21:27:24.966089||measurement||loadtime||0:00:28.634855||1||1
+2015-12-01 21:27:48.959321||error||collecting ads||Error||1||1
+2015-12-01 21:27:48.959468||event||progress-marker||measurement-end||1||1
+2015-12-01 21:27:49.489325||meta||block_id end||4
+2015-12-01 21:27:49.489618||meta||block_id start||5
+2015-12-01 21:27:49.489650||meta||assignment||2@|5@|4@|0@|1@|3
+2015-12-01 21:27:51.093235||event||progress-marker||training-start||5||0
+2015-12-01 21:27:51.109457||event||progress-marker||training-start||4||0
+2015-12-01 21:27:51.128660||event||progress-marker||training-start||2||0
+2015-12-01 21:27:52.885650||event||progress-marker||training-start||3||1
+2015-12-01 21:27:57.707127||treatment||visit website||http://irs.gov||2||0
+2015-12-01 21:27:57.735108||treatment||visit website||http://irs.gov||5||0
+2015-12-01 21:27:57.775121||treatment||visit website||http://irs.gov||4||0
+2015-12-01 21:28:02.714871||treatment||visit website||http://irs.gov||3||1
+2015-12-01 21:28:04.938567||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 21:28:04.943094||treatment||visit website||http://deloitte.com||5||0
+2015-12-01 21:28:04.943094||treatment||visit website||http://deloitte.com||4||0
+2015-12-01 21:28:09.688176||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 21:28:41.053483||treatment||visit website||http://pwc.com||4||0
+2015-12-01 21:28:41.063105||treatment||visit website||http://pwc.com||5||0
+2015-12-01 21:28:41.170790||treatment||visit website||http://pwc.com||2||0
+2015-12-01 21:28:46.925436||treatment||visit website||http://ey.com||5||0
+2015-12-01 21:28:46.967116||treatment||visit website||http://ey.com||4||0
+2015-12-01 21:28:47.035097||treatment||visit website||http://ey.com||2||0
+2015-12-01 21:28:49.715051||error||website timeout||http://pwc.com||3||1
+2015-12-01 21:28:53.756353||treatment||visit website||http://kpmg.com||4||0
+2015-12-01 21:28:53.756463||event||progress-marker||training-end||4||0
+2015-12-01 21:28:53.931093||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 21:28:53.931266||event||progress-marker||training-end||2||0
+2015-12-01 21:28:54.767098||treatment||visit website||http://ey.com||3||1
+2015-12-01 21:28:58.620815||treatment||visit website||http://kpmg.com||5||0
+2015-12-01 21:28:58.620954||event||progress-marker||training-end||5||0
+2015-12-01 21:29:01.938559||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 21:29:01.938699||event||progress-marker||training-end||3||1
+2015-12-01 21:29:03.644666||event||progress-marker||measurement-start||5||0
+2015-12-01 21:29:03.788370||event||progress-marker||measurement-start||4||0
+2015-12-01 21:29:03.963172||event||progress-marker||measurement-start||2||0
+2015-12-01 21:29:06.955129||event||progress-marker||measurement-start||3||1
+2015-12-01 21:29:17.348977||measurement||price||2015-12-01 21:29:11.507851@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:29:18.741751||measurement||price||2015-12-01 21:29:11.117135@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:29:26.917053||error||collecting ads||Error||5||0
+2015-12-01 21:29:29.693293||measurement||price||2015-12-01 21:29:11.507851@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:29:31.092658||measurement||price||2015-12-01 21:29:11.117135@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:29:33.718709||error||collecting ads||Error||3||1
+2015-12-01 21:29:36.803155||measurement||loadtime||0:00:27.836016||2||0
+2015-12-01 21:29:38.197026||measurement||loadtime||0:00:29.405881||4||0
+2015-12-01 21:29:39.223492||measurement||price||2015-12-01 21:29:33.657514@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 21:29:48.650176||measurement||price||2015-12-01 21:29:42.533011@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 21:29:49.684413||measurement||price||2015-12-01 21:29:44.295718@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:29:51.530729||measurement||price||2015-12-01 21:29:33.657514@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 21:29:58.628024||measurement||loadtime||0:00:26.708872||5||0
+2015-12-01 21:29:59.814933||event||progress-marker||training-start||0||1
+2015-12-01 21:30:00.784229||error||collecting ads||Error||4||0
+2015-12-01 21:30:01.696075||measurement||price||2015-12-01 21:29:42.533011@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 21:30:01.994220||measurement||price||2015-12-01 21:29:44.295718@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:30:06.291208||treatment||visit website||http://irs.gov||0||1
+2015-12-01 21:30:08.943142||measurement||loadtime||0:00:30.219686||3||1
+2015-12-01 21:30:09.100022||measurement||loadtime||0:00:27.292892||2||0
+2015-12-01 21:30:13.626107||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 21:30:20.850971||error||collecting ads||Error||5||0
+2015-12-01 21:30:21.888960||measurement||price||2015-12-01 21:30:16.490477@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:30:22.793295||treatment||visit website||http://pwc.com||0||1
+2015-12-01 21:30:23.094339||error||collecting ads||Error||4||0
+2015-12-01 21:30:23.135104||measurement||price||2015-12-01 21:30:16.905083@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 21:30:26.111043||event||progress-marker||training-start||1||1
+2015-12-01 21:30:28.999106||treatment||visit website||http://ey.com||0||1
+2015-12-01 21:30:32.535578||treatment||visit website||http://irs.gov||1||1
+2015-12-01 21:30:33.529859||measurement||price||2015-12-01 21:30:27.998195@|Stanley@|$9.06@|Stanley 33-425 Powerlock 25-Foot by 1-Inch Measuring Tape...||5||0
+2015-12-01 21:30:34.234049||measurement||price||2015-12-01 21:30:16.490477@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:30:35.395602||measurement||price||2015-12-01 21:30:29.853473@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:30:35.703146||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 21:30:35.703259||event||progress-marker||training-end||0||1
+2015-12-01 21:30:35.962489||measurement||price||2015-12-01 21:30:16.905083@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 21:30:39.611097||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 21:30:41.351255||measurement||loadtime||0:00:27.248036||2||0
+2015-12-01 21:30:43.155342||measurement||loadtime||0:00:29.208048||3||1
+2015-12-01 21:30:45.849598||measurement||price||2015-12-01 21:30:27.998195@|Stanley@|$99.95@|STANLEY STMT73795 Mixed Tool Set, 210-Piece||5||0
+2015-12-01 21:30:47.720114||measurement||price||2015-12-01 21:30:29.853473@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:30:49.249312||treatment||visit website||http://pwc.com||1||1
+2015-12-01 21:30:52.959140||measurement||loadtime||0:00:27.102936||5||0
+2015-12-01 21:30:54.028461||measurement||price||2015-12-01 21:30:48.593397@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:30:54.835757||measurement||loadtime||0:00:26.736209||4||0
+2015-12-01 21:30:55.203630||treatment||visit website||http://ey.com||1||1
+2015-12-01 21:31:02.514611||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 21:31:02.514735||event||progress-marker||training-end||1||1
+2015-12-01 21:31:05.164276||measurement||price||2015-12-01 21:30:59.635085@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 21:31:05.778488||event||progress-marker||measurement-start||0||1
+2015-12-01 21:31:06.339371||measurement||price||2015-12-01 21:30:48.593397@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:31:06.872753||error||collecting ads||Error||3||1
+2015-12-01 21:31:07.528875||event||progress-marker||measurement-start||1||1
+2015-12-01 21:31:13.427161||measurement||loadtime||0:00:27.070667||2||0
+2015-12-01 21:31:17.158352||error||collecting ads||Error||4||0
+2015-12-01 21:31:17.480191||measurement||price||2015-12-01 21:30:59.635085@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 21:31:20.513330||measurement||price||2015-12-01 21:31:13.795141@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:31:21.191974||measurement||price||2015-12-01 21:31:14.794623@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 21:31:22.359217||measurement||price||2015-12-01 21:31:15.619912@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:31:24.592021||measurement||loadtime||0:00:26.627674||5||0
+2015-12-01 21:31:26.116741||measurement||price||2015-12-01 21:31:20.760824@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:31:29.362299||measurement||price||2015-12-01 21:31:23.735860@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:31:33.329198||measurement||price||2015-12-01 21:31:13.795141@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 21:31:34.054352||measurement||price||2015-12-01 21:31:14.794623@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 21:31:35.202432||measurement||price||2015-12-01 21:31:15.619912@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:31:38.399967||measurement||price||2015-12-01 21:31:20.760824@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:31:40.544261||measurement||loadtime||0:00:29.760576||0||1
+2015-12-01 21:31:41.274758||measurement||loadtime||0:00:29.396802||3||1
+2015-12-01 21:31:41.687136||measurement||price||2015-12-01 21:31:23.735860@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:31:42.406060||measurement||loadtime||0:00:29.871980||1||1
+2015-12-01 21:31:45.496543||measurement||loadtime||0:00:27.064202||2||0
+2015-12-01 21:31:46.831590||error||collecting ads||Error||5||0
+2015-12-01 21:31:48.789636||measurement||loadtime||0:00:26.626067||4||0
+2015-12-01 21:31:54.619665||measurement||price||2015-12-01 21:31:48.130184@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 21:31:56.460803||measurement||price||2015-12-01 21:31:49.987002@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:31:58.140392||measurement||price||2015-12-01 21:31:52.758065@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:31:59.110088||measurement||price||2015-12-01 21:31:53.434114@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 21:32:00.937066||measurement||price||2015-12-01 21:31:55.396239@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:32:05.147240||error||collecting ads||Error||3||1
+2015-12-01 21:32:07.682085||measurement||price||2015-12-01 21:31:48.130184@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 21:32:09.512477||measurement||price||2015-12-01 21:31:49.987002@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:32:10.425643||measurement||price||2015-12-01 21:31:52.758065@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:32:11.408500||measurement||price||2015-12-01 21:31:53.434114@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 21:32:13.225096||measurement||price||2015-12-01 21:31:55.396239@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:32:14.892668||measurement||loadtime||0:00:29.347273||0||1
+2015-12-01 21:32:16.721947||measurement||loadtime||0:00:29.310745||1||1
+2015-12-01 21:32:17.512098||measurement||loadtime||0:00:27.010345||2||0
+2015-12-01 21:32:18.514470||measurement||loadtime||0:00:26.677671||5||0
+2015-12-01 21:32:18.843899||measurement||price||2015-12-01 21:32:12.724387@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 21:32:20.303144||measurement||loadtime||0:00:26.511925||4||0
+2015-12-01 21:32:28.905702||measurement||price||2015-12-01 21:32:22.273793@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:32:30.339677||measurement||price||2015-12-01 21:32:24.892935@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:32:30.732563||measurement||price||2015-12-01 21:32:24.167926@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:32:31.832287||measurement||price||2015-12-01 21:32:12.724387@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 21:32:32.596302||measurement||price||2015-12-01 21:32:27.073910@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:32:39.010047||measurement||loadtime||0:00:28.857560||3||1
+2015-12-01 21:32:40.880054||error||collecting ads||Error||5||0
+2015-12-01 21:32:41.928438||measurement||price||2015-12-01 21:32:22.273793@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 21:32:42.661084||measurement||price||2015-12-01 21:32:24.892935@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:32:43.585301||measurement||price||2015-12-01 21:32:24.167926@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:32:44.907678||measurement||price||2015-12-01 21:32:27.073910@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:32:49.111147||measurement||loadtime||0:00:29.213281||0||1
+2015-12-01 21:32:49.768506||measurement||loadtime||0:00:27.255393||2||0
+2015-12-01 21:32:50.773216||measurement||loadtime||0:00:29.046057||1||1
+2015-12-01 21:32:52.027495||measurement||loadtime||0:00:26.720354||4||0
+2015-12-01 21:32:53.175325||measurement||price||2015-12-01 21:32:47.576231@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 21:33:02.553220||measurement||price||2015-12-01 21:32:57.152950@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:33:03.015317||error||collecting ads||Error||3||1
+2015-12-01 21:33:03.989304||measurement||price||2015-12-01 21:32:56.380063@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:33:04.427218||measurement||price||2015-12-01 21:32:58.799929@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:33:04.653254||measurement||price||2015-12-01 21:32:58.210842@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:33:05.503746||measurement||price||2015-12-01 21:32:47.576231@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 21:33:12.604634||measurement||loadtime||0:00:26.720133||5||0
+2015-12-01 21:33:14.860188||measurement||price||2015-12-01 21:32:57.152950@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:33:16.755567||measurement||price||2015-12-01 21:32:58.799929@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:33:17.066623||measurement||price||2015-12-01 21:32:56.380063@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 21:33:17.660610||measurement||price||2015-12-01 21:32:58.210842@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:33:21.971256||measurement||loadtime||0:00:27.197588||2||0
+2015-12-01 21:33:23.863146||measurement||loadtime||0:00:26.832018||4||0
+2015-12-01 21:33:24.266987||measurement||loadtime||0:00:30.153843||0||1
+2015-12-01 21:33:24.814344||measurement||price||2015-12-01 21:33:19.216306@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 21:33:24.855166||measurement||loadtime||0:00:29.080013||1||1
+2015-12-01 21:33:26.705842||error||collecting ads||Error||3||1
+2015-12-01 21:33:35.176276||measurement||price||2015-12-01 21:33:29.776693@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:33:36.167901||measurement||price||2015-12-01 21:33:30.583609@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:33:37.141073||measurement||price||2015-12-01 21:33:19.216306@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 21:33:38.297642||measurement||price||2015-12-01 21:33:31.686193@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 21:33:39.012986||measurement||price||2015-12-01 21:33:32.357206@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:33:40.904108||measurement||price||2015-12-01 21:33:34.655633@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 21:33:44.250215||measurement||loadtime||0:00:26.643067||5||0
+2015-12-01 21:33:47.510751||measurement||price||2015-12-01 21:33:29.776693@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:33:48.498162||measurement||price||2015-12-01 21:33:30.583609@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:33:51.113470||measurement||price||2015-12-01 21:33:31.686193@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 21:33:52.065425||measurement||price||2015-12-01 21:33:32.357206@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:33:53.730018||measurement||price||2015-12-01 21:33:34.655633@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 21:33:54.620352||measurement||loadtime||0:00:27.648113||2||0
+2015-12-01 21:33:55.619414||measurement||loadtime||0:00:26.752275||4||0
+2015-12-01 21:33:56.487583||measurement||price||2015-12-01 21:33:50.905585@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 21:33:58.326510||measurement||loadtime||0:00:29.055374||0||1
+2015-12-01 21:33:59.264055||measurement||loadtime||0:00:29.404900||1||1
+2015-12-01 21:34:00.927187||measurement||loadtime||0:00:29.220029||3||1
+2015-12-01 21:34:07.342175||measurement||price||2015-12-01 21:34:01.910449@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:34:07.951018||measurement||price||2015-12-01 21:34:02.289710@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:34:08.809578||measurement||price||2015-12-01 21:33:50.905585@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 21:34:13.214823||measurement||price||2015-12-01 21:34:06.591511@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:34:14.669158||measurement||price||2015-12-01 21:34:08.739259@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 21:34:15.931237||measurement||loadtime||0:00:26.677629||5||0
+2015-12-01 21:34:19.684436||measurement||price||2015-12-01 21:34:01.910449@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:34:20.323100||measurement||price||2015-12-01 21:34:02.289710@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:34:22.289840||error||collecting ads||Error||0||1
+2015-12-01 21:34:26.024524||measurement||price||2015-12-01 21:34:06.591511@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:34:26.796958||measurement||loadtime||0:00:27.171432||2||0
+2015-12-01 21:34:27.431140||measurement||loadtime||0:00:26.806538||4||0
+2015-12-01 21:34:27.499116||measurement||price||2015-12-01 21:34:08.739259@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 21:34:28.236954||measurement||price||2015-12-01 21:34:22.612867@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 21:34:33.251146||measurement||loadtime||0:00:28.981885||1||1
+2015-12-01 21:34:34.711152||measurement||loadtime||0:00:28.778769||3||1
+2015-12-01 21:34:35.965712||measurement||price||2015-12-01 21:34:29.466909@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:34:39.912562||measurement||price||2015-12-01 21:34:34.546106@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:34:39.996526||measurement||price||2015-12-01 21:34:34.516582@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:34:40.585507||measurement||price||2015-12-01 21:34:22.612867@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 21:34:47.695171||measurement||loadtime||0:00:26.758727||5||0
+2015-12-01 21:34:48.858186||measurement||price||2015-12-01 21:34:29.466909@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 21:34:52.251545||measurement||price||2015-12-01 21:34:34.546106@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:34:52.329561||measurement||price||2015-12-01 21:34:34.516582@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:34:56.035141||measurement||loadtime||0:00:28.740650||0||1
+2015-12-01 21:34:57.159896||error||collecting ads||Error||1||1
+2015-12-01 21:34:58.698822||error||collecting ads||Error||3||1
+2015-12-01 21:34:59.361004||measurement||loadtime||0:00:27.561850||2||0
+2015-12-01 21:34:59.439156||measurement||loadtime||0:00:27.003440||4||0
+2015-12-01 21:35:09.950578||measurement||price||2015-12-01 21:35:03.355376@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 21:35:09.984013||error||collecting ads||Error||5||0
+2015-12-01 21:35:12.182777||measurement||price||2015-12-01 21:35:06.717700@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:35:12.465998||measurement||price||2015-12-01 21:35:06.921588@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||0
+2015-12-01 21:35:12.980573||measurement||price||2015-12-01 21:35:06.560070@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 21:35:21.439609||error||collecting ads||Error||1||1
+2015-12-01 21:35:22.226273||measurement||price||2015-12-01 21:35:16.674614@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 21:35:22.822511||measurement||price||2015-12-01 21:35:03.355376@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 21:35:24.479300||measurement||price||2015-12-01 21:35:06.717700@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:35:24.823664||measurement||price||2015-12-01 21:35:06.921588@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||0
+2015-12-01 21:35:25.817296||measurement||price||2015-12-01 21:35:06.560070@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 21:35:30.002794||measurement||loadtime||0:00:28.962475||0||1
+2015-12-01 21:35:31.559923||measurement||loadtime||0:00:27.193700||2||0
+2015-12-01 21:35:31.938870||measurement||loadtime||0:00:27.495327||4||0
+2015-12-01 21:35:33.018405||measurement||loadtime||0:00:29.315261||3||1
+2015-12-01 21:35:34.560914||measurement||price||2015-12-01 21:35:16.674614@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 21:35:35.066610||measurement||price||2015-12-01 21:35:28.615208@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:35:41.677538||measurement||loadtime||0:00:26.688338||5||0
+2015-12-01 21:35:44.277894||measurement||price||2015-12-01 21:35:38.852364@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:35:44.301135||measurement||price||2015-12-01 21:35:38.625096@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:35:47.012108||measurement||price||2015-12-01 21:35:40.897193@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 21:35:47.886421||measurement||price||2015-12-01 21:35:28.615208@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:35:53.880444||measurement||price||2015-12-01 21:35:48.340612@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 21:35:54.499677||error||collecting ads||Error||0||1
+2015-12-01 21:35:55.083170||measurement||loadtime||0:00:28.638360||1||1
+2015-12-01 21:35:56.624241||measurement||price||2015-12-01 21:35:38.852364@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:35:56.660310||measurement||price||2015-12-01 21:35:38.625096@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:35:59.858557||measurement||price||2015-12-01 21:35:40.897193@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 21:36:03.731159||measurement||loadtime||0:00:27.168024||2||0
+2015-12-01 21:36:03.773288||measurement||loadtime||0:00:26.830130||4||0
+2015-12-01 21:36:06.201933||measurement||price||2015-12-01 21:35:48.340612@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 21:36:07.068004||measurement||loadtime||0:00:29.047277||3||1
+2015-12-01 21:36:08.134862||measurement||price||2015-12-01 21:36:01.768248@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:36:08.980471||measurement||price||2015-12-01 21:36:02.388241@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:36:13.307152||measurement||loadtime||0:00:26.624431||5||0
+2015-12-01 21:36:16.006971||measurement||price||2015-12-01 21:36:10.391435@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:36:16.642377||measurement||price||2015-12-01 21:36:11.224875@|Amy Poehler@| $24.96   @|Inside Out (Blu-ray/DVD Combo Pack + Digital Copy)||2||0
+2015-12-01 21:36:21.045035||measurement||price||2015-12-01 21:36:01.768248@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 21:36:21.821092||measurement||price||2015-12-01 21:36:02.388241@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:36:25.529285||measurement||price||2015-12-01 21:36:19.984363@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 21:36:28.256648||measurement||loadtime||0:00:28.751760||0||1
+2015-12-01 21:36:28.341530||measurement||price||2015-12-01 21:36:10.391435@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:36:28.984131||measurement||price||2015-12-01 21:36:11.224875@|Sandra Bullock@| $18.99   @|Minions (Blu-ray + DVD + DIGITAL HD)||2||0
+2015-12-01 21:36:29.035166||measurement||loadtime||0:00:28.948557||1||1
+2015-12-01 21:36:30.898424||error||collecting ads||Error||3||1
+2015-12-01 21:36:35.451753||measurement||loadtime||0:00:26.676629||4||0
+2015-12-01 21:36:36.099157||measurement||loadtime||0:00:27.364030||2||0
+2015-12-01 21:36:37.866646||measurement||price||2015-12-01 21:36:19.984363@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 21:36:42.074077||measurement||price||2015-12-01 21:36:35.570332@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 21:36:42.802318||measurement||price||2015-12-01 21:36:36.313533@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:36:44.979142||measurement||loadtime||0:00:26.666791||5||0
+2015-12-01 21:36:47.711955||measurement||price||2015-12-01 21:36:42.139500@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:36:48.782797||measurement||price||2015-12-01 21:36:43.345524@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 21:36:54.728904||error||collecting ads||Error||3||1
+2015-12-01 21:36:54.916265||measurement||price||2015-12-01 21:36:35.570332@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 21:36:55.685482||measurement||price||2015-12-01 21:36:36.313533@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:36:57.277227||measurement||price||2015-12-01 21:36:51.718162@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 21:37:00.038771||measurement||price||2015-12-01 21:36:42.139500@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:37:01.092789||measurement||price||2015-12-01 21:36:43.345524@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 21:37:02.119152||measurement||loadtime||0:00:28.860017||0||1
+2015-12-01 21:37:02.903133||measurement||loadtime||0:00:28.862797||1||1
+2015-12-01 21:37:07.149758||measurement||loadtime||0:00:26.694640||4||0
+2015-12-01 21:37:08.179143||measurement||loadtime||0:00:27.074781||2||0
+2015-12-01 21:37:09.610057||measurement||price||2015-12-01 21:36:51.718162@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 21:37:16.720117||measurement||loadtime||0:00:26.735784||5||0
+2015-12-01 21:37:17.050442||measurement||price||2015-12-01 21:37:10.268847@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:37:18.222387||error||collecting ads||Error||3||1
+2015-12-01 21:37:20.877368||measurement||price||2015-12-01 21:37:15.550712@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:37:26.381382||error||collecting ads||Error||0||1
+2015-12-01 21:37:28.909658||measurement||price||2015-12-01 21:37:23.352429@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 21:37:29.397170||error||collecting ads||Error||4||0
+2015-12-01 21:37:29.955810||measurement||price||2015-12-01 21:37:10.268847@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:37:32.009641||measurement||price||2015-12-01 21:37:25.906420@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 21:37:33.167116||measurement||price||2015-12-01 21:37:15.550712@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:37:37.135218||measurement||loadtime||0:00:29.228056||1||1
+2015-12-01 21:37:40.072939||measurement||price||2015-12-01 21:37:33.667349@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 21:37:40.254375||measurement||loadtime||0:00:27.071243||2||0
+2015-12-01 21:37:41.242632||measurement||price||2015-12-01 21:37:23.352429@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 21:37:44.876346||measurement||price||2015-12-01 21:37:25.906420@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 21:37:48.352677||measurement||loadtime||0:00:26.629500||5||0
+2015-12-01 21:37:50.943692||measurement||price||2015-12-01 21:37:44.513750@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:37:51.655803||error||collecting ads||Error||4||0
+2015-12-01 21:37:52.075170||measurement||loadtime||0:00:28.848014||3||1
+2015-12-01 21:37:52.765638||measurement||price||2015-12-01 21:37:47.361443@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:37:52.952127||measurement||price||2015-12-01 21:37:33.667349@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 21:38:00.183164||measurement||loadtime||0:00:28.796539||0||1
+2015-12-01 21:38:03.981749||measurement||price||2015-12-01 21:37:44.513750@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:38:04.025966||measurement||price||2015-12-01 21:37:58.364115@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:38:05.067589||measurement||price||2015-12-01 21:37:47.361443@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:38:06.218417||measurement||price||2015-12-01 21:37:59.982693@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 21:38:10.625299||error||collecting ads||Error||5||0
+2015-12-01 21:38:11.179164||measurement||loadtime||0:00:29.038706||1||1
+2015-12-01 21:38:12.156491||measurement||loadtime||0:00:26.897771||2||0
+2015-12-01 21:38:14.087845||measurement||price||2015-12-01 21:38:07.684818@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 21:38:16.365477||measurement||price||2015-12-01 21:37:58.364115@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:38:19.084792||measurement||price||2015-12-01 21:37:59.982693@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 21:38:22.895019||measurement||price||2015-12-01 21:38:17.329657@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 21:38:23.480226||measurement||loadtime||0:00:26.819204||4||0
+2015-12-01 21:38:24.935054||measurement||price||2015-12-01 21:38:19.525928@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:38:25.269129||measurement||price||2015-12-01 21:38:18.522402@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:38:26.287081||measurement||loadtime||0:00:29.206676||3||1
+2015-12-01 21:38:26.857873||measurement||price||2015-12-01 21:38:07.684818@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 21:38:34.054193||measurement||loadtime||0:00:28.865852||0||1
+2015-12-01 21:38:35.159713||measurement||price||2015-12-01 21:38:17.329657@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 21:38:35.790316||measurement||price||2015-12-01 21:38:30.157135@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:38:37.244037||measurement||price||2015-12-01 21:38:19.525928@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:38:38.375881||measurement||price||2015-12-01 21:38:18.522402@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:38:40.765695||measurement||price||2015-12-01 21:38:34.630682@|Stanley@|$9.06@|Stanley 33-425 Powerlock 25-Foot by 1-Inch Measuring Tape...||3||1
+2015-12-01 21:38:42.254461||measurement||loadtime||0:00:26.623949||5||0
+2015-12-01 21:38:42.254553||event||progress-marker||measurement-end||5||0
+2015-12-01 21:38:44.348624||measurement||loadtime||0:00:27.190924||2||0
+2015-12-01 21:38:45.595807||measurement||loadtime||0:00:29.411459||1||1
+2015-12-01 21:38:48.049394||measurement||price||2015-12-01 21:38:41.295545@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 21:38:48.110078||measurement||price||2015-12-01 21:38:30.157135@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:38:53.835828||measurement||price||2015-12-01 21:38:34.630682@|Stanley@|$99.95@|STANLEY STMT73795 Mixed Tool Set, 210-Piece||3||1
+2015-12-01 21:38:55.224598||measurement||loadtime||0:00:26.739178||4||0
+2015-12-01 21:38:55.224706||event||progress-marker||measurement-end||4||0
+2015-12-01 21:39:00.015753||measurement||price||2015-12-01 21:38:53.607285@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:39:00.937144||measurement||price||2015-12-01 21:38:41.295545@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 21:39:01.019121||measurement||loadtime||0:00:29.726969||3||1
+2015-12-01 21:39:01.019200||event||progress-marker||measurement-end||3||1
+2015-12-01 21:39:07.041181||error||collecting ads||Error||2||0
+2015-12-01 21:39:08.118782||measurement||loadtime||0:00:29.059391||0||1
+2015-12-01 21:39:12.876743||measurement||price||2015-12-01 21:38:53.607285@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:39:19.655766||measurement||price||2015-12-01 21:39:14.294829@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:39:20.147956||measurement||loadtime||0:00:29.546936||1||1
+2015-12-01 21:39:31.879316||error||collecting ads||Error||0||1
+2015-12-01 21:39:31.967204||measurement||price||2015-12-01 21:39:14.294829@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:39:39.074689||measurement||loadtime||0:00:27.028305||2||0
+2015-12-01 21:39:39.074814||event||progress-marker||measurement-end||2||0
+2015-12-01 21:39:44.047162||error||collecting ads||Error||1||1
+2015-12-01 21:39:45.738692||measurement||price||2015-12-01 21:39:39.164355@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 21:39:57.849674||measurement||price||2015-12-01 21:39:51.235355@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:39:58.571783||measurement||price||2015-12-01 21:39:39.164355@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 21:40:05.772595||measurement||loadtime||0:00:28.889125||0||1
+2015-12-01 21:40:10.895509||measurement||price||2015-12-01 21:39:51.235355@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:40:18.114218||measurement||loadtime||0:00:29.061829||1||1
+2015-12-01 21:40:29.454966||error||collecting ads||Error||0||1
+2015-12-01 21:40:31.927163||measurement||price||2015-12-01 21:40:26.037315@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:40:45.024097||measurement||price||2015-12-01 21:40:26.037315@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:40:52.205319||measurement||loadtime||0:00:29.085874||1||1
+2015-12-01 21:40:53.380209||error||collecting ads||Error||0||1
+2015-12-01 21:41:06.233754||measurement||price||2015-12-01 21:40:59.506568@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:41:07.481826||measurement||price||2015-12-01 21:41:00.656856@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:41:19.167729||measurement||price||2015-12-01 21:40:59.506568@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:41:20.437519||measurement||price||2015-12-01 21:41:00.656856@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 21:41:26.359783||measurement||loadtime||0:00:29.149187||1||1
+2015-12-01 21:41:27.641309||measurement||loadtime||0:00:29.255857||0||1
+2015-12-01 21:41:27.641413||event||progress-marker||measurement-end||0||1
+2015-12-01 21:41:40.162411||measurement||price||2015-12-01 21:41:33.650127@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:41:53.095994||measurement||price||2015-12-01 21:41:33.650127@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:42:00.287362||measurement||loadtime||0:00:28.922385||1||1
+2015-12-01 21:42:00.287476||event||progress-marker||measurement-end||1||1
+2015-12-01 21:42:00.833168||meta||block_id end||5
+2015-12-01 21:42:00.833395||meta||block_id start||6
+2015-12-01 21:42:00.833413||meta||assignment||3@|0@|4@|5@|1@|2
+2015-12-01 21:42:02.457145||event||progress-marker||training-start||3||0
+2015-12-01 21:42:02.469947||event||progress-marker||training-start||0||0
+2015-12-01 21:42:02.485098||event||progress-marker||training-start||4||0
+2015-12-01 21:42:09.311126||treatment||visit website||http://irs.gov||4||0
+2015-12-01 21:42:09.339121||treatment||visit website||http://irs.gov||0||0
+2015-12-01 21:42:09.375123||treatment||visit website||http://irs.gov||3||0
+2015-12-01 21:42:16.755842||treatment||visit website||http://deloitte.com||4||0
+2015-12-01 21:42:16.763135||treatment||visit website||http://deloitte.com||3||0
+2015-12-01 21:42:16.766328||treatment||visit website||http://deloitte.com||0||0
+2015-12-01 21:42:24.862697||treatment||visit website||http://pwc.com||4||0
+2015-12-01 21:42:25.031126||treatment||visit website||http://pwc.com||0||0
+2015-12-01 21:42:25.175101||treatment||visit website||http://pwc.com||3||0
+2015-12-01 21:42:30.764136||treatment||visit website||http://ey.com||4||0
+2015-12-01 21:42:30.907097||treatment||visit website||http://ey.com||0||0
+2015-12-01 21:42:31.031705||treatment||visit website||http://ey.com||3||0
+2015-12-01 21:42:38.079111||treatment||visit website||http://kpmg.com||3||0
+2015-12-01 21:42:38.079238||event||progress-marker||training-end||3||0
+2015-12-01 21:42:38.983137||treatment||visit website||http://kpmg.com||4||0
+2015-12-01 21:42:38.983287||event||progress-marker||training-end||4||0
+2015-12-01 21:42:48.906117||treatment||visit website||http://kpmg.com||0||0
+2015-12-01 21:42:48.906257||event||progress-marker||training-end||0||0
+2015-12-01 21:42:49.020123||event||progress-marker||measurement-start||4||0
+2015-12-01 21:42:53.121870||event||progress-marker||measurement-start||3||0
+2015-12-01 21:42:53.932938||event||progress-marker||measurement-start||0||0
+2015-12-01 21:43:01.884102||measurement||price||2015-12-01 21:42:56.436545@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:43:06.287248||measurement||price||2015-12-01 21:43:00.317210@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:43:07.266043||measurement||price||2015-12-01 21:43:01.315644@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:43:14.261207||measurement||price||2015-12-01 21:42:56.436545@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:43:18.643354||measurement||price||2015-12-01 21:43:00.317210@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:43:19.609540||measurement||price||2015-12-01 21:43:01.315644@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:43:21.359511||measurement||loadtime||0:00:27.336847||4||0
+2015-12-01 21:43:25.755181||measurement||loadtime||0:00:27.628517||3||0
+2015-12-01 21:43:26.750908||measurement||loadtime||0:00:27.812757||0||0
+2015-12-01 21:43:33.720629||measurement||price||2015-12-01 21:43:28.391149@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:43:38.134069||measurement||price||2015-12-01 21:43:32.426130@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:43:39.284024||measurement||price||2015-12-01 21:43:33.897944@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:43:46.049168||measurement||price||2015-12-01 21:43:28.391149@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:43:50.446082||measurement||price||2015-12-01 21:43:32.426130@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:43:51.558967||measurement||price||2015-12-01 21:43:33.897944@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:43:53.159179||measurement||loadtime||0:00:26.794492||4||0
+2015-12-01 21:43:57.553794||measurement||loadtime||0:00:26.794663||3||0
+2015-12-01 21:43:58.646850||measurement||loadtime||0:00:26.891698||0||0
+2015-12-01 21:44:05.502509||event||progress-marker||training-start||2||1
+2015-12-01 21:44:05.526891||measurement||price||2015-12-01 21:44:00.140884@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:44:11.156893||measurement||price||2015-12-01 21:44:05.701080@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:44:11.998047||treatment||visit website||http://irs.gov||2||1
+2015-12-01 21:44:16.242004||event||progress-marker||training-start||1||1
+2015-12-01 21:44:17.855485||measurement||price||2015-12-01 21:44:00.140884@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:44:19.820336||error||collecting ads||Error||3||0
+2015-12-01 21:44:22.610827||treatment||visit website||http://irs.gov||1||1
+2015-12-01 21:44:23.523513||measurement||price||2015-12-01 21:44:05.701080@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:44:24.965760||measurement||loadtime||0:00:26.801368||4||0
+2015-12-01 21:44:30.639173||measurement||loadtime||0:00:26.988030||0||0
+2015-12-01 21:44:31.416222||treatment||visit website||http://deloitte.com||2||1
+2015-12-01 21:44:32.101936||measurement||price||2015-12-01 21:44:26.457769@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:44:37.163760||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 21:44:37.520034||event||progress-marker||training-start||5||1
+2015-12-01 21:44:44.065425||treatment||visit website||http://irs.gov||5||1
+2015-12-01 21:44:44.466156||measurement||price||2015-12-01 21:44:26.457769@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:44:47.452265||error||collecting ads||Error||4||0
+2015-12-01 21:44:51.581384||measurement||loadtime||0:00:26.755819||3||0
+2015-12-01 21:44:53.152758||error||collecting ads||Error||0||0
+2015-12-01 21:44:53.580982||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 21:45:02.345856||treatment||visit website||http://pwc.com||5||1
+2015-12-01 21:45:03.883013||measurement||price||2015-12-01 21:44:58.358659@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:45:08.580306||treatment||visit website||http://ey.com||5||1
+2015-12-01 21:45:09.946904||error||collecting ads||Error||4||0
+2015-12-01 21:45:11.442473||error||website timeout||http://pwc.com||2||1
+2015-12-01 21:45:15.389338||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 21:45:15.389452||event||progress-marker||training-end||5||1
+2015-12-01 21:45:15.577337||error||collecting ads||Error||0||0
+2015-12-01 21:45:16.216407||measurement||price||2015-12-01 21:44:58.358659@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:45:16.479101||treatment||visit website||http://ey.com||2||1
+2015-12-01 21:45:17.183542||error||website timeout||http://pwc.com||1||1
+2015-12-01 21:45:22.227118||treatment||visit website||http://ey.com||1||1
+2015-12-01 21:45:23.158729||treatment||visit website||http://kpmg.com||2||1
+2015-12-01 21:45:23.158854||event||progress-marker||training-end||2||1
+2015-12-01 21:45:23.328913||measurement||loadtime||0:00:26.745621||3||0
+2015-12-01 21:45:28.025040||measurement||price||2015-12-01 21:45:22.608178@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:45:28.962284||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 21:45:28.962414||event||progress-marker||training-end||1||1
+2015-12-01 21:45:30.432770||event||progress-marker||measurement-start||5||1
+2015-12-01 21:45:32.390789||error||collecting ads||Error||4||0
+2015-12-01 21:45:33.191156||event||progress-marker||measurement-start||2||1
+2015-12-01 21:45:33.976887||event||progress-marker||measurement-start||1||1
+2015-12-01 21:45:35.593052||measurement||price||2015-12-01 21:45:29.932239@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:45:40.362659||measurement||price||2015-12-01 21:45:22.608178@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:45:44.743439||measurement||price||2015-12-01 21:45:39.404961@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:45:45.115179||measurement||price||2015-12-01 21:45:38.341890@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:45:47.501219||measurement||loadtime||0:00:26.919309||0||0
+2015-12-01 21:45:47.766687||measurement||price||2015-12-01 21:45:41.221896@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:45:47.924970||measurement||price||2015-12-01 21:45:29.932239@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:45:55.035462||measurement||loadtime||0:00:26.701341||3||0
+2015-12-01 21:45:57.069799||measurement||price||2015-12-01 21:45:39.404961@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:45:57.997575||measurement||price||2015-12-01 21:45:38.341890@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:45:58.447756||error||collecting ads||Error||1||1
+2015-12-01 21:45:59.929755||measurement||price||2015-12-01 21:45:54.525636@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:46:00.631218||measurement||price||2015-12-01 21:45:41.221896@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:46:04.187147||measurement||loadtime||0:00:26.791167||4||0
+2015-12-01 21:46:05.207174||measurement||loadtime||0:00:29.769170||5||1
+2015-12-01 21:46:07.239260||measurement||price||2015-12-01 21:46:01.705848@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:46:07.845296||measurement||loadtime||0:00:29.650139||2||1
+2015-12-01 21:46:12.236924||measurement||price||2015-12-01 21:46:05.767141@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:46:12.265606||measurement||price||2015-12-01 21:45:54.525636@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:46:16.586792||measurement||price||2015-12-01 21:46:11.243358@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:46:19.102798||measurement||price||2015-12-01 21:46:12.803018@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 21:46:19.381023||measurement||loadtime||0:00:26.876539||0||0
+2015-12-01 21:46:19.583575||measurement||price||2015-12-01 21:46:01.705848@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:46:21.853114||measurement||price||2015-12-01 21:46:15.354656@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:46:25.117657||measurement||price||2015-12-01 21:46:05.767141@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:46:26.695165||measurement||loadtime||0:00:26.654517||3||0
+2015-12-01 21:46:28.904782||measurement||price||2015-12-01 21:46:11.243358@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:46:31.873200||measurement||price||2015-12-01 21:46:26.444426@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:46:32.127741||measurement||price||2015-12-01 21:46:12.803018@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 21:46:32.335187||measurement||loadtime||0:00:28.882225||1||1
+2015-12-01 21:46:34.678419||measurement||price||2015-12-01 21:46:15.354656@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:46:36.017591||measurement||loadtime||0:00:26.826471||4||0
+2015-12-01 21:46:39.339151||measurement||loadtime||0:00:29.126764||5||1
+2015-12-01 21:46:41.895364||measurement||loadtime||0:00:29.049418||2||1
+2015-12-01 21:46:44.203457||measurement||price||2015-12-01 21:46:26.444426@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:46:48.489268||measurement||price||2015-12-01 21:46:43.101400@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:46:49.084235||error||collecting ads||Error||3||0
+2015-12-01 21:46:51.311151||measurement||loadtime||0:00:26.924920||0||0
+2015-12-01 21:46:53.156270||measurement||price||2015-12-01 21:46:46.679056@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:46:55.827632||measurement||price||2015-12-01 21:46:49.352411@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 21:46:56.230175||error||collecting ads||Error||1||1
+2015-12-01 21:47:00.841626||measurement||price||2015-12-01 21:46:43.101400@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:47:01.968571||measurement||price||2015-12-01 21:46:56.385372@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||0
+2015-12-01 21:47:06.010511||measurement||price||2015-12-01 21:46:46.679056@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:47:07.959284||measurement||loadtime||0:00:26.936482||4||0
+2015-12-01 21:47:08.759527||measurement||price||2015-12-01 21:46:49.352411@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 21:47:10.166763||measurement||price||2015-12-01 21:47:03.411464@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:47:13.207183||measurement||loadtime||0:00:28.862837||5||1
+2015-12-01 21:47:13.783418||error||collecting ads||Error||0||0
+2015-12-01 21:47:14.321089||measurement||price||2015-12-01 21:46:56.385372@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||0
+2015-12-01 21:47:15.942280||measurement||loadtime||0:00:29.044587||2||1
+2015-12-01 21:47:20.364345||measurement||price||2015-12-01 21:47:14.555437@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:47:21.420388||measurement||loadtime||0:00:27.330986||3||0
+2015-12-01 21:47:22.986464||measurement||price||2015-12-01 21:47:03.411464@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:47:26.357325||measurement||price||2015-12-01 21:47:20.967801@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:47:27.578284||measurement||price||2015-12-01 21:47:21.265316@|Mitchell@|$73.90@|Mitchell 300 Pro Spinning Rod and Reel Combo, 7-Feet/Medium||5||1
+2015-12-01 21:47:30.161290||measurement||price||2015-12-01 21:47:23.785835@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:47:30.202402||measurement||loadtime||0:00:28.967287||1||1
+2015-12-01 21:47:32.703430||measurement||price||2015-12-01 21:47:14.555437@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:47:33.701650||measurement||price||2015-12-01 21:47:28.058016@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:47:38.667705||measurement||price||2015-12-01 21:47:20.967801@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:47:39.816672||measurement||loadtime||0:00:26.853520||4||0
+2015-12-01 21:47:40.458112||measurement||price||2015-12-01 21:47:21.265316@|Penn@|$89.65@|Penn Battle II Spinning Reel, 4000||5||1
+2015-12-01 21:47:43.167582||measurement||price||2015-12-01 21:47:23.785835@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:47:45.775169||measurement||loadtime||0:00:26.988342||0||0
+2015-12-01 21:47:46.028413||measurement||price||2015-12-01 21:47:28.058016@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:47:47.659042||measurement||loadtime||0:00:29.448600||5||1
+2015-12-01 21:47:50.353549||measurement||loadtime||0:00:29.406402||2||1
+2015-12-01 21:47:52.211187||measurement||price||2015-12-01 21:47:46.821733@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:47:53.140807||measurement||loadtime||0:00:26.716505||3||0
+2015-12-01 21:47:54.069129||error||collecting ads||Error||1||1
+2015-12-01 21:48:01.608034||measurement||price||2015-12-01 21:47:55.029048@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:48:04.523967||measurement||price||2015-12-01 21:47:57.711617@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 21:48:04.580242||measurement||price||2015-12-01 21:47:46.821733@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:48:05.591275||measurement||price||2015-12-01 21:47:59.893715@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:48:08.135075||measurement||price||2015-12-01 21:48:01.450667@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:48:08.225006||error||collecting ads||Error||0||0
+2015-12-01 21:48:11.702611||measurement||loadtime||0:00:26.880734||4||0
+2015-12-01 21:48:14.432565||measurement||price||2015-12-01 21:47:55.029048@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:48:17.497578||measurement||price||2015-12-01 21:47:57.711617@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 21:48:17.914633||measurement||price||2015-12-01 21:47:59.893715@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:48:20.697752||measurement||price||2015-12-01 21:48:15.325626@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:48:21.058108||measurement||price||2015-12-01 21:48:01.450667@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:48:21.635009||measurement||loadtime||0:00:28.971857||5||1
+2015-12-01 21:48:24.140283||measurement||price||2015-12-01 21:48:18.742157@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:48:24.695739||measurement||loadtime||0:00:29.336937||2||1
+2015-12-01 21:48:25.030595||measurement||loadtime||0:00:26.884610||3||0
+2015-12-01 21:48:28.233632||measurement||loadtime||0:00:29.162477||1||1
+2015-12-01 21:48:33.013344||measurement||price||2015-12-01 21:48:15.325626@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:48:36.451472||measurement||price||2015-12-01 21:48:18.742157@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:48:37.387299||measurement||price||2015-12-01 21:48:31.723448@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:48:38.552416||measurement||price||2015-12-01 21:48:32.071331@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:48:40.130977||measurement||loadtime||0:00:26.905423||0||0
+2015-12-01 21:48:41.965516||measurement||price||2015-12-01 21:48:35.432108@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:48:43.555442||measurement||loadtime||0:00:26.847639||4||0
+2015-12-01 21:48:45.511448||error||collecting ads||Error||5||1
+2015-12-01 21:48:49.710667||measurement||price||2015-12-01 21:48:31.723448@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:48:51.551747||measurement||price||2015-12-01 21:48:32.071331@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:48:55.012498||measurement||price||2015-12-01 21:48:35.432108@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:48:55.166934||measurement||price||2015-12-01 21:48:49.778292@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:48:56.116708||measurement||price||2015-12-01 21:48:50.712545@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:48:56.832462||measurement||loadtime||0:00:26.796671||3||0
+2015-12-01 21:48:58.769047||measurement||loadtime||0:00:29.068561||2||1
+2015-12-01 21:48:59.422673||measurement||price||2015-12-01 21:48:52.887230@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:49:02.222286||measurement||loadtime||0:00:28.983436||1||1
+2015-12-01 21:49:07.515130||measurement||price||2015-12-01 21:48:49.778292@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:49:08.421965||measurement||price||2015-12-01 21:48:50.712545@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:49:09.201807||measurement||price||2015-12-01 21:49:03.593537@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 21:49:12.238341||measurement||price||2015-12-01 21:48:52.887230@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:49:12.723887||measurement||price||2015-12-01 21:49:06.111523@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:49:14.627457||measurement||loadtime||0:00:29.491263||0||0
+2015-12-01 21:49:15.513529||measurement||loadtime||0:00:26.952883||4||0
+2015-12-01 21:49:16.072415||measurement||price||2015-12-01 21:49:09.531844@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:49:19.440447||measurement||loadtime||0:00:28.928112||5||1
+2015-12-01 21:49:21.541215||measurement||price||2015-12-01 21:49:03.593537@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 21:49:25.526649||measurement||price||2015-12-01 21:49:06.111523@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:49:27.191607||measurement||price||2015-12-01 21:49:21.772468@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:49:28.071909||measurement||price||2015-12-01 21:49:22.686237@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:49:28.655159||measurement||loadtime||0:00:26.821368||3||0
+2015-12-01 21:49:28.892857||measurement||price||2015-12-01 21:49:09.531844@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:49:32.727825||measurement||loadtime||0:00:28.956640||2||1
+2015-12-01 21:49:33.293678||measurement||price||2015-12-01 21:49:26.836227@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 21:49:36.091145||measurement||loadtime||0:00:28.865874||1||1
+2015-12-01 21:49:39.516272||measurement||price||2015-12-01 21:49:21.772468@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:49:40.398672||measurement||price||2015-12-01 21:49:22.686237@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:49:46.161112||measurement||price||2015-12-01 21:49:26.836227@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 21:49:46.619149||measurement||loadtime||0:00:26.986492||0||0
+2015-12-01 21:49:47.507146||measurement||loadtime||0:00:26.988430||4||0
+2015-12-01 21:49:50.850273||error||collecting ads||Error||3||0
+2015-12-01 21:49:53.352614||measurement||loadtime||0:00:28.906968||5||1
+2015-12-01 21:49:56.843827||error||collecting ads||Error||2||1
+2015-12-01 21:49:59.176250||measurement||price||2015-12-01 21:49:53.750747@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:49:59.934967||error||collecting ads||Error||1||1
+2015-12-01 21:50:03.319588||measurement||price||2015-12-01 21:49:57.682783@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:50:07.121167||measurement||price||2015-12-01 21:50:00.637512@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:50:09.965853||error||collecting ads||Error||4||0
+2015-12-01 21:50:10.766737||measurement||price||2015-12-01 21:50:04.036856@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 21:50:11.511537||measurement||price||2015-12-01 21:49:53.750747@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:50:13.822055||measurement||price||2015-12-01 21:50:07.278701@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:50:15.651892||measurement||price||2015-12-01 21:49:57.682783@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:50:18.621238||measurement||loadtime||0:00:26.996905||0||0
+2015-12-01 21:50:19.937731||measurement||price||2015-12-01 21:50:00.637512@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:50:22.373381||measurement||price||2015-12-01 21:50:16.987802@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:50:22.756784||measurement||loadtime||0:00:26.904246||3||0
+2015-12-01 21:50:23.762898||measurement||price||2015-12-01 21:50:04.036856@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 21:50:26.711434||measurement||price||2015-12-01 21:50:07.278701@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:50:27.154208||measurement||loadtime||0:00:28.801015||5||1
+2015-12-01 21:50:30.981859||measurement||loadtime||0:00:29.130740||2||1
+2015-12-01 21:50:31.046604||measurement||price||2015-12-01 21:50:25.693327@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 21:50:33.891447||measurement||loadtime||0:00:28.951231||1||1
+2015-12-01 21:50:34.665812||measurement||price||2015-12-01 21:50:16.987802@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:50:41.116675||measurement||price||2015-12-01 21:50:34.388456@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:50:41.771282||measurement||loadtime||0:00:26.800227||4||0
+2015-12-01 21:50:43.360244||measurement||price||2015-12-01 21:50:25.693327@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 21:50:45.022006||error||collecting ads||Error||3||0
+2015-12-01 21:50:47.617741||measurement||price||2015-12-01 21:50:41.189938@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:50:50.471192||measurement||loadtime||0:00:26.847812||0||0
+2015-12-01 21:50:54.095589||measurement||price||2015-12-01 21:50:34.388456@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:50:54.282995||measurement||price||2015-12-01 21:50:48.843271@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 21:50:54.656376||error||collecting ads||Error||2||1
+2015-12-01 21:51:00.419936||measurement||price||2015-12-01 21:50:41.189938@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:51:01.307167||measurement||loadtime||0:00:29.147775||5||1
+2015-12-01 21:51:02.909159||measurement||price||2015-12-01 21:50:57.512291@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:51:06.593936||measurement||price||2015-12-01 21:50:48.843271@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 21:51:07.262254||error||collecting ads||Error||3||0
+2015-12-01 21:51:07.648308||measurement||loadtime||0:00:28.751674||1||1
+2015-12-01 21:51:13.693117||measurement||loadtime||0:00:26.916638||4||0
+2015-12-01 21:51:15.253075||measurement||price||2015-12-01 21:50:57.512291@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:51:15.263047||measurement||price||2015-12-01 21:51:08.566933@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:51:18.779135||error||collecting ads||Error||2||1
+2015-12-01 21:51:19.515273||measurement||price||2015-12-01 21:51:13.879537@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:51:21.494933||measurement||price||2015-12-01 21:51:14.919878@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:51:22.365562||measurement||loadtime||0:00:26.889351||0||0
+2015-12-01 21:51:26.015875||measurement||price||2015-12-01 21:51:20.683427@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:51:28.293594||measurement||price||2015-12-01 21:51:08.566933@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:51:31.839104||measurement||price||2015-12-01 21:51:13.879537@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:51:32.465763||measurement||price||2015-12-01 21:51:26.004510@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 21:51:34.320860||measurement||price||2015-12-01 21:51:14.919878@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:51:34.972596||measurement||price||2015-12-01 21:51:29.529056@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 21:51:35.513437||measurement||loadtime||0:00:29.202276||5||1
+2015-12-01 21:51:38.354669||measurement||price||2015-12-01 21:51:20.683427@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:51:38.956355||measurement||loadtime||0:00:26.688892||3||0
+2015-12-01 21:51:41.515155||measurement||loadtime||0:00:28.861658||1||1
+2015-12-01 21:51:45.411299||measurement||price||2015-12-01 21:51:26.004510@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 21:51:45.471156||measurement||loadtime||0:00:26.772838||4||0
+2015-12-01 21:51:47.307992||measurement||price||2015-12-01 21:51:29.529056@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 21:51:49.173059||measurement||price||2015-12-01 21:51:42.797258@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 21:51:51.257047||measurement||price||2015-12-01 21:51:45.689753@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 21:51:52.759158||measurement||loadtime||0:00:28.974773||2||1
+2015-12-01 21:51:54.418599||measurement||loadtime||0:00:27.051470||0||0
+2015-12-01 21:51:55.421983||measurement||price||2015-12-01 21:51:48.831472@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:51:57.887628||measurement||price||2015-12-01 21:51:52.526704@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 21:52:02.104307||measurement||price||2015-12-01 21:51:42.797258@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 21:52:03.575580||measurement||price||2015-12-01 21:51:45.689753@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 21:52:07.102642||measurement||price||2015-12-01 21:52:00.262205@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 21:52:07.445337||measurement||price||2015-12-01 21:52:02.005784@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||0||0
+2015-12-01 21:52:08.440405||measurement||price||2015-12-01 21:51:48.831472@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:52:09.309476||measurement||loadtime||0:00:28.794329||5||1
+2015-12-01 21:52:10.217253||measurement||price||2015-12-01 21:51:52.526704@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 21:52:10.696348||measurement||loadtime||0:00:26.734802||3||0
+2015-12-01 21:52:15.648160||measurement||loadtime||0:00:29.132810||1||1
+2015-12-01 21:52:17.319073||measurement||loadtime||0:00:26.842691||4||0
+2015-12-01 21:52:19.793497||measurement||price||2015-12-01 21:52:02.005784@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||0||0
+2015-12-01 21:52:19.958642||measurement||price||2015-12-01 21:52:00.262205@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 21:52:22.986354||measurement||price||2015-12-01 21:52:17.352448@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 21:52:23.406047||measurement||price||2015-12-01 21:52:16.653945@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:52:26.898460||measurement||loadtime||0:00:27.474661||0||0
+2015-12-01 21:52:27.171179||measurement||loadtime||0:00:29.406849||2||1
+2015-12-01 21:52:29.434928||measurement||price||2015-12-01 21:52:23.120981@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:52:29.965076||measurement||price||2015-12-01 21:52:24.542083@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 21:52:35.317599||measurement||price||2015-12-01 21:52:17.352448@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 21:52:36.443101||measurement||price||2015-12-01 21:52:16.653945@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:52:39.784255||measurement||price||2015-12-01 21:52:34.264053@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 21:52:42.274623||measurement||price||2015-12-01 21:52:24.542083@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 21:52:42.359291||measurement||price||2015-12-01 21:52:23.120981@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:52:42.431163||measurement||loadtime||0:00:26.729647||3||0
+2015-12-01 21:52:42.431253||event||progress-marker||measurement-end||3||0
+2015-12-01 21:52:43.660277||measurement||loadtime||0:00:29.349117||5||1
+2015-12-01 21:52:49.362778||measurement||loadtime||0:00:27.040404||4||0
+2015-12-01 21:52:49.362909||event||progress-marker||measurement-end||4||0
+2015-12-01 21:52:49.559214||measurement||loadtime||0:00:28.905867||1||1
+2015-12-01 21:52:50.968641||error||collecting ads||Error||2||1
+2015-12-01 21:52:52.081245||measurement||price||2015-12-01 21:52:34.264053@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 21:52:59.163623||measurement||loadtime||0:00:27.259965||0||0
+2015-12-01 21:52:59.163744||event||progress-marker||measurement-end||0||0
+2015-12-01 21:53:05.001664||measurement||price||2015-12-01 21:52:58.233336@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 21:53:07.527533||error||collecting ads||Error||5||1
+2015-12-01 21:53:13.279724||error||collecting ads||Error||1||1
+2015-12-01 21:53:17.997241||measurement||price||2015-12-01 21:52:58.233336@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 21:53:25.315162||measurement||loadtime||0:00:29.343988||2||1
+2015-12-01 21:53:31.418801||error||collecting ads||Error||5||1
+2015-12-01 21:53:37.015771||error||collecting ads||Error||1||1
+2015-12-01 21:53:39.183860||measurement||price||2015-12-01 21:53:32.562369@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 21:53:45.207729||measurement||price||2015-12-01 21:53:38.619657@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:53:50.671108||measurement||price||2015-12-01 21:53:44.216881@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 21:53:52.051184||measurement||price||2015-12-01 21:53:32.562369@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 21:53:58.131557||measurement||price||2015-12-01 21:53:38.619657@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:53:59.254517||measurement||loadtime||0:00:28.935387||2||1
+2015-12-01 21:54:03.444250||measurement||price||2015-12-01 21:53:44.216881@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 21:54:05.313490||measurement||loadtime||0:00:28.890349||5||1
+2015-12-01 21:54:10.643142||measurement||loadtime||0:00:28.622170||1||1
+2015-12-01 21:54:13.471646||measurement||price||2015-12-01 21:54:07.120152@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||2||1
+2015-12-01 21:54:24.426979||measurement||price||2015-12-01 21:54:17.951991@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 21:54:26.396215||measurement||price||2015-12-01 21:54:07.120152@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||1
+2015-12-01 21:54:29.012770||error||collecting ads||Error||5||1
+2015-12-01 21:54:33.614783||measurement||loadtime||0:00:29.358296||2||1
+2015-12-01 21:54:37.220020||measurement||price||2015-12-01 21:54:17.951991@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 21:54:42.844178||measurement||price||2015-12-01 21:54:36.137659@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:54:44.405023||measurement||loadtime||0:00:28.756691||1||1
+2015-12-01 21:54:47.434044||measurement||price||2015-12-01 21:54:41.236032@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:54:55.726400||measurement||price||2015-12-01 21:54:36.137659@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:54:58.226888||measurement||price||2015-12-01 21:54:51.721331@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:55:00.300402||measurement||price||2015-12-01 21:54:41.236032@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:55:02.909731||measurement||loadtime||0:00:28.891706||5||1
+2015-12-01 21:55:07.495200||measurement||loadtime||0:00:28.875170||2||1
+2015-12-01 21:55:11.115214||measurement||price||2015-12-01 21:54:51.721331@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:55:16.452224||measurement||price||2015-12-01 21:55:10.107828@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 21:55:18.315833||measurement||loadtime||0:00:28.905595||1||1
+2015-12-01 21:55:21.285359||measurement||price||2015-12-01 21:55:14.857511@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 21:55:29.289486||measurement||price||2015-12-01 21:55:10.107828@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 21:55:31.868449||measurement||price||2015-12-01 21:55:25.582891@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 21:55:34.138808||measurement||price||2015-12-01 21:55:14.857511@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 21:55:36.474526||measurement||loadtime||0:00:28.559596||5||1
+2015-12-01 21:55:41.339144||measurement||loadtime||0:00:28.840024||2||1
+2015-12-01 21:55:44.658096||measurement||price||2015-12-01 21:55:25.582891@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 21:55:50.241094||measurement||price||2015-12-01 21:55:44.001466@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:55:51.859876||measurement||loadtime||0:00:28.543091||1||1
+2015-12-01 21:55:51.859996||event||progress-marker||measurement-end||1||1
+2015-12-01 21:55:54.947005||measurement||price||2015-12-01 21:55:48.637114@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 21:56:03.055574||measurement||price||2015-12-01 21:55:44.001466@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 21:56:07.854440||measurement||price||2015-12-01 21:55:48.637114@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 21:56:10.252634||measurement||loadtime||0:00:28.773506||5||1
+2015-12-01 21:56:10.252731||event||progress-marker||measurement-end||5||1
+2015-12-01 21:56:15.052602||measurement||loadtime||0:00:28.712975||2||1
+2015-12-01 21:56:15.052691||event||progress-marker||measurement-end||2||1
+2015-12-01 21:56:15.614426||meta||block_id end||6
+2015-12-01 21:56:15.614768||meta||block_id start||7
+2015-12-01 21:56:15.614797||meta||assignment||2@|3@|1@|0@|5@|4
+2015-12-01 21:56:17.240867||event||progress-marker||training-start||1||0
+2015-12-01 21:56:17.257166||event||progress-marker||training-start||2||0
+2015-12-01 21:56:23.755136||treatment||visit website||http://irs.gov||1||0
+2015-12-01 21:56:23.770504||treatment||visit website||http://irs.gov||2||0
+2015-12-01 21:56:31.270014||treatment||visit website||http://deloitte.com||1||0
+2015-12-01 21:56:31.275125||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 21:56:39.583120||treatment||visit website||http://pwc.com||1||0
+2015-12-01 21:56:45.434044||treatment||visit website||http://ey.com||1||0
+2015-12-01 21:56:52.551181||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 21:56:52.551319||event||progress-marker||training-end||1||0
+2015-12-01 21:57:11.495007||error||website timeout||http://pwc.com||2||0
+2015-12-01 21:57:17.251250||treatment||visit website||http://ey.com||2||0
+2015-12-01 21:57:24.117151||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 21:57:24.117265||event||progress-marker||training-end||2||0
+2015-12-01 21:57:27.651433||event||progress-marker||measurement-start||1||0
+2015-12-01 21:57:29.138204||event||progress-marker||measurement-start||2||0
+2015-12-01 21:57:42.383142||measurement||price||2015-12-01 21:57:36.559572@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:57:49.112968||event||progress-marker||training-start||5||1
+2015-12-01 21:57:50.175971||event||progress-marker||training-start||4||1
+2015-12-01 21:57:50.445900||error||collecting ads||Error||1||0
+2015-12-01 21:57:54.744055||measurement||price||2015-12-01 21:57:36.559572@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:57:55.917351||treatment||visit website||http://irs.gov||5||1
+2015-12-01 21:57:56.581251||treatment||visit website||http://irs.gov||4||1
+2015-12-01 21:58:01.854603||measurement||loadtime||0:00:27.711211||2||0
+2015-12-01 21:58:02.534185||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 21:58:02.799887||measurement||price||2015-12-01 21:57:57.077784@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 21:58:03.865310||treatment||visit website||http://deloitte.com||4||1
+2015-12-01 21:58:14.421218||measurement||price||2015-12-01 21:58:09.098397@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 21:58:15.139091||measurement||price||2015-12-01 21:57:57.077784@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 21:58:17.395620||treatment||visit website||http://pwc.com||4||1
+2015-12-01 21:58:22.227713||measurement||loadtime||0:00:26.776625||1||0
+2015-12-01 21:58:23.351119||treatment||visit website||http://ey.com||4||1
+2015-12-01 21:58:26.748473||measurement||price||2015-12-01 21:58:09.098397@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 21:58:27.979801||event||progress-marker||training-start||0||1
+2015-12-01 21:58:31.195738||treatment||visit website||http://kpmg.com||4||1
+2015-12-01 21:58:31.195869||event||progress-marker||training-end||4||1
+2015-12-01 21:58:32.717615||treatment||visit website||http://pwc.com||5||1
+2015-12-01 21:58:33.854999||measurement||loadtime||0:00:26.995201||2||0
+2015-12-01 21:58:34.563130||treatment||visit website||http://irs.gov||0||1
+2015-12-01 21:58:38.603141||treatment||visit website||http://ey.com||5||1
+2015-12-01 21:58:40.983116||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 21:58:44.485540||error||collecting ads||Error||1||0
+2015-12-01 21:58:45.031860||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 21:58:45.031967||event||progress-marker||training-end||5||1
+2015-12-01 21:58:46.546312||measurement||price||2015-12-01 21:58:41.109962@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:58:56.728289||measurement||price||2015-12-01 21:58:51.072964@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 21:58:58.844976||measurement||price||2015-12-01 21:58:41.109962@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:59:05.928295||measurement||loadtime||0:00:27.069134||2||0
+2015-12-01 21:59:09.047930||measurement||price||2015-12-01 21:58:51.072964@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 21:59:16.161559||measurement||loadtime||0:00:26.670785||1||0
+2015-12-01 21:59:21.004634||error||website timeout||http://pwc.com||0||1
+2015-12-01 21:59:26.043715||treatment||visit website||http://ey.com||0||1
+2015-12-01 21:59:28.346682||measurement||price||2015-12-01 21:59:22.806229@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 21:59:28.549019||error||collecting ads||Error||2||0
+2015-12-01 21:59:33.198076||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 21:59:33.198212||event||progress-marker||training-end||0||1
+2015-12-01 21:59:35.187302||event||progress-marker||measurement-start||5||1
+2015-12-01 21:59:36.367762||event||progress-marker||measurement-start||4||1
+2015-12-01 21:59:38.220080||event||progress-marker||measurement-start||0||1
+2015-12-01 21:59:40.671452||measurement||price||2015-12-01 21:59:22.806229@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 21:59:41.151897||measurement||price||2015-12-01 21:59:35.661353@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 21:59:47.789724||measurement||loadtime||0:00:26.626594||1||0
+2015-12-01 21:59:51.413398||measurement||price||2015-12-01 21:59:44.948009@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 21:59:52.250167||measurement||price||2015-12-01 21:59:45.804959@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 21:59:53.482698||measurement||price||2015-12-01 21:59:35.661353@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 21:59:53.675673||measurement||price||2015-12-01 21:59:47.042305@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 21:59:59.977634||measurement||price||2015-12-01 21:59:54.393032@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 22:00:00.607165||measurement||loadtime||0:00:27.052834||2||0
+2015-12-01 22:00:04.397112||measurement||price||2015-12-01 21:59:44.948009@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:00:05.165105||measurement||price||2015-12-01 21:59:45.804959@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 22:00:06.689788||measurement||price||2015-12-01 21:59:47.042305@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:00:11.674485||measurement||loadtime||0:00:30.301507||4||1
+2015-12-01 22:00:12.306876||measurement||price||2015-12-01 21:59:54.393032@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 22:00:12.391046||measurement||loadtime||0:00:32.199853||5||1
+2015-12-01 22:00:13.596047||measurement||price||2015-12-01 22:00:08.223052@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||2||0
+2015-12-01 22:00:13.951169||measurement||loadtime||0:00:30.728021||0||1
+2015-12-01 22:00:19.412720||measurement||loadtime||0:00:26.621588||1||0
+2015-12-01 22:00:25.378608||measurement||price||2015-12-01 22:00:19.131612@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 22:00:25.909100||measurement||price||2015-12-01 22:00:08.223052@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 22:00:27.843569||measurement||price||2015-12-01 22:00:21.792699@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:00:31.573067||measurement||price||2015-12-01 22:00:25.949396@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 22:00:32.987171||measurement||loadtime||0:00:27.374782||2||0
+2015-12-01 22:00:36.356242||error||collecting ads||Error||5||1
+2015-12-01 22:00:38.184264||measurement||price||2015-12-01 22:00:19.131612@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:00:40.710915||measurement||price||2015-12-01 22:00:21.792699@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:00:43.906993||measurement||price||2015-12-01 22:00:25.949396@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 22:00:45.406989||measurement||loadtime||0:00:28.727282||4||1
+2015-12-01 22:00:45.511934||measurement||price||2015-12-01 22:00:40.144613@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 22:00:47.926850||measurement||loadtime||0:00:28.970477||0||1
+2015-12-01 22:00:51.017939||measurement||loadtime||0:00:26.602772||1||0
+2015-12-01 22:00:57.839379||measurement||price||2015-12-01 22:00:40.144613@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 22:01:00.175475||error||collecting ads||Error||5||1
+2015-12-01 22:01:01.942591||measurement||price||2015-12-01 22:00:55.822262@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:01:03.352946||measurement||price||2015-12-01 22:00:57.671224@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 22:01:04.962075||measurement||loadtime||0:00:26.970330||2||0
+2015-12-01 22:01:09.207437||error||collecting ads||Error||4||1
+2015-12-01 22:01:14.870785||measurement||price||2015-12-01 22:00:55.822262@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:01:15.682188||measurement||price||2015-12-01 22:00:57.671224@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 22:01:17.569708||measurement||price||2015-12-01 22:01:12.250535@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:01:22.079717||measurement||loadtime||0:00:29.148581||0||1
+2015-12-01 22:01:22.767235||measurement||price||2015-12-01 22:01:16.400227@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 22:01:22.786185||measurement||loadtime||0:00:26.763069||1||0
+2015-12-01 22:01:23.764607||error||collecting ads||Error||5||1
+2015-12-01 22:01:29.914291||measurement||price||2015-12-01 22:01:12.250535@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:01:35.768780||measurement||price||2015-12-01 22:01:16.400227@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:01:36.391819||measurement||price||2015-12-01 22:01:30.042977@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:01:37.047143||measurement||loadtime||0:00:27.084795||2||0
+2015-12-01 22:01:37.686910||measurement||price||2015-12-01 22:01:31.539579@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 22:01:42.967191||measurement||loadtime||0:00:28.754550||4||1
+2015-12-01 22:01:45.014772||error||collecting ads||Error||1||0
+2015-12-01 22:01:49.482544||measurement||price||2015-12-01 22:01:30.042977@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:01:49.826036||measurement||price||2015-12-01 22:01:44.407403@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:01:50.675862||measurement||price||2015-12-01 22:01:31.539579@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 22:01:56.582923||measurement||price||2015-12-01 22:01:50.200390@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 22:01:56.679078||measurement||loadtime||0:00:29.594132||0||1
+2015-12-01 22:01:57.290661||measurement||price||2015-12-01 22:01:51.696094@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 22:01:57.872805||measurement||loadtime||0:00:29.105650||5||1
+2015-12-01 22:02:02.169317||measurement||price||2015-12-01 22:01:44.407403@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:02:09.271567||measurement||loadtime||0:00:27.220419||2||0
+2015-12-01 22:02:09.487607||measurement||price||2015-12-01 22:01:50.200390@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:02:09.641609||measurement||price||2015-12-01 22:01:51.696094@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 22:02:10.456395||measurement||price||2015-12-01 22:02:04.484707@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 22:02:11.784777||measurement||price||2015-12-01 22:02:05.679203@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 22:02:16.719445||measurement||loadtime||0:00:28.748292||4||1
+2015-12-01 22:02:16.755163||measurement||loadtime||0:00:26.736948||1||0
+2015-12-01 22:02:21.805530||measurement||price||2015-12-01 22:02:16.405704@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:02:23.288675||measurement||price||2015-12-01 22:02:04.484707@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 22:02:24.678080||measurement||price||2015-12-01 22:02:05.679203@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 22:02:29.376222||measurement||price||2015-12-01 22:02:23.907733@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||0
+2015-12-01 22:02:30.515129||measurement||loadtime||0:00:28.834358||0||1
+2015-12-01 22:02:30.581961||measurement||price||2015-12-01 22:02:23.970761@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 22:02:31.903924||measurement||loadtime||0:00:29.028769||5||1
+2015-12-01 22:02:34.139731||measurement||price||2015-12-01 22:02:16.405704@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:02:41.250181||measurement||loadtime||0:00:26.976771||2||0
+2015-12-01 22:02:41.691504||measurement||price||2015-12-01 22:02:23.907733@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||0
+2015-12-01 22:02:43.580974||measurement||price||2015-12-01 22:02:23.970761@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 22:02:44.719621||measurement||price||2015-12-01 22:02:38.169953@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:02:45.710166||measurement||price||2015-12-01 22:02:39.531940@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 22:02:48.799175||measurement||loadtime||0:00:27.040033||1||0
+2015-12-01 22:02:50.780881||measurement||loadtime||0:00:29.056267||4||1
+2015-12-01 22:02:57.652744||measurement||price||2015-12-01 22:02:38.169953@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:02:58.587906||measurement||price||2015-12-01 22:02:39.531940@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 22:03:00.994133||measurement||price||2015-12-01 22:02:55.404488@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 22:03:03.825014||error||collecting ads||Error||2||0
+2015-12-01 22:03:04.440144||measurement||price||2015-12-01 22:02:57.987633@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 22:03:04.847168||measurement||loadtime||0:00:29.326863||0||1
+2015-12-01 22:03:05.787149||measurement||loadtime||0:00:28.880009||5||1
+2015-12-01 22:03:13.334280||measurement||price||2015-12-01 22:02:55.404488@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 22:03:16.457761||measurement||price||2015-12-01 22:03:11.067979@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 22:03:17.388415||measurement||price||2015-12-01 22:02:57.987633@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:03:19.050558||measurement||price||2015-12-01 22:03:12.925207@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:03:19.770179||measurement||price||2015-12-01 22:03:13.506624@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 22:03:20.454320||measurement||loadtime||0:00:26.651190||1||0
+2015-12-01 22:03:24.589941||measurement||loadtime||0:00:28.806796||4||1
+2015-12-01 22:03:28.776316||measurement||price||2015-12-01 22:03:11.067979@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 22:03:32.116828||measurement||price||2015-12-01 22:03:12.925207@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:03:32.620546||measurement||price||2015-12-01 22:03:13.506624@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 22:03:32.778389||measurement||price||2015-12-01 22:03:27.198729@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 22:03:35.880743||measurement||loadtime||0:00:27.050485||2||0
+2015-12-01 22:03:38.192067||measurement||price||2015-12-01 22:03:31.743300@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 22:03:39.341091||measurement||loadtime||0:00:29.489940||0||1
+2015-12-01 22:03:39.819141||measurement||loadtime||0:00:29.026807||5||1
+2015-12-01 22:03:45.109949||measurement||price||2015-12-01 22:03:27.198729@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 22:03:48.445830||measurement||price||2015-12-01 22:03:43.049344@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 22:03:51.122114||measurement||price||2015-12-01 22:03:31.743300@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 22:03:52.219632||measurement||loadtime||0:00:26.760132||1||0
+2015-12-01 22:03:52.936929||measurement||price||2015-12-01 22:03:46.985806@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 22:03:58.335507||measurement||loadtime||0:00:28.740333||4||1
+2015-12-01 22:04:00.772326||measurement||price||2015-12-01 22:03:43.049344@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 22:04:03.445974||error||collecting ads||Error||5||1
+2015-12-01 22:04:04.774161||measurement||price||2015-12-01 22:03:59.147987@|@|$37.46@|OtterBox DEFENDER iPhone 6/6s Case - Retail Packaging - BLACK||1||0
+2015-12-01 22:04:05.915179||measurement||price||2015-12-01 22:03:46.985806@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 22:04:07.887146||measurement||loadtime||0:00:27.004030||2||0
+2015-12-01 22:04:12.629594||measurement||price||2015-12-01 22:04:06.344969@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 22:04:13.113424||measurement||loadtime||0:00:28.768106||0||1
+2015-12-01 22:04:17.119142||measurement||price||2015-12-01 22:03:59.147987@|@|$18.89@|OtterBox COMMUTER iPhone 6/6s Case - Frustration-Free Packag...||1||0
+2015-12-01 22:04:17.175467||measurement||price||2015-12-01 22:04:11.014199@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 22:04:20.490039||measurement||price||2015-12-01 22:04:15.057188@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 22:04:24.230643||measurement||loadtime||0:00:27.007198||1||0
+2015-12-01 22:04:25.648937||measurement||price||2015-12-01 22:04:06.344969@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 22:04:26.831609||measurement||price||2015-12-01 22:04:20.567600@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:04:30.018466||measurement||price||2015-12-01 22:04:11.014199@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 22:04:32.806256||measurement||price||2015-12-01 22:04:15.057188@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 22:04:32.887537||measurement||loadtime||0:00:29.548388||4||1
+2015-12-01 22:04:36.430815||measurement||price||2015-12-01 22:04:30.879209@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 22:04:37.221292||measurement||loadtime||0:00:28.770149||5||1
+2015-12-01 22:04:39.698237||measurement||price||2015-12-01 22:04:20.567600@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:04:39.892564||measurement||loadtime||0:00:27.002475||2||0
+2015-12-01 22:04:46.927154||measurement||loadtime||0:00:28.808543||0||1
+2015-12-01 22:04:48.761817||measurement||price||2015-12-01 22:04:30.879209@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 22:04:55.863165||measurement||loadtime||0:00:26.629457||1||0
+2015-12-01 22:04:56.226455||error||collecting ads||Error||4||1
+2015-12-01 22:05:00.509039||measurement||price||2015-12-01 22:04:54.439002@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:05:00.995130||error||collecting ads||Error||5||1
+2015-12-01 22:05:02.398809||error||collecting ads||Error||2||0
+2015-12-01 22:05:10.353773||measurement||price||2015-12-01 22:05:03.515654@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 22:05:13.377838||measurement||price||2015-12-01 22:04:54.439002@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:05:14.755940||measurement||price||2015-12-01 22:05:08.596289@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 22:05:15.632633||measurement||price||2015-12-01 22:05:10.276480@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-01 22:05:18.152882||error||collecting ads||Error||1||0
+2015-12-01 22:05:20.590963||measurement||loadtime||0:00:28.658600||0||1
+2015-12-01 22:05:23.202256||measurement||price||2015-12-01 22:05:03.515654@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:05:27.513946||measurement||price||2015-12-01 22:05:08.596289@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 22:05:27.984629||measurement||price||2015-12-01 22:05:10.276480@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-01 22:05:30.272309||measurement||price||2015-12-01 22:05:24.681240@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 22:05:30.454632||measurement||loadtime||0:00:29.223478||4||1
+2015-12-01 22:05:34.480728||measurement||price||2015-12-01 22:05:28.398776@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 22:05:34.730970||measurement||loadtime||0:00:28.731839||5||1
+2015-12-01 22:05:35.098924||measurement||loadtime||0:00:27.694916||2||0
+2015-12-01 22:05:42.597822||measurement||price||2015-12-01 22:05:24.681240@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 22:05:44.493626||measurement||price||2015-12-01 22:05:38.330047@|Makita@|$549.00@|Makita XT601 18-volt LXT Lithium-Ion Cordless Combo Kit, 6-P...||4||1
+2015-12-01 22:05:47.362052||measurement||price||2015-12-01 22:05:28.398776@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 22:05:48.001030||measurement||price||2015-12-01 22:05:42.572930@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:05:48.434116||measurement||price||2015-12-01 22:05:42.339837@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 22:05:49.724270||measurement||loadtime||0:00:26.569141||1||0
+2015-12-01 22:05:54.556754||measurement||loadtime||0:00:28.960530||0||1
+2015-12-01 22:05:57.287092||measurement||price||2015-12-01 22:05:38.330047@|Makita@|$469.00@|Makita BBX7600N 75.6 CC 4-Stroke Backpack Blower||4||1
+2015-12-01 22:06:00.336374||measurement||price||2015-12-01 22:05:42.572930@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:06:01.289786||measurement||price||2015-12-01 22:05:42.339837@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 22:06:01.953657||measurement||price||2015-12-01 22:05:56.334706@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 22:06:04.525964||measurement||loadtime||0:00:29.066136||4||1
+2015-12-01 22:06:07.442791||measurement||loadtime||0:00:27.339645||2||0
+2015-12-01 22:06:08.513048||measurement||price||2015-12-01 22:06:02.246057@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:06:08.519121||measurement||loadtime||0:00:28.782927||5||1
+2015-12-01 22:06:14.281049||measurement||price||2015-12-01 22:05:56.334706@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 22:06:18.033977||measurement||price||2015-12-01 22:06:11.609453@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 22:06:21.391150||measurement||loadtime||0:00:26.665386||1||0
+2015-12-01 22:06:21.497537||measurement||price||2015-12-01 22:06:02.246057@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:06:22.393452||measurement||price||2015-12-01 22:06:16.224183@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 22:06:28.699165||measurement||loadtime||0:00:29.137183||0||1
+2015-12-01 22:06:30.092115||error||collecting ads||Error||2||0
+2015-12-01 22:06:30.787781||measurement||price||2015-12-01 22:06:11.609453@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 22:06:33.603346||measurement||price||2015-12-01 22:06:27.986502@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 22:06:35.242558||measurement||price||2015-12-01 22:06:16.224183@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 22:06:37.983163||measurement||loadtime||0:00:28.452921||4||1
+2015-12-01 22:06:42.439148||measurement||loadtime||0:00:28.916019||5||1
+2015-12-01 22:06:45.933508||measurement||price||2015-12-01 22:06:27.986502@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 22:06:52.608250||error||collecting ads||Error||0||1
+2015-12-01 22:06:52.625508||error||collecting ads||Error||2||0
+2015-12-01 22:06:53.049564||measurement||loadtime||0:00:26.653202||1||0
+2015-12-01 22:06:56.171679||measurement||price||2015-12-01 22:06:50.055114@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 22:07:01.807704||error||collecting ads||Error||4||1
+2015-12-01 22:07:05.380282||measurement||price||2015-12-01 22:06:59.798999@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 22:07:05.445775||measurement||price||2015-12-01 22:06:59.987074@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 22:07:06.530646||measurement||price||2015-12-01 22:07:00.448091@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 22:07:09.070478||measurement||price||2015-12-01 22:06:50.055114@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 22:07:15.450009||measurement||price||2015-12-01 22:07:08.960011@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 22:07:16.254771||measurement||loadtime||0:00:28.811643||5||1
+2015-12-01 22:07:17.716427||measurement||price||2015-12-01 22:06:59.798999@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 22:07:17.787540||measurement||price||2015-12-01 22:06:59.987074@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 22:07:19.362139||measurement||price||2015-12-01 22:07:00.448091@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 22:07:24.821510||measurement||loadtime||0:00:26.766761||1||0
+2015-12-01 22:07:24.821602||event||progress-marker||measurement-end||1||0
+2015-12-01 22:07:24.891188||measurement||loadtime||0:00:27.264047||2||0
+2015-12-01 22:07:24.891279||event||progress-marker||measurement-end||2||0
+2015-12-01 22:07:26.556542||measurement||loadtime||0:00:28.945401||0||1
+2015-12-01 22:07:28.268618||measurement||price||2015-12-01 22:07:08.960011@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 22:07:35.477964||measurement||loadtime||0:00:28.666009||4||1
+2015-12-01 22:07:40.029588||error||collecting ads||Error||5||1
+2015-12-01 22:07:49.225928||measurement||price||2015-12-01 22:07:42.688813@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 22:07:50.412895||error||collecting ads||Error||0||1
+2015-12-01 22:07:53.669282||measurement||price||2015-12-01 22:07:47.535344@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 22:08:02.104784||measurement||price||2015-12-01 22:07:42.688813@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 22:08:04.054298||measurement||price||2015-12-01 22:07:57.898277@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:08:06.491013||measurement||price||2015-12-01 22:07:47.535344@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 22:08:09.302910||measurement||loadtime||0:00:28.819755||4||1
+2015-12-01 22:08:13.694596||measurement||loadtime||0:00:28.659783||5||1
+2015-12-01 22:08:17.072554||measurement||price||2015-12-01 22:07:57.898277@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:08:24.271396||measurement||loadtime||0:00:28.853270||0||1
+2015-12-01 22:08:33.020549||error||collecting ads||Error||4||1
+2015-12-01 22:08:37.424811||error||collecting ads||Error||5||1
+2015-12-01 22:08:37.824586||measurement||price||2015-12-01 22:08:31.769347@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:08:46.525123||measurement||price||2015-12-01 22:08:40.259808@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 22:08:50.655615||measurement||price||2015-12-01 22:08:31.769347@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:08:57.870049||measurement||loadtime||0:00:28.596804||0||1
+2015-12-01 22:08:59.416750||measurement||price||2015-12-01 22:08:40.259808@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 22:09:01.133462||error||collecting ads||Error||5||1
+2015-12-01 22:09:06.625633||measurement||loadtime||0:00:28.602490||4||1
+2015-12-01 22:09:11.588443||measurement||price||2015-12-01 22:09:05.441584@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:09:24.407832||measurement||price||2015-12-01 22:09:05.441584@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:09:24.717390||error||collecting ads||Error||5||1
+2015-12-01 22:09:24.717502||event||progress-marker||measurement-end||5||1
+2015-12-01 22:09:30.398093||error||collecting ads||Error||4||1
+2015-12-01 22:09:31.603769||measurement||loadtime||0:00:28.728478||0||1
+2015-12-01 22:09:45.424418||measurement||price||2015-12-01 22:09:39.336043@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 22:09:54.008422||error||collecting ads||Error||4||1
+2015-12-01 22:09:54.008534||event||progress-marker||measurement-end||4||1
+2015-12-01 22:09:58.297193||measurement||price||2015-12-01 22:09:39.336043@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 22:10:05.475745||measurement||loadtime||0:00:28.869074||0||1
+2015-12-01 22:10:19.088644||measurement||price||2015-12-01 22:10:12.999723@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 22:10:31.922769||measurement||price||2015-12-01 22:10:12.999723@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 22:10:39.096973||measurement||loadtime||0:00:28.616054||0||1
+2015-12-01 22:10:39.097081||event||progress-marker||measurement-end||0||1
+2015-12-01 22:29:35.624027||error||block timeout||Error||0||3
+2015-12-01 22:29:35.825248||meta||block_id end||7
+2015-12-01 22:29:35.825459||meta||block_id start||8
+2015-12-01 22:29:35.825478||meta||assignment||2@|4@|5@|0@|3@|1
+2015-12-01 22:29:37.422155||event||progress-marker||training-start||2||0
+2015-12-01 22:29:37.508597||event||progress-marker||training-start||5||0
+2015-12-01 22:29:44.999457||treatment||visit website||http://irs.gov||2||0
+2015-12-01 22:29:45.003923||treatment||visit website||http://irs.gov||5||0
+2015-12-01 22:29:53.224864||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 22:29:53.225093||treatment||visit website||http://deloitte.com||5||0
+2015-12-01 22:30:01.472166||treatment||visit website||http://pwc.com||2||0
+2015-12-01 22:30:01.507114||treatment||visit website||http://pwc.com||5||0
+2015-12-01 22:30:07.373061||treatment||visit website||http://ey.com||2||0
+2015-12-01 22:30:07.375097||treatment||visit website||http://ey.com||5||0
+2015-12-01 22:30:09.614192||event||progress-marker||training-start||1||1
+2015-12-01 22:30:14.251320||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 22:30:14.251428||event||progress-marker||training-end||2||0
+2015-12-01 22:30:14.427079||treatment||visit website||http://kpmg.com||5||0
+2015-12-01 22:30:14.427159||event||progress-marker||training-end||5||0
+2015-12-01 22:30:18.781955||treatment||visit website||http://irs.gov||1||1
+2015-12-01 22:30:25.878689||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 22:30:34.878136||treatment||visit website||http://pwc.com||1||1
+2015-12-01 22:30:40.949681||treatment||visit website||http://ey.com||1||1
+2015-12-01 22:30:49.012978||event||progress-marker||training-start||0||1
+2015-12-01 22:30:51.956728||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 22:30:51.956823||event||progress-marker||training-end||1||1
+2015-12-01 22:30:55.711459||treatment||visit website||http://irs.gov||0||1
+2015-12-01 22:31:02.910494||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 22:31:11.634975||treatment||visit website||http://pwc.com||0||1
+2015-12-01 22:31:17.502381||treatment||visit website||http://ey.com||0||1
+2015-12-01 22:31:24.257783||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 22:31:24.257915||event||progress-marker||training-end||0||1
+2015-12-01 22:31:24.460093||event||progress-marker||measurement-start||2||0
+2015-12-01 22:31:24.638137||event||progress-marker||measurement-start||5||0
+2015-12-01 22:31:27.062195||event||progress-marker||measurement-start||1||1
+2015-12-01 22:31:29.282652||event||progress-marker||measurement-start||0||1
+2015-12-01 22:31:37.565474||measurement||price||2015-12-01 22:31:32.143579@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:31:37.605963||measurement||price||2015-12-01 22:31:32.229292@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:31:41.567173||measurement||price||2015-12-01 22:31:35.330177@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:31:48.112015||event||progress-marker||training-start||3||1
+2015-12-01 22:31:49.918902||measurement||price||2015-12-01 22:31:32.143579@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:31:49.974084||measurement||price||2015-12-01 22:31:32.229292@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:31:53.965306||error||collecting ads||Error||0||1
+2015-12-01 22:31:54.547147||treatment||visit website||http://irs.gov||3||1
+2015-12-01 22:31:54.621537||measurement||price||2015-12-01 22:31:35.330177@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:31:57.026687||measurement||loadtime||0:00:27.383368||5||0
+2015-12-01 22:31:57.067165||measurement||loadtime||0:00:27.604033||2||0
+2015-12-01 22:32:01.505419||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 22:32:01.812405||measurement||loadtime||0:00:29.745181||1||1
+2015-12-01 22:32:07.953275||measurement||price||2015-12-01 22:32:01.595716@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:32:09.506607||measurement||price||2015-12-01 22:32:03.701522@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 22:32:09.673234||measurement||price||2015-12-01 22:32:04.243850@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:32:10.597624||treatment||visit website||http://pwc.com||3||1
+2015-12-01 22:32:16.499086||treatment||visit website||http://ey.com||3||1
+2015-12-01 22:32:20.758449||measurement||price||2015-12-01 22:32:01.595716@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:32:21.792709||measurement||price||2015-12-01 22:32:03.701522@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 22:32:22.016670||measurement||price||2015-12-01 22:32:04.243850@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:32:24.396399||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 22:32:24.396540||event||progress-marker||training-end||3||1
+2015-12-01 22:32:25.595441||error||collecting ads||Error||1||1
+2015-12-01 22:32:27.957678||measurement||loadtime||0:00:28.987168||0||1
+2015-12-01 22:32:28.899136||measurement||loadtime||0:00:26.867251||5||0
+2015-12-01 22:32:29.130182||measurement||loadtime||0:00:27.059018||2||0
+2015-12-01 22:32:29.428967||event||progress-marker||measurement-start||3||1
+2015-12-01 22:32:39.449827||measurement||price||2015-12-01 22:32:33.249570@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:32:41.765125||measurement||price||2015-12-01 22:32:36.333590@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:32:42.127539||measurement||price||2015-12-01 22:32:35.877152@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:32:44.366130||measurement||price||2015-12-01 22:32:37.476452@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:32:51.322113||error||collecting ads||Error||5||0
+2015-12-01 22:32:52.323591||measurement||price||2015-12-01 22:32:33.249570@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:32:54.052381||measurement||price||2015-12-01 22:32:36.333590@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:32:55.002906||measurement||price||2015-12-01 22:32:35.877152@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:32:57.189870||measurement||price||2015-12-01 22:32:37.476452@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:32:59.551140||measurement||loadtime||0:00:28.950508||1||1
+2015-12-01 22:33:01.164334||measurement||loadtime||0:00:27.032321||2||0
+2015-12-01 22:33:02.182016||measurement||loadtime||0:00:29.219157||0||1
+2015-12-01 22:33:03.548466||measurement||price||2015-12-01 22:32:58.042709@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:33:04.413619||measurement||loadtime||0:00:29.979470||3||1
+2015-12-01 22:33:13.717031||measurement||price||2015-12-01 22:33:08.260655@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:33:15.867723||measurement||price||2015-12-01 22:32:58.042709@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:33:16.694329||measurement||price||2015-12-01 22:33:10.419497@|3M Littmann@|$85.00 - $234.56@|3M Littmann Classic III Stethoscope (Multiple Colors)||0||1
+2015-12-01 22:33:22.980746||measurement||loadtime||0:00:26.653345||5||0
+2015-12-01 22:33:23.607845||error||collecting ads||Error||1||1
+2015-12-01 22:33:26.036310||measurement||price||2015-12-01 22:33:08.260655@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:33:28.660027||error||collecting ads||Error||3||1
+2015-12-01 22:33:29.614701||measurement||price||2015-12-01 22:33:10.419497@|3M Littmann@|$62.96 - $319.00@|3M Littmann Classic II S.E. Stethoscope (Multiple Colors)||0||1
+2015-12-01 22:33:33.143565||measurement||loadtime||0:00:26.974023||2||0
+2015-12-01 22:33:35.243746||measurement||price||2015-12-01 22:33:29.621822@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:33:36.859147||measurement||loadtime||0:00:29.671934||0||1
+2015-12-01 22:33:37.448104||measurement||price||2015-12-01 22:33:31.306439@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 22:33:42.465381||measurement||price||2015-12-01 22:33:35.967958@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 22:33:45.622160||measurement||price||2015-12-01 22:33:40.192495@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:33:47.559510||measurement||price||2015-12-01 22:33:29.621822@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:33:50.371216||measurement||price||2015-12-01 22:33:31.306439@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 22:33:50.636945||measurement||price||2015-12-01 22:33:44.586454@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:33:54.663655||measurement||loadtime||0:00:26.677705||5||0
+2015-12-01 22:33:55.335305||measurement||price||2015-12-01 22:33:35.967958@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 22:33:57.571734||measurement||loadtime||0:00:28.960585||1||1
+2015-12-01 22:33:57.958873||measurement||price||2015-12-01 22:33:40.192495@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:34:02.530067||measurement||loadtime||0:00:28.864827||3||1
+2015-12-01 22:34:03.614952||measurement||price||2015-12-01 22:33:44.586454@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:34:05.071146||measurement||loadtime||0:00:26.924027||2||0
+2015-12-01 22:34:07.199583||measurement||price||2015-12-01 22:34:01.658965@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||5||0
+2015-12-01 22:34:10.815148||measurement||loadtime||0:00:28.950823||0||1
+2015-12-01 22:34:16.229973||measurement||price||2015-12-01 22:34:09.701735@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:34:17.623144||measurement||price||2015-12-01 22:34:11.866419@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:34:19.508870||measurement||price||2015-12-01 22:34:01.658965@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||5||0
+2015-12-01 22:34:21.372595||error||collecting ads||Error||1||1
+2015-12-01 22:34:26.613057||measurement||loadtime||0:00:26.946856||5||0
+2015-12-01 22:34:29.010515||measurement||price||2015-12-01 22:34:09.701735@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:34:29.958320||measurement||price||2015-12-01 22:34:11.866419@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:34:34.554925||error||collecting ads||Error||0||1
+2015-12-01 22:34:35.121641||measurement||price||2015-12-01 22:34:28.980878@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:34:36.238794||measurement||loadtime||0:00:28.708329||3||1
+2015-12-01 22:34:37.072006||measurement||loadtime||0:00:26.996894||2||0
+2015-12-01 22:34:39.619519||measurement||price||2015-12-01 22:34:33.956420@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 22:34:48.020592||measurement||price||2015-12-01 22:34:28.980878@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:34:48.546687||measurement||price||2015-12-01 22:34:42.162687@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:34:49.602813||measurement||price||2015-12-01 22:34:44.178808@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:34:51.909255||measurement||price||2015-12-01 22:34:33.956420@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 22:34:55.217718||measurement||loadtime||0:00:28.839891||1||1
+2015-12-01 22:34:58.995144||measurement||loadtime||0:00:27.380874||5||0
+2015-12-01 22:35:00.529811||error||collecting ads||Error||3||1
+2015-12-01 22:35:01.407240||measurement||price||2015-12-01 22:34:42.162687@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:35:01.928409||measurement||price||2015-12-01 22:34:44.178808@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:35:08.591622||measurement||loadtime||0:00:29.032481||0||1
+2015-12-01 22:35:09.010942||measurement||price||2015-12-01 22:35:02.869578@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:35:09.043137||measurement||loadtime||0:00:26.968019||2||0
+2015-12-01 22:35:11.129866||measurement||price||2015-12-01 22:35:05.567180@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:35:21.874888||measurement||price||2015-12-01 22:35:02.869578@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:35:23.409196||measurement||price||2015-12-01 22:35:05.567180@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:35:24.288553||error||collecting ads||Error||3||1
+2015-12-01 22:35:29.073090||measurement||loadtime||0:00:28.850142||1||1
+2015-12-01 22:35:30.494047||measurement||loadtime||0:00:26.495859||5||0
+2015-12-01 22:35:31.552097||error||collecting ads||Error||2||0
+2015-12-01 22:35:33.740383||error||collecting ads||Error||0||1
+2015-12-01 22:35:37.933245||measurement||price||2015-12-01 22:35:31.488693@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 22:35:42.813269||measurement||price||2015-12-01 22:35:37.179672@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:35:43.540092||measurement||price||2015-12-01 22:35:37.293773@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||1
+2015-12-01 22:35:44.138409||measurement||price||2015-12-01 22:35:38.710591@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:35:47.648378||measurement||price||2015-12-01 22:35:41.428563@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:35:50.759336||measurement||price||2015-12-01 22:35:31.488693@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 22:35:55.131677||measurement||price||2015-12-01 22:35:37.179672@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:35:56.459344||measurement||price||2015-12-01 22:35:38.710591@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:35:56.484985||measurement||price||2015-12-01 22:35:37.293773@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||1
+2015-12-01 22:35:57.977544||measurement||loadtime||0:00:28.683778||3||1
+2015-12-01 22:36:00.465148||measurement||price||2015-12-01 22:35:41.428563@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:36:02.242151||measurement||loadtime||0:00:26.742916||5||0
+2015-12-01 22:36:03.552847||measurement||loadtime||0:00:26.996420||2||0
+2015-12-01 22:36:03.700677||measurement||loadtime||0:00:29.626082||1||1
+2015-12-01 22:36:07.661340||measurement||loadtime||0:00:28.918195||0||1
+2015-12-01 22:36:11.813811||measurement||price||2015-12-01 22:36:05.233306@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 22:36:18.052427||measurement||price||2015-12-01 22:36:11.783603@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:36:21.503793||measurement||price||2015-12-01 22:36:15.315780@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:36:24.414210||error||collecting ads||Error||5||0
+2015-12-01 22:36:24.742511||measurement||price||2015-12-01 22:36:05.233306@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 22:36:26.006315||error||collecting ads||Error||2||0
+2015-12-01 22:36:31.051104||measurement||price||2015-12-01 22:36:11.783603@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:36:31.943786||measurement||loadtime||0:00:28.961018||3||1
+2015-12-01 22:36:34.374481||measurement||price||2015-12-01 22:36:15.315780@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:36:38.272548||measurement||loadtime||0:00:29.566691||1||1
+2015-12-01 22:36:38.486134||measurement||price||2015-12-01 22:36:33.114759@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 22:36:41.562970||measurement||loadtime||0:00:28.899836||0||1
+2015-12-01 22:36:45.757998||measurement||price||2015-12-01 22:36:39.257064@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:36:46.641088||error||collecting ads||Error||5||0
+2015-12-01 22:36:50.795085||measurement||price||2015-12-01 22:36:33.114759@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 22:36:52.178043||measurement||price||2015-12-01 22:36:45.879002@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 22:36:55.271580||measurement||price||2015-12-01 22:36:49.198504@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:36:57.898713||measurement||loadtime||0:00:26.887586||2||0
+2015-12-01 22:36:58.808959||measurement||price||2015-12-01 22:36:39.257064@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:36:58.918946||measurement||price||2015-12-01 22:36:53.277126@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 22:37:05.113346||measurement||price||2015-12-01 22:36:45.879002@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 22:37:06.011145||measurement||loadtime||0:00:29.066081||3||1
+2015-12-01 22:37:08.091921||measurement||price||2015-12-01 22:36:49.198504@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:37:10.325665||measurement||price||2015-12-01 22:37:04.964970@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:37:11.245710||measurement||price||2015-12-01 22:36:53.277126@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 22:37:12.295177||measurement||loadtime||0:00:29.019974||1||1
+2015-12-01 22:37:15.296934||measurement||loadtime||0:00:28.728754||0||1
+2015-12-01 22:37:18.350528||measurement||loadtime||0:00:26.707400||5||0
+2015-12-01 22:37:22.658045||measurement||price||2015-12-01 22:37:04.964970@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:37:25.901560||measurement||price||2015-12-01 22:37:19.860242@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:37:29.146328||measurement||price||2015-12-01 22:37:22.985578@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:37:29.775629||measurement||loadtime||0:00:26.871714||2||0
+2015-12-01 22:37:29.808583||error||collecting ads||Error||3||1
+2015-12-01 22:37:38.839539||measurement||price||2015-12-01 22:37:19.860242@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:37:40.617117||error||collecting ads||Error||5||0
+2015-12-01 22:37:42.026305||measurement||price||2015-12-01 22:37:22.985578@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:37:42.311064||measurement||price||2015-12-01 22:37:36.920132@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:37:43.987223||measurement||price||2015-12-01 22:37:37.068715@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:37:46.022630||measurement||loadtime||0:00:28.724081||1||1
+2015-12-01 22:37:49.212745||measurement||loadtime||0:00:28.910633||0||1
+2015-12-01 22:37:52.774096||measurement||price||2015-12-01 22:37:47.265620@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 22:37:54.644959||measurement||price||2015-12-01 22:37:36.920132@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:37:56.862756||measurement||price||2015-12-01 22:37:37.068715@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:37:59.789281||measurement||price||2015-12-01 22:37:53.652255@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 22:38:01.756537||measurement||loadtime||0:00:26.977398||2||0
+2015-12-01 22:38:03.092428||measurement||price||2015-12-01 22:37:56.848337@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:38:04.108261||measurement||loadtime||0:00:29.294475||3||1
+2015-12-01 22:38:05.098144||measurement||price||2015-12-01 22:37:47.265620@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 22:38:12.209171||measurement||loadtime||0:00:26.586834||5||0
+2015-12-01 22:38:12.626103||measurement||price||2015-12-01 22:37:53.652255@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 22:38:14.169126||measurement||price||2015-12-01 22:38:08.792434@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:38:16.000839||measurement||price||2015-12-01 22:37:56.848337@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:38:19.806064||measurement||loadtime||0:00:28.778506||1||1
+2015-12-01 22:38:23.208675||measurement||loadtime||0:00:28.995291||0||1
+2015-12-01 22:38:24.391771||measurement||price||2015-12-01 22:38:18.831856@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 22:38:26.492613||measurement||price||2015-12-01 22:38:08.792434@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:38:28.022372||error||collecting ads||Error||3||1
+2015-12-01 22:38:33.601127||measurement||loadtime||0:00:26.841992||2||0
+2015-12-01 22:38:36.714344||measurement||price||2015-12-01 22:38:18.831856@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 22:38:41.735957||measurement||price||2015-12-01 22:38:35.342053@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:38:43.445863||error||collecting ads||Error||1||1
+2015-12-01 22:38:43.819142||measurement||loadtime||0:00:26.604784||5||0
+2015-12-01 22:38:47.000310||error||collecting ads||Error||0||1
+2015-12-01 22:38:54.812124||measurement||price||2015-12-01 22:38:35.342053@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:38:56.139870||error||collecting ads||Error||2||0
+2015-12-01 22:38:56.161591||measurement||price||2015-12-01 22:38:50.502638@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:39:01.102789||measurement||price||2015-12-01 22:38:54.956731@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:39:02.031170||measurement||loadtime||0:00:29.003578||3||1
+2015-12-01 22:39:07.749879||error||collecting ads||Error||1||1
+2015-12-01 22:39:08.476449||measurement||price||2015-12-01 22:38:50.502638@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:39:08.614683||measurement||price||2015-12-01 22:39:03.147784@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:39:14.015956||measurement||price||2015-12-01 22:38:54.956731@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:39:15.599172||measurement||loadtime||0:00:26.776033||5||0
+2015-12-01 22:39:16.786963||measurement||price||2015-12-01 22:39:09.849366@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:39:20.943347||measurement||price||2015-12-01 22:39:03.147784@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:39:21.213919||measurement||loadtime||0:00:29.210773||0||1
+2015-12-01 22:39:21.613684||measurement||price||2015-12-01 22:39:15.472882@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 22:39:27.805361||measurement||price||2015-12-01 22:39:22.221578@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 22:39:28.050292||measurement||loadtime||0:00:26.907156||2||0
+2015-12-01 22:39:29.830843||measurement||price||2015-12-01 22:39:09.849366@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:39:34.620207||measurement||price||2015-12-01 22:39:15.472882@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 22:39:34.875494||measurement||price||2015-12-01 22:39:28.798798@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 22:39:37.046755||measurement||loadtime||0:00:30.010323||3||1
+2015-12-01 22:39:40.141309||measurement||price||2015-12-01 22:39:22.221578@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 22:39:41.867185||measurement||loadtime||0:00:29.112092||1||1
+2015-12-01 22:39:47.241238||measurement||loadtime||0:00:26.637989||5||0
+2015-12-01 22:39:47.741983||measurement||price||2015-12-01 22:39:28.798798@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 22:39:50.520982||error||collecting ads||Error||2||0
+2015-12-01 22:39:51.103740||measurement||price||2015-12-01 22:39:44.402367@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 22:39:54.915907||measurement||loadtime||0:00:28.700559||0||1
+2015-12-01 22:40:02.934033||measurement||price||2015-12-01 22:39:57.539893@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 22:40:03.919061||measurement||price||2015-12-01 22:39:44.402367@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 22:40:05.716268||error||collecting ads||Error||1||1
+2015-12-01 22:40:09.416805||error||collecting ads||Error||5||0
+2015-12-01 22:40:11.133209||measurement||loadtime||0:00:29.083434||3||1
+2015-12-01 22:40:15.262782||measurement||price||2015-12-01 22:39:57.539893@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 22:40:18.633330||error||collecting ads||Error||0||1
+2015-12-01 22:40:19.436771||measurement||price||2015-12-01 22:40:13.261031@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 22:40:21.605028||measurement||price||2015-12-01 22:40:16.001355@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 22:40:22.379223||measurement||loadtime||0:00:26.856153||2||0
+2015-12-01 22:40:24.916942||measurement||price||2015-12-01 22:40:18.381296@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 22:40:32.306439||measurement||price||2015-12-01 22:40:13.261031@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 22:40:33.091547||measurement||price||2015-12-01 22:40:26.837029@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||0||1
+2015-12-01 22:40:33.939250||measurement||price||2015-12-01 22:40:16.001355@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 22:40:37.858754||measurement||price||2015-12-01 22:40:18.381296@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 22:40:39.523085||measurement||loadtime||0:00:28.801565||1||1
+2015-12-01 22:40:41.047215||measurement||loadtime||0:00:26.625075||5||0
+2015-12-01 22:40:44.835680||error||collecting ads||Error||2||0
+2015-12-01 22:40:45.077457||measurement||loadtime||0:00:28.942317||3||1
+2015-12-01 22:40:45.985317||measurement||price||2015-12-01 22:40:26.837029@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||0||1
+2015-12-01 22:40:53.231119||measurement||loadtime||0:00:29.592612||0||1
+2015-12-01 22:40:59.061937||measurement||price||2015-12-01 22:40:52.444873@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 22:41:03.191623||error||collecting ads||Error||5||0
+2015-12-01 22:41:03.191723||event||progress-marker||measurement-end||5||0
+2015-12-01 22:41:03.410305||error||collecting ads||Error||1||1
+2015-12-01 22:41:07.296631||error||collecting ads||Error||2||0
+2015-12-01 22:41:07.296733||event||progress-marker||measurement-end||2||0
+2015-12-01 22:41:12.091487||measurement||price||2015-12-01 22:40:52.444873@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 22:41:17.263997||error||collecting ads||Error||0||1
+2015-12-01 22:41:17.596549||measurement||price||2015-12-01 22:41:11.683831@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 22:41:19.286867||measurement||loadtime||0:00:29.203697||3||1
+2015-12-01 22:41:30.503149||measurement||price||2015-12-01 22:41:11.683831@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 22:41:30.980701||measurement||price||2015-12-01 22:41:24.811223@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 22:41:37.695153||measurement||loadtime||0:00:29.279620||1||1
+2015-12-01 22:41:37.695249||event||progress-marker||measurement-end||1||1
+2015-12-01 22:41:43.175985||error||collecting ads||Error||3||1
+2015-12-01 22:41:43.958499||measurement||price||2015-12-01 22:41:24.811223@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 22:41:51.139172||measurement||loadtime||0:00:28.872521||0||1
+2015-12-01 22:41:51.139280||event||progress-marker||measurement-end||0||1
+2015-12-01 22:42:06.777687||error||collecting ads||Error||3||1
+2015-12-01 22:42:20.493067||measurement||price||2015-12-01 22:42:13.938181@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 22:42:33.395275||measurement||price||2015-12-01 22:42:13.938181@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 22:42:40.594023||measurement||loadtime||0:00:28.811144||3||1
+2015-12-01 22:42:40.594118||event||progress-marker||measurement-end||3||1
+2015-12-01 23:02:55.834996||error||block timeout||Error||0||4
+2015-12-01 23:02:55.996539||meta||block_id end||8
+2015-12-01 23:02:55.996769||meta||block_id start||9
+2015-12-01 23:02:55.996788||meta||assignment||5@|3@|1@|2@|0@|4
+2015-12-01 23:02:57.609002||event||progress-marker||training-start||5||0
+2015-12-01 23:02:57.651992||event||progress-marker||training-start||3||0
+2015-12-01 23:02:57.662041||event||progress-marker||training-start||1||0
+2015-12-01 23:03:04.277316||treatment||visit website||http://irs.gov||5||0
+2015-12-01 23:03:04.307128||treatment||visit website||http://irs.gov||3||0
+2015-12-01 23:03:04.407111||treatment||visit website||http://irs.gov||1||0
+2015-12-01 23:03:11.555087||treatment||visit website||http://deloitte.com||5||0
+2015-12-01 23:03:11.556712||treatment||visit website||http://deloitte.com||1||0
+2015-12-01 23:03:11.575101||treatment||visit website||http://deloitte.com||3||0
+2015-12-01 23:03:19.654975||treatment||visit website||http://pwc.com||3||0
+2015-12-01 23:03:19.695100||treatment||visit website||http://pwc.com||1||0
+2015-12-01 23:03:19.923986||treatment||visit website||http://pwc.com||5||0
+2015-12-01 23:03:25.488571||treatment||visit website||http://ey.com||3||0
+2015-12-01 23:03:25.527096||treatment||visit website||http://ey.com||1||0
+2015-12-01 23:03:25.752195||treatment||visit website||http://ey.com||5||0
+2015-12-01 23:03:32.146539||treatment||visit website||http://kpmg.com||3||0
+2015-12-01 23:03:32.146652||event||progress-marker||training-end||3||0
+2015-12-01 23:03:32.391105||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 23:03:32.391206||event||progress-marker||training-end||1||0
+2015-12-01 23:03:32.549801||treatment||visit website||http://kpmg.com||5||0
+2015-12-01 23:03:32.549909||event||progress-marker||training-end||5||0
+2015-12-01 23:03:37.176696||event||progress-marker||measurement-start||3||0
+2015-12-01 23:03:37.415640||event||progress-marker||measurement-start||1||0
+2015-12-01 23:03:37.578606||event||progress-marker||measurement-start||5||0
+2015-12-01 23:03:51.055189||measurement||price||2015-12-01 23:03:44.525875@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:03:52.545126||measurement||price||2015-12-01 23:03:44.419890@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:04:00.711151||error||collecting ads||Error||5||0
+2015-12-01 23:04:03.398250||measurement||price||2015-12-01 23:03:44.525875@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:04:04.903217||measurement||price||2015-12-01 23:03:44.419890@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:04:05.441544||event||progress-marker||training-start||4||1
+2015-12-01 23:04:07.490406||event||progress-marker||training-start||2||1
+2015-12-01 23:04:10.503168||measurement||loadtime||0:00:28.084025||1||0
+2015-12-01 23:04:12.008386||measurement||loadtime||0:00:29.829221||3||0
+2015-12-01 23:04:12.043686||treatment||visit website||http://irs.gov||4||1
+2015-12-01 23:04:14.463109||treatment||visit website||http://irs.gov||2||1
+2015-12-01 23:04:18.730495||treatment||visit website||http://deloitte.com||4||1
+2015-12-01 23:04:21.533926||treatment||visit website||http://deloitte.com||2||1
+2015-12-01 23:04:23.020130||error||collecting ads||Error||5||0
+2015-12-01 23:04:23.143864||measurement||price||2015-12-01 23:04:17.217746@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:04:24.372525||measurement||price||2015-12-01 23:04:18.591523@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:04:27.483728||treatment||visit website||http://pwc.com||4||1
+2015-12-01 23:04:30.399123||treatment||visit website||http://pwc.com||2||1
+2015-12-01 23:04:33.443880||treatment||visit website||http://ey.com||4||1
+2015-12-01 23:04:35.192068||measurement||price||2015-12-01 23:04:29.658274@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:04:35.463124||measurement||price||2015-12-01 23:04:17.217746@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:04:36.322701||treatment||visit website||http://ey.com||2||1
+2015-12-01 23:04:36.581651||event||progress-marker||training-start||0||1
+2015-12-01 23:04:36.689710||measurement||price||2015-12-01 23:04:18.591523@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:04:40.386478||treatment||visit website||http://kpmg.com||4||1
+2015-12-01 23:04:40.386612||event||progress-marker||training-end||4||1
+2015-12-01 23:04:42.582224||measurement||loadtime||0:00:27.075078||1||0
+2015-12-01 23:04:43.419779||treatment||visit website||http://irs.gov||0||1
+2015-12-01 23:04:43.801054||measurement||loadtime||0:00:26.789898||3||0
+2015-12-01 23:04:43.803095||treatment||visit website||http://kpmg.com||2||1
+2015-12-01 23:04:43.803191||event||progress-marker||training-end||2||1
+2015-12-01 23:04:47.527006||measurement||price||2015-12-01 23:04:29.658274@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:04:49.751133||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 23:04:54.643197||measurement||loadtime||0:00:26.619558||5||0
+2015-12-01 23:04:56.082197||measurement||price||2015-12-01 23:04:50.426655@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 23:05:04.861013||error||collecting ads||Error||1||0
+2015-12-01 23:05:06.818119||measurement||price||2015-12-01 23:05:01.214268@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:05:08.400412||measurement||price||2015-12-01 23:04:50.426655@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 23:05:15.507153||measurement||loadtime||0:00:26.704027||3||0
+2015-12-01 23:05:19.130258||measurement||price||2015-12-01 23:05:01.214268@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:05:26.239140||measurement||loadtime||0:00:26.592006||5||0
+2015-12-01 23:05:27.031449||error||collecting ads||Error||1||0
+2015-12-01 23:05:27.709207||measurement||price||2015-12-01 23:05:22.136104@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:05:29.775490||error||website timeout||http://pwc.com||0||1
+2015-12-01 23:05:34.811170||treatment||visit website||http://ey.com||0||1
+2015-12-01 23:05:39.211071||measurement||price||2015-12-01 23:05:33.595726@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:05:40.048404||measurement||price||2015-12-01 23:05:22.136104@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:05:41.259127||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 23:05:41.259279||event||progress-marker||training-end||0||1
+2015-12-01 23:05:43.997534||event||progress-marker||measurement-start||2||1
+2015-12-01 23:05:45.605740||event||progress-marker||measurement-start||4||1
+2015-12-01 23:05:46.291165||event||progress-marker||measurement-start||0||1
+2015-12-01 23:05:47.174005||measurement||loadtime||0:00:26.661647||3||0
+2015-12-01 23:05:48.461020||error||collecting ads||Error||5||0
+2015-12-01 23:05:51.558575||measurement||price||2015-12-01 23:05:33.595726@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:05:58.670098||measurement||loadtime||0:00:26.634924||1||0
+2015-12-01 23:05:59.697860||measurement||price||2015-12-01 23:05:53.955122@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 23:06:00.621035||measurement||price||2015-12-01 23:05:53.769109@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:06:00.975775||measurement||price||2015-12-01 23:05:55.274562@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 23:06:01.282667||measurement||price||2015-12-01 23:05:54.916233@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:06:08.628148||error||collecting ads||Error||2||1
+2015-12-01 23:06:12.036952||measurement||price||2015-12-01 23:05:53.955122@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 23:06:13.302307||measurement||price||2015-12-01 23:05:55.274562@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 23:06:13.499934||measurement||price||2015-12-01 23:05:53.769109@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:06:14.165205||measurement||price||2015-12-01 23:05:54.916233@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:06:19.150112||measurement||loadtime||0:00:26.970975||3||0
+2015-12-01 23:06:20.406270||measurement||loadtime||0:00:26.943122||5||0
+2015-12-01 23:06:20.715161||measurement||loadtime||0:00:30.104235||4||1
+2015-12-01 23:06:20.920355||error||collecting ads||Error||1||0
+2015-12-01 23:06:21.345956||measurement||loadtime||0:00:30.049566||0||1
+2015-12-01 23:06:31.438175||measurement||price||2015-12-01 23:06:25.702429@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:06:32.498821||error||collecting ads||Error||2||1
+2015-12-01 23:06:35.618986||measurement||price||2015-12-01 23:06:29.385276@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:06:42.857670||error||collecting ads||Error||5||0
+2015-12-01 23:06:43.403187||error||collecting ads||Error||1||0
+2015-12-01 23:06:43.744087||measurement||price||2015-12-01 23:06:25.702429@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:06:45.154990||error||collecting ads||Error||4||1
+2015-12-01 23:06:46.346325||measurement||price||2015-12-01 23:06:40.354035@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 23:06:48.616505||measurement||price||2015-12-01 23:06:29.385276@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:06:50.827145||measurement||loadtime||0:00:26.671843||3||0
+2015-12-01 23:06:55.093184||measurement||price||2015-12-01 23:06:49.568796@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:06:55.819171||measurement||loadtime||0:00:29.468019||0||1
+2015-12-01 23:06:59.204867||measurement||price||2015-12-01 23:06:40.354035@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 23:06:59.456976||measurement||price||2015-12-01 23:06:53.049987@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||1
+2015-12-01 23:07:05.740124||error||collecting ads||Error||1||0
+2015-12-01 23:07:06.401657||measurement||loadtime||0:00:28.898521||2||1
+2015-12-01 23:07:07.435836||measurement||price||2015-12-01 23:06:49.568796@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:07:09.868707||measurement||price||2015-12-01 23:07:03.613345@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:07:12.313934||measurement||price||2015-12-01 23:06:53.049987@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||1
+2015-12-01 23:07:12.959401||error||collecting ads||Error||3||0
+2015-12-01 23:07:14.555179||measurement||loadtime||0:00:26.692305||5||0
+2015-12-01 23:07:17.933461||measurement||price||2015-12-01 23:07:12.358533@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:07:19.538006||measurement||loadtime||0:00:29.378867||4||1
+2015-12-01 23:07:20.870244||measurement||price||2015-12-01 23:07:14.707115@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||2||1
+2015-12-01 23:07:22.818476||measurement||price||2015-12-01 23:07:03.613345@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:07:25.238288||measurement||price||2015-12-01 23:07:19.533734@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 23:07:30.154297||measurement||loadtime||0:00:29.331165||0||1
+2015-12-01 23:07:30.256895||measurement||price||2015-12-01 23:07:12.358533@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:07:33.663523||measurement||price||2015-12-01 23:07:26.875627@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:07:33.840780||measurement||price||2015-12-01 23:07:14.707115@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||1
+2015-12-01 23:07:36.763991||error||collecting ads||Error||5||0
+2015-12-01 23:07:37.367145||measurement||loadtime||0:00:26.623687||1||0
+2015-12-01 23:07:37.557441||measurement||price||2015-12-01 23:07:19.533734@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 23:07:41.023185||measurement||loadtime||0:00:29.620044||2||1
+2015-12-01 23:07:44.174129||measurement||price||2015-12-01 23:07:38.006961@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:07:44.659858||measurement||loadtime||0:00:26.696680||3||0
+2015-12-01 23:07:46.757247||measurement||price||2015-12-01 23:07:26.875627@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:07:49.775852||measurement||price||2015-12-01 23:07:44.169689@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:07:53.969827||measurement||loadtime||0:00:29.426595||4||1
+2015-12-01 23:07:55.598636||measurement||price||2015-12-01 23:07:49.599866@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 23:07:56.952419||measurement||price||2015-12-01 23:07:51.357158@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:07:57.047645||measurement||price||2015-12-01 23:07:38.006961@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:07:59.111730||error||collecting ads||Error||5||0
+2015-12-01 23:08:02.097756||measurement||price||2015-12-01 23:07:44.169689@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:08:04.263179||measurement||loadtime||0:00:29.104049||0||1
+2015-12-01 23:08:08.666434||measurement||price||2015-12-01 23:07:49.599866@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 23:08:09.195783||measurement||loadtime||0:00:26.823431||1||0
+2015-12-01 23:08:09.281462||measurement||price||2015-12-01 23:07:51.357158@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:08:11.296339||measurement||price||2015-12-01 23:08:05.683983@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 23:08:15.867153||measurement||loadtime||0:00:29.838763||2||1
+2015-12-01 23:08:16.395151||measurement||loadtime||0:00:26.732028||3||0
+2015-12-01 23:08:17.694646||error||collecting ads||Error||4||1
+2015-12-01 23:08:18.109444||measurement||price||2015-12-01 23:08:11.919731@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:08:21.408003||measurement||price||2015-12-01 23:08:15.770402@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:08:23.618417||measurement||price||2015-12-01 23:08:05.683983@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 23:08:28.626365||measurement||price||2015-12-01 23:08:23.097732@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:08:29.935664||measurement||price||2015-12-01 23:08:23.798826@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 23:08:30.723181||measurement||loadtime||0:00:26.608066||5||0
+2015-12-01 23:08:31.108122||measurement||price||2015-12-01 23:08:11.919731@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:08:31.823688||measurement||price||2015-12-01 23:08:25.677425@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||4||1
+2015-12-01 23:08:33.693550||measurement||price||2015-12-01 23:08:15.770402@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:08:38.305651||measurement||loadtime||0:00:29.037278||0||1
+2015-12-01 23:08:40.799925||measurement||loadtime||0:00:26.600791||1||0
+2015-12-01 23:08:40.962729||measurement||price||2015-12-01 23:08:23.097732@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:08:42.938439||measurement||price||2015-12-01 23:08:23.798826@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 23:08:42.958589||measurement||price||2015-12-01 23:08:37.410503@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:08:44.720843||measurement||price||2015-12-01 23:08:25.677425@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||4||1
+2015-12-01 23:08:48.067170||measurement||loadtime||0:00:26.670148||3||0
+2015-12-01 23:08:50.151558||measurement||loadtime||0:00:29.280420||2||1
+2015-12-01 23:08:51.930914||measurement||loadtime||0:00:29.231789||4||1
+2015-12-01 23:08:52.050519||measurement||price||2015-12-01 23:08:45.860075@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:08:53.027421||measurement||price||2015-12-01 23:08:47.443927@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:08:55.256826||measurement||price||2015-12-01 23:08:37.410503@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:09:00.277336||measurement||price||2015-12-01 23:08:54.719954@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 23:09:02.347859||measurement||loadtime||0:00:26.620723||5||0
+2015-12-01 23:09:04.865875||measurement||price||2015-12-01 23:08:45.860075@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:09:05.366454||measurement||price||2015-12-01 23:08:47.443927@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:09:05.557555||measurement||price||2015-12-01 23:08:59.230973@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:09:12.081055||measurement||loadtime||0:00:28.771421||0||1
+2015-12-01 23:09:12.481726||measurement||loadtime||0:00:26.680676||1||0
+2015-12-01 23:09:12.618152||measurement||price||2015-12-01 23:08:54.719954@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 23:09:13.862579||error||collecting ads||Error||2||1
+2015-12-01 23:09:14.572470||measurement||price||2015-12-01 23:09:09.001409@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:09:18.335935||measurement||price||2015-12-01 23:08:59.230973@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:09:19.731172||measurement||loadtime||0:00:26.660029||3||0
+2015-12-01 23:09:25.531196||measurement||loadtime||0:00:28.596126||4||1
+2015-12-01 23:09:26.603606||measurement||price||2015-12-01 23:09:20.347845@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:09:26.889673||measurement||price||2015-12-01 23:09:09.001409@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:09:32.372418||measurement||price||2015-12-01 23:09:26.716612@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||3||0
+2015-12-01 23:09:34.007151||measurement||loadtime||0:00:26.656009||5||0
+2015-12-01 23:09:34.766235||error||collecting ads||Error||1||0
+2015-12-01 23:09:37.905519||error||collecting ads||Error||2||1
+2015-12-01 23:09:39.614580||measurement||price||2015-12-01 23:09:20.347845@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:09:44.690129||measurement||price||2015-12-01 23:09:26.716612@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||3||0
+2015-12-01 23:09:46.851153||measurement||loadtime||0:00:29.764925||0||1
+2015-12-01 23:09:47.064954||measurement||price||2015-12-01 23:09:41.397119@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:09:49.608300||error||collecting ads||Error||4||1
+2015-12-01 23:09:51.654434||measurement||price||2015-12-01 23:09:45.474571@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 23:09:51.804859||measurement||loadtime||0:00:27.068487||3||0
+2015-12-01 23:09:56.324530||error||collecting ads||Error||5||0
+2015-12-01 23:09:59.404250||measurement||price||2015-12-01 23:09:41.397119@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:10:00.911957||measurement||price||2015-12-01 23:09:54.658543@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:10:03.672975||measurement||price||2015-12-01 23:09:56.794490@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:10:04.035135||measurement||price||2015-12-01 23:09:58.437500@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 23:10:04.775366||measurement||price||2015-12-01 23:09:45.474571@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 23:10:06.533137||measurement||loadtime||0:00:26.761996||1||0
+2015-12-01 23:10:08.520793||measurement||price||2015-12-01 23:10:02.959860@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 23:10:11.955161||measurement||loadtime||0:00:29.047317||2||1
+2015-12-01 23:10:14.012025||measurement||price||2015-12-01 23:09:54.658543@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:10:16.375939||measurement||price||2015-12-01 23:09:58.437500@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 23:10:16.573143||measurement||price||2015-12-01 23:09:56.794490@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:10:20.842092||measurement||price||2015-12-01 23:10:02.959860@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 23:10:21.220133||measurement||loadtime||0:00:29.364975||0||1
+2015-12-01 23:10:23.493267||measurement||loadtime||0:00:26.686136||3||0
+2015-12-01 23:10:23.806568||measurement||loadtime||0:00:29.195413||4||1
+2015-12-01 23:10:27.951156||measurement||loadtime||0:00:26.624006||5||0
+2015-12-01 23:10:29.626817||error||collecting ads||Error||1||0
+2015-12-01 23:10:35.763636||error||collecting ads||Error||2||1
+2015-12-01 23:10:35.779056||measurement||price||2015-12-01 23:10:30.131161@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:10:37.988736||measurement||price||2015-12-01 23:10:31.223948@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:10:40.198820||measurement||price||2015-12-01 23:10:34.526994@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 23:10:45.098229||error||collecting ads||Error||0||1
+2015-12-01 23:10:48.121421||measurement||price||2015-12-01 23:10:30.131161@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:10:49.533823||measurement||price||2015-12-01 23:10:43.494722@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 23:10:50.807607||measurement||price||2015-12-01 23:10:31.223948@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:10:51.911876||error||collecting ads||Error||1||0
+2015-12-01 23:10:52.531107||measurement||price||2015-12-01 23:10:34.526994@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 23:10:55.229169||measurement||loadtime||0:00:26.730711||3||0
+2015-12-01 23:10:58.023931||measurement||loadtime||0:00:29.214217||4||1
+2015-12-01 23:10:58.817936||measurement||price||2015-12-01 23:10:52.790549@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:10:59.643732||measurement||loadtime||0:00:26.687392||5||0
+2015-12-01 23:11:02.557781||measurement||price||2015-12-01 23:10:43.494722@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 23:11:04.151384||measurement||price||2015-12-01 23:10:58.519956@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:11:07.396140||measurement||price||2015-12-01 23:11:01.848446@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 23:11:09.779740||measurement||loadtime||0:00:29.010880||2||1
+2015-12-01 23:11:11.726174||measurement||price||2015-12-01 23:10:52.790549@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:11:11.992646||measurement||price||2015-12-01 23:11:06.369295@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 23:11:12.056633||measurement||price||2015-12-01 23:11:05.300667@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:11:16.468639||measurement||price||2015-12-01 23:10:58.519956@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:11:18.929161||measurement||loadtime||0:00:28.825615||0||1
+2015-12-01 23:11:19.734842||measurement||price||2015-12-01 23:11:01.848446@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 23:11:23.579145||measurement||loadtime||0:00:26.662092||1||0
+2015-12-01 23:11:24.335529||measurement||price||2015-12-01 23:11:06.369295@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 23:11:25.153171||measurement||price||2015-12-01 23:11:05.300667@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:11:26.851632||measurement||loadtime||0:00:26.617274||3||0
+2015-12-01 23:11:31.440059||measurement||loadtime||0:00:26.792909||5||0
+2015-12-01 23:11:32.377172||measurement||loadtime||0:00:29.349266||4||1
+2015-12-01 23:11:33.666074||error||collecting ads||Error||2||1
+2015-12-01 23:11:42.806189||error||collecting ads||Error||0||1
+2015-12-01 23:11:44.161907||measurement||price||2015-12-01 23:11:38.480877@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:11:45.816664||error||collecting ads||Error||1||0
+2015-12-01 23:11:48.589648||measurement||price||2015-12-01 23:11:42.608676@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-01 23:11:49.108457||error||collecting ads||Error||3||0
+2015-12-01 23:11:56.509022||measurement||price||2015-12-01 23:11:38.480877@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:11:56.643018||error||collecting ads||Error||4||1
+2015-12-01 23:11:58.019805||measurement||price||2015-12-01 23:11:52.480719@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:12:01.440636||measurement||price||2015-12-01 23:11:42.608676@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-01 23:12:03.631160||measurement||loadtime||0:00:27.185886||5||0
+2015-12-01 23:12:06.619395||error||collecting ads||Error||0||1
+2015-12-01 23:12:08.659141||measurement||loadtime||0:00:29.988019||2||1
+2015-12-01 23:12:10.348595||measurement||price||2015-12-01 23:11:52.480719@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:12:11.258812||error||collecting ads||Error||3||0
+2015-12-01 23:12:15.924407||measurement||price||2015-12-01 23:12:10.302880@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 23:12:17.470275||measurement||loadtime||0:00:26.651143||1||0
+2015-12-01 23:12:20.463104||measurement||price||2015-12-01 23:12:14.173459@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:12:20.643132||error||collecting ads||Error||4||1
+2015-12-01 23:12:23.330550||measurement||price||2015-12-01 23:12:17.411659@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||1
+2015-12-01 23:12:23.914889||measurement||price||2015-12-01 23:12:18.299419@|3M Littmann@|$85.00 - $234.56@|3M Littmann Classic III Stethoscope (Multiple Colors)||3||0
+2015-12-01 23:12:28.257474||measurement||price||2015-12-01 23:12:10.302880@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 23:12:33.298347||measurement||price||2015-12-01 23:12:14.173459@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:12:34.709736||measurement||price||2015-12-01 23:12:27.843817@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:12:35.371963||measurement||loadtime||0:00:26.735603||5||0
+2015-12-01 23:12:36.255695||measurement||price||2015-12-01 23:12:18.299419@|3M Littmann@|$62.96 - $319.00@|3M Littmann Classic II S.E. Stethoscope (Multiple Colors)||3||0
+2015-12-01 23:12:36.320219||measurement||price||2015-12-01 23:12:17.411659@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||1
+2015-12-01 23:12:39.754819||error||collecting ads||Error||1||0
+2015-12-01 23:12:39.754915||event||progress-marker||measurement-end||1||0
+2015-12-01 23:12:40.528640||measurement||loadtime||0:00:28.904055||0||1
+2015-12-01 23:12:43.368574||measurement||loadtime||0:00:27.104538||3||0
+2015-12-01 23:12:43.775908||measurement||loadtime||0:00:30.116509||2||1
+2015-12-01 23:12:47.631301||measurement||price||2015-12-01 23:12:27.843817@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:12:54.703100||measurement||price||2015-12-01 23:12:48.409286@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:12:54.846200||measurement||loadtime||0:00:29.199041||4||1
+2015-12-01 23:12:57.541285||error||collecting ads||Error||5||0
+2015-12-01 23:12:57.541407||event||progress-marker||measurement-end||5||0
+2015-12-01 23:12:58.250021||measurement||price||2015-12-01 23:12:51.978662@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 23:13:05.563398||error||collecting ads||Error||3||0
+2015-12-01 23:13:07.582735||measurement||price||2015-12-01 23:12:48.409286@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:13:08.785581||measurement||price||2015-12-01 23:13:02.139863@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:13:11.159617||measurement||price||2015-12-01 23:12:51.978662@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 23:13:14.783200||measurement||loadtime||0:00:29.249366||0||1
+2015-12-01 23:13:18.395101||measurement||loadtime||0:00:29.613967||2||1
+2015-12-01 23:13:21.806487||measurement||price||2015-12-01 23:13:02.139863@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:13:27.748774||error||collecting ads||Error||3||0
+2015-12-01 23:13:27.748907||event||progress-marker||measurement-end||3||0
+2015-12-01 23:13:29.028015||measurement||loadtime||0:00:29.180675||4||1
+2015-12-01 23:13:32.708527||measurement||price||2015-12-01 23:13:26.228438@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 23:13:38.696856||error||collecting ads||Error||0||1
+2015-12-01 23:13:45.659865||measurement||price||2015-12-01 23:13:26.228438@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 23:13:52.494581||measurement||price||2015-12-01 23:13:46.350257@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:13:52.883168||measurement||loadtime||0:00:29.484024||2||1
+2015-12-01 23:13:53.026659||error||collecting ads||Error||4||1
+2015-12-01 23:14:05.366266||measurement||price||2015-12-01 23:13:46.350257@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:14:06.771200||measurement||price||2015-12-01 23:14:00.201078@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:14:07.235647||measurement||price||2015-12-01 23:14:01.212497@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 23:14:12.559691||measurement||loadtime||0:00:28.857647||0||1
+2015-12-01 23:14:19.815078||measurement||price||2015-12-01 23:14:00.201078@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:14:20.160363||measurement||price||2015-12-01 23:14:01.212497@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 23:14:26.417244||measurement||price||2015-12-01 23:14:20.225928@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:14:27.015151||measurement||loadtime||0:00:28.983272||4||1
+2015-12-01 23:14:27.379246||measurement||loadtime||0:00:29.490884||2||1
+2015-12-01 23:14:39.265330||measurement||price||2015-12-01 23:14:20.225928@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:14:40.950308||measurement||price||2015-12-01 23:14:34.416336@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:14:41.232560||measurement||price||2015-12-01 23:14:35.285341@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 23:14:46.449844||measurement||loadtime||0:00:28.884956||0||1
+2015-12-01 23:14:53.974086||measurement||price||2015-12-01 23:14:34.416336@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:14:54.091544||measurement||price||2015-12-01 23:14:35.285341@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 23:15:00.367607||measurement||price||2015-12-01 23:14:54.237984@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:15:01.192299||measurement||loadtime||0:00:29.173160||4||1
+2015-12-01 23:15:01.294862||measurement||loadtime||0:00:28.910512||2||1
+2015-12-01 23:15:13.206601||measurement||price||2015-12-01 23:14:54.237984@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:15:15.199265||measurement||price||2015-12-01 23:15:08.506797@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 23:15:20.403394||measurement||loadtime||0:00:28.951610||0||1
+2015-12-01 23:15:25.066737||error||collecting ads||Error||2||1
+2015-12-01 23:15:28.062132||measurement||price||2015-12-01 23:15:08.506797@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 23:15:35.239146||measurement||loadtime||0:00:29.041631||4||1
+2015-12-01 23:15:44.290141||error||collecting ads||Error||0||1
+2015-12-01 23:15:49.027126||measurement||price||2015-12-01 23:15:42.496139@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 23:15:49.106095||error||collecting ads||Error||2||1
+2015-12-01 23:15:49.106187||event||progress-marker||measurement-end||2||1
+2015-12-01 23:15:57.947354||measurement||price||2015-12-01 23:15:51.840083@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:16:01.853131||measurement||price||2015-12-01 23:15:42.496139@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 23:16:09.056309||measurement||loadtime||0:00:28.811950||4||1
+2015-12-01 23:16:09.056442||event||progress-marker||measurement-end||4||1
+2015-12-01 23:16:10.860551||measurement||price||2015-12-01 23:15:51.840083@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:16:18.042289||measurement||loadtime||0:00:28.746880||0||1
+2015-12-01 23:16:18.042432||event||progress-marker||measurement-end||0||1
+2015-12-01 23:16:18.626179||meta||block_id end||9
+2015-12-01 23:16:18.626463||meta||block_id start||10
+2015-12-01 23:16:18.626493||meta||assignment||2@|4@|1@|5@|3@|0
+2015-12-01 23:16:20.257961||event||progress-marker||training-start||1||0
+2015-12-01 23:16:20.314577||event||progress-marker||training-start||2||0
+2015-12-01 23:16:20.333510||event||progress-marker||training-start||4||0
+2015-12-01 23:16:25.811123||event||progress-marker||training-start||5||1
+2015-12-01 23:16:27.011138||treatment||visit website||http://irs.gov||4||0
+2015-12-01 23:16:27.027097||treatment||visit website||http://irs.gov||1||0
+2015-12-01 23:16:27.175134||treatment||visit website||http://irs.gov||2||0
+2015-12-01 23:16:32.651096||treatment||visit website||http://irs.gov||5||1
+2015-12-01 23:16:34.709884||treatment||visit website||http://deloitte.com||4||0
+2015-12-01 23:16:34.711427||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 23:16:34.713104||treatment||visit website||http://deloitte.com||1||0
+2015-12-01 23:16:42.915101||treatment||visit website||http://pwc.com||4||0
+2015-12-01 23:16:42.918332||treatment||visit website||http://pwc.com||1||0
+2015-12-01 23:16:42.943103||treatment||visit website||http://pwc.com||2||0
+2015-12-01 23:16:44.301029||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 23:16:48.779131||treatment||visit website||http://ey.com||4||0
+2015-12-01 23:16:48.815110||treatment||visit website||http://ey.com||2||0
+2015-12-01 23:16:48.907121||treatment||visit website||http://ey.com||1||0
+2015-12-01 23:16:52.904164||treatment||visit website||http://pwc.com||5||1
+2015-12-01 23:16:55.550183||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 23:16:55.550292||event||progress-marker||training-end||2||0
+2015-12-01 23:16:55.600885||treatment||visit website||http://kpmg.com||4||0
+2015-12-01 23:16:55.600959||event||progress-marker||training-end||4||0
+2015-12-01 23:16:55.659085||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 23:16:55.659165||event||progress-marker||training-end||1||0
+2015-12-01 23:16:58.912203||treatment||visit website||http://ey.com||5||1
+2015-12-01 23:17:05.535091||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 23:17:05.535190||event||progress-marker||training-end||5||1
+2015-12-01 23:17:05.598055||event||progress-marker||measurement-start||2||0
+2015-12-01 23:17:05.649715||event||progress-marker||measurement-start||4||0
+2015-12-01 23:17:05.709189||event||progress-marker||measurement-start||1||0
+2015-12-01 23:17:10.562289||event||progress-marker||measurement-start||5||1
+2015-12-01 23:17:25.015439||measurement||price||2015-12-01 23:17:18.701079@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:17:27.803693||event||progress-marker||training-start||3||1
+2015-12-01 23:17:29.116188||error||collecting ads||Error||2||0
+2015-12-01 23:17:29.146489||error||collecting ads||Error||1||0
+2015-12-01 23:17:30.553058||error||collecting ads||Error||4||0
+2015-12-01 23:17:37.742993||treatment||visit website||http://irs.gov||3||1
+2015-12-01 23:17:37.868376||measurement||price||2015-12-01 23:17:18.701079@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:17:43.164428||measurement||price||2015-12-01 23:17:37.391043@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:17:45.073275||measurement||loadtime||0:00:29.506125||5||1
+2015-12-01 23:17:46.551355||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 23:17:51.458641||error||collecting ads||Error||2||0
+2015-12-01 23:17:52.149707||error||collecting ads||Error||1||0
+2015-12-01 23:17:53.291097||event||progress-marker||training-start||0||1
+2015-12-01 23:17:55.473081||measurement||price||2015-12-01 23:17:37.391043@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:17:55.493032||treatment||visit website||http://pwc.com||3||1
+2015-12-01 23:17:58.894051||measurement||price||2015-12-01 23:17:52.845254@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:17:59.791118||treatment||visit website||http://irs.gov||0||1
+2015-12-01 23:18:01.668292||treatment||visit website||http://ey.com||3||1
+2015-12-01 23:18:02.559161||measurement||loadtime||0:00:27.004033||4||0
+2015-12-01 23:18:03.782579||measurement||price||2015-12-01 23:17:58.303483@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:18:04.834484||measurement||price||2015-12-01 23:17:59.404534@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:18:06.940042||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 23:18:08.636100||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 23:18:08.636200||event||progress-marker||training-end||3||1
+2015-12-01 23:18:11.715605||measurement||price||2015-12-01 23:17:52.845254@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:18:14.938895||measurement||price||2015-12-01 23:18:09.355196@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:18:15.945200||treatment||visit website||http://pwc.com||0||1
+2015-12-01 23:18:16.109585||measurement||price||2015-12-01 23:17:58.303483@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:18:17.177451||measurement||price||2015-12-01 23:17:59.404534@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:18:18.946909||measurement||loadtime||0:00:28.869316||5||1
+2015-12-01 23:18:21.933313||treatment||visit website||http://ey.com||0||1
+2015-12-01 23:18:23.215491||measurement||loadtime||0:00:26.752093||2||0
+2015-12-01 23:18:24.284136||measurement||loadtime||0:00:27.132998||1||0
+2015-12-01 23:18:27.253825||measurement||price||2015-12-01 23:18:09.355196@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:18:29.189533||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 23:18:29.189722||event||progress-marker||training-end||0||1
+2015-12-01 23:18:32.866050||measurement||price||2015-12-01 23:18:26.652831@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:18:33.741021||event||progress-marker||measurement-start||3||1
+2015-12-01 23:18:34.214774||event||progress-marker||measurement-start||0||1
+2015-12-01 23:18:34.359141||measurement||loadtime||0:00:26.796017||4||0
+2015-12-01 23:18:35.424102||measurement||price||2015-12-01 23:18:29.906608@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:18:37.086335||measurement||price||2015-12-01 23:18:31.737550@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:18:45.785982||measurement||price||2015-12-01 23:18:26.652831@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:18:46.715096||measurement||price||2015-12-01 23:18:41.195071@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:18:47.745775||measurement||price||2015-12-01 23:18:29.906608@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:18:48.491407||measurement||price||2015-12-01 23:18:42.026842@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:18:48.968368||measurement||price||2015-12-01 23:18:42.686310@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:18:49.399368||measurement||price||2015-12-01 23:18:31.737550@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:18:52.984606||measurement||loadtime||0:00:29.033450||5||1
+2015-12-01 23:18:54.854015||measurement||loadtime||0:00:26.634839||2||0
+2015-12-01 23:18:56.509174||measurement||loadtime||0:00:27.222031||1||0
+2015-12-01 23:18:59.023593||measurement||price||2015-12-01 23:18:41.195071@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:19:01.339232||measurement||price||2015-12-01 23:18:42.026842@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:19:01.814235||measurement||price||2015-12-01 23:18:42.686310@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:19:06.139327||measurement||loadtime||0:00:26.775034||4||0
+2015-12-01 23:19:06.922758||measurement||price||2015-12-01 23:19:00.713263@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:19:07.345161||measurement||price||2015-12-01 23:19:01.663904@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:19:08.539172||measurement||loadtime||0:00:29.792936||3||1
+2015-12-01 23:19:09.039970||measurement||loadtime||0:00:29.820810||0||1
+2015-12-01 23:19:09.685164||measurement||price||2015-12-01 23:19:04.233148@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||0
+2015-12-01 23:19:18.521945||measurement||price||2015-12-01 23:19:12.978860@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:19:19.646789||measurement||price||2015-12-01 23:19:01.663904@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:19:19.798024||measurement||price||2015-12-01 23:19:00.713263@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:19:22.014507||measurement||price||2015-12-01 23:19:04.233148@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||0
+2015-12-01 23:19:23.091172||measurement||price||2015-12-01 23:19:16.410644@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:19:23.325452||measurement||price||2015-12-01 23:19:16.997558@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:19:26.732603||measurement||loadtime||0:00:26.876746||2||0
+2015-12-01 23:19:26.994317||measurement||loadtime||0:00:29.004507||5||1
+2015-12-01 23:19:29.102671||measurement||loadtime||0:00:27.588290||1||0
+2015-12-01 23:19:30.858100||measurement||price||2015-12-01 23:19:12.978860@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:19:36.220914||measurement||price||2015-12-01 23:19:16.410644@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:19:36.438950||measurement||price||2015-12-01 23:19:16.997558@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:19:37.977814||measurement||loadtime||0:00:26.833316||4||0
+2015-12-01 23:19:38.948552||measurement||price||2015-12-01 23:19:33.442902@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:19:40.902528||measurement||price||2015-12-01 23:19:34.825358@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:19:41.931794||measurement||price||2015-12-01 23:19:36.526717@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:19:43.444286||measurement||loadtime||0:00:29.899929||3||1
+2015-12-01 23:19:43.678031||measurement||loadtime||0:00:29.570883||0||1
+2015-12-01 23:19:51.232053||measurement||price||2015-12-01 23:19:33.442902@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:19:53.785331||measurement||price||2015-12-01 23:19:34.825358@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:19:54.255910||measurement||price||2015-12-01 23:19:36.526717@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:19:57.793508||measurement||price||2015-12-01 23:19:51.615228@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:19:57.932563||measurement||price||2015-12-01 23:19:51.349966@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||1
+2015-12-01 23:19:58.323186||measurement||loadtime||0:00:26.588046||2||0
+2015-12-01 23:20:00.347599||error||collecting ads||Error||4||0
+2015-12-01 23:20:00.975860||measurement||loadtime||0:00:28.976693||5||1
+2015-12-01 23:20:01.367181||measurement||loadtime||0:00:27.263134||1||0
+2015-12-01 23:20:10.620198||measurement||price||2015-12-01 23:20:05.112334@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:20:10.851888||measurement||price||2015-12-01 23:19:51.615228@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:20:10.916401||measurement||price||2015-12-01 23:19:51.349966@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||1
+2015-12-01 23:20:12.706252||measurement||price||2015-12-01 23:20:07.180081@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:20:14.217774||measurement||price||2015-12-01 23:20:08.780776@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:20:15.054857||measurement||price||2015-12-01 23:20:08.876107@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:20:18.067310||measurement||loadtime||0:00:29.384180||0||1
+2015-12-01 23:20:18.122788||measurement||loadtime||0:00:29.675642||3||1
+2015-12-01 23:20:22.944447||measurement||price||2015-12-01 23:20:05.112334@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:20:25.008974||measurement||price||2015-12-01 23:20:07.180081@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:20:26.518641||measurement||price||2015-12-01 23:20:08.780776@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:20:27.977895||measurement||price||2015-12-01 23:20:08.876107@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:20:30.067173||measurement||loadtime||0:00:26.738746||2||0
+2015-12-01 23:20:32.088752||measurement||price||2015-12-01 23:20:25.830709@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:20:32.119131||measurement||loadtime||0:00:26.768020||4||0
+2015-12-01 23:20:33.602264||measurement||loadtime||0:00:27.230329||1||0
+2015-12-01 23:20:35.175146||measurement||loadtime||0:00:29.196009||5||1
+2015-12-01 23:20:42.205063||error||collecting ads||Error||3||1
+2015-12-01 23:20:42.437084||measurement||price||2015-12-01 23:20:36.841087@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:20:45.157304||measurement||price||2015-12-01 23:20:25.830709@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:20:49.143312||measurement||price||2015-12-01 23:20:43.025929@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:20:52.379498||measurement||loadtime||0:00:29.308345||0||1
+2015-12-01 23:20:54.395554||error||collecting ads||Error||4||0
+2015-12-01 23:20:54.792030||measurement||price||2015-12-01 23:20:36.841087@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:20:55.891314||measurement||price||2015-12-01 23:20:49.899866@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:20:56.312225||error||collecting ads||Error||1||0
+2015-12-01 23:21:01.903158||measurement||loadtime||0:00:26.830771||2||0
+2015-12-01 23:21:02.177663||measurement||price||2015-12-01 23:20:43.025929@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:21:06.260028||measurement||price||2015-12-01 23:21:00.084812@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:21:08.992885||measurement||price||2015-12-01 23:21:03.543435@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:21:09.000628||measurement||price||2015-12-01 23:20:49.899866@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:21:09.399170||measurement||loadtime||0:00:29.220022||5||1
+2015-12-01 23:21:14.395922||measurement||price||2015-12-01 23:21:08.692080@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:21:16.239131||measurement||loadtime||0:00:29.028883||3||1
+2015-12-01 23:21:16.733042||error||collecting ads||Error||4||0
+2015-12-01 23:21:19.199292||measurement||price||2015-12-01 23:21:00.084812@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:21:21.335011||measurement||price||2015-12-01 23:21:03.543435@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:21:23.262259||measurement||price||2015-12-01 23:21:17.202243@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:21:26.379932||measurement||loadtime||0:00:28.995207||0||1
+2015-12-01 23:21:26.725759||measurement||price||2015-12-01 23:21:08.692080@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:21:28.440534||measurement||loadtime||0:00:27.123117||1||0
+2015-12-01 23:21:29.085883||measurement||price||2015-12-01 23:21:23.523292@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:21:33.831157||measurement||loadtime||0:00:26.922811||2||0
+2015-12-01 23:21:36.231377||measurement||price||2015-12-01 23:21:17.202243@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:21:40.187262||error||collecting ads||Error||3||1
+2015-12-01 23:21:41.157818||measurement||price||2015-12-01 23:21:35.350975@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:21:41.431409||measurement||price||2015-12-01 23:21:23.523292@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:21:43.443470||measurement||loadtime||0:00:29.040342||5||1
+2015-12-01 23:21:46.079987||measurement||price||2015-12-01 23:21:40.474403@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:21:48.563167||measurement||loadtime||0:00:26.828032||4||0
+2015-12-01 23:21:50.220589||error||collecting ads||Error||0||1
+2015-12-01 23:21:53.484270||measurement||price||2015-12-01 23:21:35.350975@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:21:58.371951||measurement||price||2015-12-01 23:21:40.474403@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:22:00.599152||measurement||loadtime||0:00:27.155528||1||0
+2015-12-01 23:22:00.775264||measurement||price||2015-12-01 23:21:55.167197@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:22:03.945285||error||collecting ads||Error||3||1
+2015-12-01 23:22:04.059427||measurement||price||2015-12-01 23:21:57.821532@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:22:05.458468||measurement||loadtime||0:00:26.624705||2||0
+2015-12-01 23:22:08.040612||error||collecting ads||Error||5||1
+2015-12-01 23:22:13.109317||measurement||price||2015-12-01 23:21:55.167197@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:22:13.410688||measurement||price||2015-12-01 23:22:07.947131@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:22:16.970596||measurement||price||2015-12-01 23:21:57.821532@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:22:17.963841||measurement||price||2015-12-01 23:22:11.192377@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:22:18.499737||measurement||price||2015-12-01 23:22:12.661303@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:22:20.232601||measurement||loadtime||0:00:26.664770||4||0
+2015-12-01 23:22:21.794806||measurement||price||2015-12-01 23:22:15.622866@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:22:24.165475||measurement||loadtime||0:00:28.942323||0||1
+2015-12-01 23:22:25.763480||measurement||price||2015-12-01 23:22:07.947131@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:22:30.846598||measurement||price||2015-12-01 23:22:12.661303@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:22:31.010220||measurement||price||2015-12-01 23:22:11.192377@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:22:32.773311||measurement||price||2015-12-01 23:22:27.288073@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:22:32.879160||measurement||loadtime||0:00:27.276041||1||0
+2015-12-01 23:22:34.601670||measurement||price||2015-12-01 23:22:15.622866@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:22:37.961035||measurement||loadtime||0:00:27.497914||2||0
+2015-12-01 23:22:38.235162||measurement||loadtime||0:00:29.286762||3||1
+2015-12-01 23:22:41.803134||measurement||loadtime||0:00:28.760009||5||1
+2015-12-01 23:22:45.113683||measurement||price||2015-12-01 23:22:27.288073@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:22:47.862049||error||collecting ads||Error||0||1
+2015-12-01 23:22:52.231397||measurement||price||2015-12-01 23:22:45.546351@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:22:52.243116||measurement||loadtime||0:00:27.005357||4||0
+2015-12-01 23:22:55.677935||error||collecting ads||Error||1||0
+2015-12-01 23:22:55.812554||measurement||price||2015-12-01 23:22:49.428263@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:23:00.350769||error||collecting ads||Error||2||0
+2015-12-01 23:23:05.274013||measurement||price||2015-12-01 23:22:45.546351@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:23:09.157541||measurement||price||2015-12-01 23:22:49.428263@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:23:12.466450||measurement||loadtime||0:00:29.227320||3||1
+2015-12-01 23:23:12.719842||measurement||price||2015-12-01 23:23:02.024653@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:23:13.403648||measurement||price||2015-12-01 23:23:07.998245@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:23:15.336756||measurement||price||2015-12-01 23:23:09.998012@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||1||0
+2015-12-01 23:23:16.395441||measurement||loadtime||0:00:29.589794||5||1
+2015-12-01 23:23:19.363279||measurement||price||2015-12-01 23:23:14.005010@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:23:25.622843||measurement||price||2015-12-01 23:23:02.024653@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:23:25.768536||measurement||price||2015-12-01 23:23:07.998245@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:23:27.685803||measurement||price||2015-12-01 23:23:09.998012@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||0
+2015-12-01 23:23:29.109485||measurement||price||2015-12-01 23:23:23.032408@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:23:31.693767||measurement||price||2015-12-01 23:23:14.005010@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:23:32.094543||measurement||price||2015-12-01 23:23:25.844992@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:23:32.820612||measurement||loadtime||0:00:39.953322||0||1
+2015-12-01 23:23:32.876288||measurement||loadtime||0:00:35.628004||4||0
+2015-12-01 23:23:34.791172||measurement||loadtime||0:00:34.109224||1||0
+2015-12-01 23:23:38.795877||measurement||loadtime||0:00:33.440735||2||0
+2015-12-01 23:23:41.981341||measurement||price||2015-12-01 23:23:23.032408@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:23:44.923490||measurement||price||2015-12-01 23:23:25.844992@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:23:45.839859||measurement||price||2015-12-01 23:23:40.257253@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||4||0
+2015-12-01 23:23:46.953554||measurement||price||2015-12-01 23:23:40.642708@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:23:47.542970||measurement||price||2015-12-01 23:23:42.109235@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:23:49.185815||measurement||loadtime||0:00:31.714167||3||1
+2015-12-01 23:23:51.018185||measurement||price||2015-12-01 23:23:45.435622@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:23:52.121414||measurement||loadtime||0:00:30.720783||5||1
+2015-12-01 23:23:58.166178||measurement||price||2015-12-01 23:23:40.257253@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||4||0
+2015-12-01 23:23:59.808980||measurement||price||2015-12-01 23:23:40.642708@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:23:59.877451||measurement||price||2015-12-01 23:23:42.109235@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:24:02.992748||measurement||price||2015-12-01 23:23:56.440444@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:24:03.323129||measurement||price||2015-12-01 23:23:45.435622@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:24:05.296084||measurement||loadtime||0:00:27.414595||4||0
+2015-12-01 23:24:06.118548||measurement||price||2015-12-01 23:23:59.895248@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:24:07.005390||measurement||loadtime||0:00:27.210241||1||0
+2015-12-01 23:24:07.027158||measurement||loadtime||0:00:29.204040||0||1
+2015-12-01 23:24:10.411196||measurement||loadtime||0:00:26.611270||2||0
+2015-12-01 23:24:15.819656||measurement||price||2015-12-01 23:23:56.440444@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:24:18.985242||measurement||price||2015-12-01 23:23:59.895248@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:24:21.028364||measurement||price||2015-12-01 23:24:14.847216@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:24:22.742300||measurement||price||2015-12-01 23:24:17.149409@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:24:23.034467||measurement||loadtime||0:00:28.845091||3||1
+2015-12-01 23:24:26.197036||measurement||loadtime||0:00:29.074080||5||1
+2015-12-01 23:24:27.575569||error||collecting ads||Error||4||0
+2015-12-01 23:24:29.792618||error||collecting ads||Error||1||0
+2015-12-01 23:24:33.956828||measurement||price||2015-12-01 23:24:14.847216@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:24:35.038140||measurement||price||2015-12-01 23:24:17.149409@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:24:36.877144||measurement||price||2015-12-01 23:24:30.293967@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:24:40.402942||measurement||price||2015-12-01 23:24:34.684481@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||4||0
+2015-12-01 23:24:41.155437||measurement||loadtime||0:00:29.124291||0||1
+2015-12-01 23:24:42.132621||measurement||loadtime||0:00:26.717469||2||0
+2015-12-01 23:24:49.767484||measurement||price||2015-12-01 23:24:30.293967@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:24:49.999137||error||collecting ads||Error||5||1
+2015-12-01 23:24:52.486650||error||collecting ads||Error||1||0
+2015-12-01 23:24:55.228358||measurement||price||2015-12-01 23:24:48.940532@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:24:56.995386||measurement||loadtime||0:00:28.956032||3||1
+2015-12-01 23:25:02.717682||error||collecting ads||Error||4||0
+2015-12-01 23:25:03.823453||measurement||price||2015-12-01 23:24:57.618257@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:25:04.580085||error||collecting ads||Error||2||0
+2015-12-01 23:25:08.281011||measurement||price||2015-12-01 23:24:48.940532@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:25:10.866859||measurement||price||2015-12-01 23:25:04.281138@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:25:14.988473||measurement||price||2015-12-01 23:25:09.396806@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:25:15.228609||error||collecting ads||Error||1||0
+2015-12-01 23:25:15.491153||measurement||loadtime||0:00:29.332022||0||1
+2015-12-01 23:25:16.840815||measurement||price||2015-12-01 23:24:57.618257@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:25:23.883314||measurement||price||2015-12-01 23:25:04.281138@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:25:24.051508||measurement||loadtime||0:00:29.047032||5||1
+2015-12-01 23:25:26.931252||error||collecting ads||Error||2||0
+2015-12-01 23:25:27.310147||measurement||price||2015-12-01 23:25:09.396806@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:25:29.604462||measurement||price||2015-12-01 23:25:23.390923@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:25:31.064388||measurement||loadtime||0:00:29.063780||3||1
+2015-12-01 23:25:34.419152||measurement||loadtime||0:00:26.696297||4||0
+2015-12-01 23:25:38.025417||error||collecting ads||Error||1||0
+2015-12-01 23:25:42.678931||measurement||price||2015-12-01 23:25:23.390923@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:25:46.751953||measurement||price||2015-12-01 23:25:41.160338@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:25:46.894583||measurement||price||2015-12-01 23:25:40.873875@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:25:47.864817||error||collecting ads||Error||5||1
+2015-12-01 23:25:49.709366||error||collecting ads||Error||2||0
+2015-12-01 23:25:49.906900||measurement||loadtime||0:00:29.411750||0||1
+2015-12-01 23:25:59.083324||measurement||price||2015-12-01 23:25:41.160338@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:26:00.075376||measurement||price||2015-12-01 23:25:40.873875@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:26:00.670203||error||collecting ads||Error||1||0
+2015-12-01 23:26:01.736706||measurement||price||2015-12-01 23:25:55.493252@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:26:02.118822||measurement||price||2015-12-01 23:25:56.512173@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:26:04.129296||measurement||price||2015-12-01 23:25:57.850465@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:26:06.196430||measurement||loadtime||0:00:26.773242||4||0
+2015-12-01 23:26:07.311133||measurement||loadtime||0:00:31.243672||3||1
+2015-12-01 23:26:13.324856||measurement||price||2015-12-01 23:26:07.963983@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:26:14.396202||measurement||price||2015-12-01 23:25:56.512173@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:26:14.614388||measurement||price||2015-12-01 23:25:55.493252@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:26:17.103428||measurement||price||2015-12-01 23:25:57.850465@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:26:18.490206||measurement||price||2015-12-01 23:26:12.861874@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:26:21.487766||measurement||loadtime||0:00:26.773192||2||0
+2015-12-01 23:26:21.540397||measurement||price||2015-12-01 23:26:15.421881@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||1
+2015-12-01 23:26:21.832380||measurement||loadtime||0:00:28.962370||5||1
+2015-12-01 23:26:24.313183||measurement||loadtime||0:00:29.402048||0||1
+2015-12-01 23:26:25.657769||measurement||price||2015-12-01 23:26:07.963983@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:26:30.823936||measurement||price||2015-12-01 23:26:12.861874@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:26:32.767180||measurement||loadtime||0:00:27.091783||1||0
+2015-12-01 23:26:32.767273||event||progress-marker||measurement-end||1||0
+2015-12-01 23:26:34.156986||measurement||price||2015-12-01 23:26:28.571663@|@|$118.00@|BLU Studio 7.0 II -Unlocked Smartphone - US GSM - Gold||2||0
+2015-12-01 23:26:34.429952||measurement||price||2015-12-01 23:26:15.421881@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||1
+2015-12-01 23:26:35.813695||measurement||price||2015-12-01 23:26:29.734227@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:26:37.942738||measurement||loadtime||0:00:26.741120||4||0
+2015-12-01 23:26:38.150989||measurement||price||2015-12-01 23:26:32.023691@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:26:41.643198||measurement||loadtime||0:00:29.328034||3||1
+2015-12-01 23:26:46.487524||measurement||price||2015-12-01 23:26:28.571663@|@|$199.00@|BLU Vivo Air LTE Smartphone - GSM Unlocked - Black||2||0
+2015-12-01 23:26:48.654133||measurement||price||2015-12-01 23:26:29.734227@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:26:50.244703||measurement||price||2015-12-01 23:26:44.624248@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:26:51.187413||measurement||price||2015-12-01 23:26:32.023691@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:26:53.591340||measurement||loadtime||0:00:27.098353||2||0
+2015-12-01 23:26:53.591473||event||progress-marker||measurement-end||2||0
+2015-12-01 23:26:55.467103||measurement||price||2015-12-01 23:26:48.981238@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:26:55.842512||measurement||loadtime||0:00:29.004961||5||1
+2015-12-01 23:26:58.387869||measurement||loadtime||0:00:29.069497||0||1
+2015-12-01 23:27:02.573048||measurement||price||2015-12-01 23:26:44.624248@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:27:08.367709||measurement||price||2015-12-01 23:26:48.981238@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:27:09.679166||measurement||loadtime||0:00:26.732625||4||0
+2015-12-01 23:27:09.679260||event||progress-marker||measurement-end||4||0
+2015-12-01 23:27:09.773826||measurement||price||2015-12-01 23:27:03.518072@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:27:12.184763||measurement||price||2015-12-01 23:27:06.072904@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:27:15.552172||measurement||loadtime||0:00:28.903727||3||1
+2015-12-01 23:27:22.716048||measurement||price||2015-12-01 23:27:03.518072@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:27:25.058980||measurement||price||2015-12-01 23:27:06.072904@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:27:29.902381||measurement||loadtime||0:00:29.054689||5||1
+2015-12-01 23:27:32.243867||measurement||loadtime||0:00:28.852714||0||1
+2015-12-01 23:27:39.382573||error||collecting ads||Error||3||1
+2015-12-01 23:27:43.625099||measurement||price||2015-12-01 23:27:37.399098@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:27:46.127909||measurement||price||2015-12-01 23:27:39.972558@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:27:53.631636||measurement||price||2015-12-01 23:27:47.323559@|Makita@|$549.00@|Makita XT601 18-volt LXT Lithium-Ion Cordless Combo Kit, 6-P...||3||1
+2015-12-01 23:27:56.557577||measurement||price||2015-12-01 23:27:37.399098@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:27:58.932261||measurement||price||2015-12-01 23:27:39.972558@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:28:03.743190||measurement||loadtime||0:00:28.835626||5||1
+2015-12-01 23:28:03.743322||event||progress-marker||measurement-end||5||1
+2015-12-01 23:28:06.115412||measurement||loadtime||0:00:28.868276||0||1
+2015-12-01 23:28:06.509229||measurement||price||2015-12-01 23:27:47.323559@|Makita@|$469.00@|Makita BBX7600N 75.6 CC 4-Stroke Backpack Blower||3||1
+2015-12-01 23:28:13.707127||measurement||loadtime||0:00:29.323153||3||1
+2015-12-01 23:28:19.828880||measurement||price||2015-12-01 23:28:13.730852@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:28:27.471476||measurement||price||2015-12-01 23:28:20.991993@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:28:32.673447||measurement||price||2015-12-01 23:28:13.730852@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:28:39.863153||measurement||loadtime||0:00:28.742483||0||1
+2015-12-01 23:28:40.244831||measurement||price||2015-12-01 23:28:20.991993@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:28:47.439667||measurement||loadtime||0:00:28.727340||3||1
+2015-12-01 23:29:01.263250||measurement||price||2015-12-01 23:28:54.674371@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:29:03.641737||error||collecting ads||Error||0||1
+2015-12-01 23:29:14.154132||measurement||price||2015-12-01 23:28:54.674371@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:29:21.335895||measurement||loadtime||0:00:28.891010||3||1
+2015-12-01 23:29:21.336027||event||progress-marker||measurement-end||3||1
+2015-12-01 23:29:27.341931||error||collecting ads||Error||0||1
+2015-12-01 23:29:27.342033||event||progress-marker||measurement-end||0||1
+2015-12-01 23:29:27.966745||meta||block_id end||10
+2015-12-01 23:29:27.966962||meta||block_id start||11
+2015-12-01 23:29:27.966980||meta||assignment||4@|1@|2@|5@|0@|3
+2015-12-01 23:29:29.570659||event||progress-marker||training-start||2||0
+2015-12-01 23:29:29.612307||event||progress-marker||training-start||1||0
+2015-12-01 23:29:29.630885||event||progress-marker||training-start||4||0
+2015-12-01 23:29:36.107130||treatment||visit website||http://irs.gov||2||0
+2015-12-01 23:29:36.279127||treatment||visit website||http://irs.gov||1||0
+2015-12-01 23:29:36.335144||treatment||visit website||http://irs.gov||4||0
+2015-12-01 23:29:43.471122||treatment||visit website||http://deloitte.com||4||0
+2015-12-01 23:29:43.583121||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 23:29:44.958351||treatment||visit website||http://deloitte.com||1||0
+2015-12-01 23:29:51.723097||treatment||visit website||http://pwc.com||4||0
+2015-12-01 23:29:51.751097||treatment||visit website||http://pwc.com||2||0
+2015-12-01 23:29:53.006823||treatment||visit website||http://pwc.com||1||0
+2015-12-01 23:29:57.580467||treatment||visit website||http://ey.com||2||0
+2015-12-01 23:29:57.599087||treatment||visit website||http://ey.com||4||0
+2015-12-01 23:29:58.869502||treatment||visit website||http://ey.com||1||0
+2015-12-01 23:30:04.445706||treatment||visit website||http://kpmg.com||4||0
+2015-12-01 23:30:04.445811||event||progress-marker||training-end||4||0
+2015-12-01 23:30:05.938558||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 23:30:05.938656||event||progress-marker||training-end||2||0
+2015-12-01 23:30:13.903105||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 23:30:13.903212||event||progress-marker||training-end||1||0
+2015-12-01 23:30:14.498728||event||progress-marker||measurement-start||4||0
+2015-12-01 23:30:15.987869||event||progress-marker||measurement-start||2||0
+2015-12-01 23:30:18.937426||event||progress-marker||measurement-start||1||0
+2015-12-01 23:30:28.127755||measurement||price||2015-12-01 23:30:22.062211@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:30:29.304451||measurement||price||2015-12-01 23:30:23.867248@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||2||0
+2015-12-01 23:30:32.311635||measurement||price||2015-12-01 23:30:26.421893@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:30:40.467893||measurement||price||2015-12-01 23:30:22.062211@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:30:44.665249||measurement||price||2015-12-01 23:30:26.421893@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:30:47.555160||measurement||loadtime||0:00:28.052805||4||0
+2015-12-01 23:30:51.642030||error||collecting ads||Error||2||0
+2015-12-01 23:30:51.782879||measurement||loadtime||0:00:27.843737||1||0
+2015-12-01 23:30:52.329781||event||progress-marker||training-start||5||1
+2015-12-01 23:30:58.823110||treatment||visit website||http://irs.gov||5||1
+2015-12-01 23:31:01.510969||event||progress-marker||training-start||0||1
+2015-12-01 23:31:04.199866||measurement||price||2015-12-01 23:30:58.763095@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:31:04.424832||measurement||price||2015-12-01 23:30:59.005270@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:31:05.856472||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 23:31:07.839089||treatment||visit website||http://irs.gov||0||1
+2015-12-01 23:31:10.102536||error||collecting ads||Error||4||0
+2015-12-01 23:31:14.531123||treatment||visit website||http://pwc.com||5||1
+2015-12-01 23:31:16.534330||measurement||price||2015-12-01 23:30:58.763095@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:31:16.720875||measurement||price||2015-12-01 23:30:59.005270@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:31:16.991401||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 23:31:20.551100||treatment||visit website||http://ey.com||5||1
+2015-12-01 23:31:23.624783||measurement||loadtime||0:00:26.977558||2||0
+2015-12-01 23:31:23.808992||measurement||loadtime||0:00:27.023498||1||0
+2015-12-01 23:31:24.360470||measurement||price||2015-12-01 23:31:19.053639@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:31:30.376099||treatment||visit website||http://pwc.com||0||1
+2015-12-01 23:31:36.704695||measurement||price||2015-12-01 23:31:19.053639@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:31:42.451943||measurement||price||2015-12-01 23:31:37.105097@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:31:43.091534||treatment||visit website||http://ey.com||0||1
+2015-12-01 23:31:43.219101||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 23:31:43.219198||event||progress-marker||training-end||5||1
+2015-12-01 23:31:43.828337||measurement||loadtime||0:00:28.721180||4||0
+2015-12-01 23:31:44.460190||event||progress-marker||training-start||3||1
+2015-12-01 23:31:50.798712||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 23:31:50.798816||event||progress-marker||training-end||0||1
+2015-12-01 23:31:51.023124||treatment||visit website||http://irs.gov||3||1
+2015-12-01 23:31:51.517266||error||collecting ads||Error||2||0
+2015-12-01 23:31:54.751525||measurement||price||2015-12-01 23:31:37.105097@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:31:56.507413||measurement||price||2015-12-01 23:31:51.139278@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:31:57.630093||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 23:32:01.839590||measurement||loadtime||0:00:33.025397||1||0
+2015-12-01 23:32:08.827857||measurement||price||2015-12-01 23:31:51.139278@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:32:12.001953||treatment||visit website||http://pwc.com||3||1
+2015-12-01 23:32:14.783069||measurement||price||2015-12-01 23:32:09.363190@|Extech@|$17.75@|Extech MN35 Digital Mini MultiMeter||1||0
+2015-12-01 23:32:15.952430||measurement||loadtime||0:00:27.118911||4||0
+2015-12-01 23:32:17.413172||error||collecting ads||Error||2||0
+2015-12-01 23:32:17.936191||treatment||visit website||http://ey.com||3||1
+2015-12-01 23:32:27.103265||measurement||price||2015-12-01 23:32:09.363190@|Extech@|$39.99@|Extech CB10 Circuit Breaker Finder locates fuses/breakers, t...||1||0
+2015-12-01 23:32:28.787761||measurement||price||2015-12-01 23:32:23.308434@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:32:34.206251||measurement||loadtime||0:00:27.361461||1||0
+2015-12-01 23:32:39.839410||error||collecting ads||Error||2||0
+2015-12-01 23:32:41.086828||measurement||price||2015-12-01 23:32:23.308434@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:32:43.743522||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 23:32:43.743664||event||progress-marker||training-end||3||1
+2015-12-01 23:32:46.003599||event||progress-marker||measurement-start||0||1
+2015-12-01 23:32:48.173312||measurement||loadtime||0:00:27.215721||4||0
+2015-12-01 23:32:48.459483||event||progress-marker||measurement-start||5||1
+2015-12-01 23:32:48.776722||event||progress-marker||measurement-start||3||1
+2015-12-01 23:32:52.357963||measurement||price||2015-12-01 23:32:46.947449@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:32:56.718407||error||collecting ads||Error||1||0
+2015-12-01 23:33:03.054064||measurement||price||2015-12-01 23:32:56.442467@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:33:03.412126||measurement||price||2015-12-01 23:32:56.815812@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:33:04.696653||measurement||price||2015-12-01 23:32:46.947449@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:33:09.261201||measurement||price||2015-12-01 23:33:03.882352@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:33:10.901147||error||collecting ads||Error||0||1
+2015-12-01 23:33:11.474434||error||collecting ads||Error||4||0
+2015-12-01 23:33:11.809758||measurement||loadtime||0:00:26.965124||2||0
+2015-12-01 23:33:15.851779||measurement||price||2015-12-01 23:32:56.442467@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:33:16.292839||measurement||price||2015-12-01 23:32:56.815812@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:33:21.584178||measurement||price||2015-12-01 23:33:03.882352@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:33:23.050731||measurement||loadtime||0:00:29.587584||5||1
+2015-12-01 23:33:23.539197||measurement||loadtime||0:00:29.759081||3||1
+2015-12-01 23:33:24.343720||measurement||price||2015-12-01 23:33:18.948453@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:33:24.414109||measurement||price||2015-12-01 23:33:18.980944@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:33:28.695148||measurement||loadtime||0:00:26.972027||1||0
+2015-12-01 23:33:35.847299||error||collecting ads||Error||0||1
+2015-12-01 23:33:36.649743||measurement||price||2015-12-01 23:33:30.309717@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:33:36.710927||measurement||price||2015-12-01 23:33:18.948453@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:33:36.765815||measurement||price||2015-12-01 23:33:18.980944@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:33:37.391968||measurement||price||2015-12-01 23:33:30.846451@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:33:41.210008||measurement||price||2015-12-01 23:33:35.847880@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:33:43.836877||measurement||loadtime||0:00:27.357729||4||0
+2015-12-01 23:33:43.887156||measurement||loadtime||0:00:27.074831||2||0
+2015-12-01 23:33:49.518288||measurement||price||2015-12-01 23:33:30.309717@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:33:50.204038||measurement||price||2015-12-01 23:33:30.846451@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:33:53.525314||measurement||price||2015-12-01 23:33:35.847880@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:33:56.440231||measurement||price||2015-12-01 23:33:50.998377@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:33:56.602279||measurement||price||2015-12-01 23:33:51.225139@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:33:56.755458||measurement||loadtime||0:00:28.700310||5||1
+2015-12-01 23:33:57.443971||measurement||loadtime||0:00:28.900822||3||1
+2015-12-01 23:33:59.828706||error||collecting ads||Error||0||1
+2015-12-01 23:34:00.630876||measurement||loadtime||0:00:26.930537||1||0
+2015-12-01 23:34:08.739257||measurement||price||2015-12-01 23:33:50.998377@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:34:08.937186||measurement||price||2015-12-01 23:33:51.225139@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:34:10.549747||measurement||price||2015-12-01 23:34:04.003143@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:34:11.913897||measurement||price||2015-12-01 23:34:05.076461@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:34:13.295497||measurement||price||2015-12-01 23:34:07.946041@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:34:15.839618||measurement||loadtime||0:00:26.948450||2||0
+2015-12-01 23:34:16.063101||measurement||loadtime||0:00:27.220985||4||0
+2015-12-01 23:34:23.460317||measurement||price||2015-12-01 23:34:04.003143@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:34:23.864875||error||collecting ads||Error||0||1
+2015-12-01 23:34:24.719919||measurement||price||2015-12-01 23:34:05.076461@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:34:25.600627||measurement||price||2015-12-01 23:34:07.946041@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:34:28.798717||measurement||price||2015-12-01 23:34:23.412237@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:34:30.679163||measurement||loadtime||0:00:28.918475||5||1
+2015-12-01 23:34:31.939334||measurement||loadtime||0:00:29.492201||3||1
+2015-12-01 23:34:32.684833||measurement||loadtime||0:00:27.049698||1||0
+2015-12-01 23:34:37.870210||measurement||price||2015-12-01 23:34:31.065367@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:34:38.329532||error||collecting ads||Error||2||0
+2015-12-01 23:34:41.113832||measurement||price||2015-12-01 23:34:23.412237@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:34:44.359171||measurement||price||2015-12-01 23:34:37.889306@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:34:48.219400||measurement||loadtime||0:00:27.151107||4||0
+2015-12-01 23:34:50.748645||measurement||price||2015-12-01 23:34:45.409668@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:34:50.931259||measurement||price||2015-12-01 23:34:31.065367@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:34:55.350254||error||collecting ads||Error||1||0
+2015-12-01 23:34:55.795385||error||collecting ads||Error||3||1
+2015-12-01 23:34:57.241086||measurement||price||2015-12-01 23:34:37.889306@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:34:58.131255||measurement||loadtime||0:00:29.264120||0||1
+2015-12-01 23:35:00.819359||measurement||price||2015-12-01 23:34:55.427144@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:35:03.069234||measurement||price||2015-12-01 23:34:45.409668@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:35:04.443162||measurement||loadtime||0:00:28.758784||5||1
+2015-12-01 23:35:08.051647||measurement||price||2015-12-01 23:35:02.199647@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:35:09.642645||measurement||price||2015-12-01 23:35:03.057320@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:35:10.186470||measurement||loadtime||0:00:26.855333||2||0
+2015-12-01 23:35:12.042509||measurement||price||2015-12-01 23:35:05.427637@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:35:13.144678||measurement||price||2015-12-01 23:34:55.427144@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:35:18.037939||measurement||price||2015-12-01 23:35:11.664349@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:35:20.262914||measurement||loadtime||0:00:27.039773||4||0
+2015-12-01 23:35:20.364376||measurement||price||2015-12-01 23:35:02.199647@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:35:22.524311||measurement||price||2015-12-01 23:35:03.057320@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:35:23.017561||measurement||price||2015-12-01 23:35:17.602786@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||2||0
+2015-12-01 23:35:24.883324||measurement||price||2015-12-01 23:35:05.427637@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:35:27.474124||measurement||loadtime||0:00:27.122806||1||0
+2015-12-01 23:35:29.751132||measurement||loadtime||0:00:28.951986||3||1
+2015-12-01 23:35:30.898738||measurement||price||2015-12-01 23:35:11.664349@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:35:32.082612||measurement||loadtime||0:00:28.947470||0||1
+2015-12-01 23:35:32.869839||measurement||price||2015-12-01 23:35:27.437591@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:35:35.336038||measurement||price||2015-12-01 23:35:17.602786@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||2||0
+2015-12-01 23:35:38.115138||measurement||loadtime||0:00:28.669143||5||1
+2015-12-01 23:35:40.080769||measurement||price||2015-12-01 23:35:34.667487@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:35:42.475143||measurement||loadtime||0:00:27.284597||2||0
+2015-12-01 23:35:43.568417||measurement||price||2015-12-01 23:35:36.962600@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:35:45.198554||measurement||price||2015-12-01 23:35:27.437591@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:35:51.772608||measurement||price||2015-12-01 23:35:45.278545@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:35:52.315162||measurement||loadtime||0:00:27.048009||4||0
+2015-12-01 23:35:52.356284||measurement||price||2015-12-01 23:35:34.667487@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:35:54.904342||measurement||price||2015-12-01 23:35:49.512069@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:35:56.145300||error||collecting ads||Error||0||1
+2015-12-01 23:35:56.392452||measurement||price||2015-12-01 23:35:36.962600@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:35:59.443149||measurement||loadtime||0:00:26.965884||1||0
+2015-12-01 23:36:03.592040||measurement||loadtime||0:00:28.836897||3||1
+2015-12-01 23:36:04.691921||measurement||price||2015-12-01 23:35:45.278545@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:36:04.996670||measurement||price||2015-12-01 23:35:59.574468@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:36:07.221694||measurement||price||2015-12-01 23:35:49.512069@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:36:09.959366||measurement||price||2015-12-01 23:36:03.425472@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:36:11.923980||measurement||loadtime||0:00:28.803668||5||1
+2015-12-01 23:36:14.335136||measurement||loadtime||0:00:26.856024||2||0
+2015-12-01 23:36:17.341089||measurement||price||2015-12-01 23:35:59.574468@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:36:22.601940||error||collecting ads||Error||1||0
+2015-12-01 23:36:22.831207||measurement||price||2015-12-01 23:36:03.425472@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:36:24.453469||measurement||loadtime||0:00:27.137858||4||0
+2015-12-01 23:36:25.692448||measurement||price||2015-12-01 23:36:19.216416@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:36:27.225291||error||collecting ads||Error||3||1
+2015-12-01 23:36:27.284678||measurement||price||2015-12-01 23:36:21.624427@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:36:30.035171||measurement||loadtime||0:00:28.884896||0||1
+2015-12-01 23:36:35.114776||measurement||price||2015-12-01 23:36:29.659240@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:36:37.077452||measurement||price||2015-12-01 23:36:31.679385@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:36:38.481654||measurement||price||2015-12-01 23:36:19.216416@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:36:39.588633||measurement||price||2015-12-01 23:36:21.624427@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:36:44.021461||measurement||price||2015-12-01 23:36:37.331755@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:36:45.709043||measurement||loadtime||0:00:28.781924||5||1
+2015-12-01 23:36:46.675692||measurement||loadtime||0:00:27.336546||2||0
+2015-12-01 23:36:47.452529||measurement||price||2015-12-01 23:36:29.659240@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:36:49.411870||measurement||price||2015-12-01 23:36:31.679385@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:36:51.081294||error||collecting ads||Error||3||1
+2015-12-01 23:36:54.559162||measurement||loadtime||0:00:26.952025||1||0
+2015-12-01 23:36:56.529769||measurement||loadtime||0:00:27.074628||4||0
+2015-12-01 23:36:56.894083||measurement||price||2015-12-01 23:36:37.331755@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:36:59.379368||measurement||price||2015-12-01 23:36:54.005475@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:36:59.521846||measurement||price||2015-12-01 23:36:52.916320@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:37:04.095154||measurement||loadtime||0:00:29.056010||0||1
+2015-12-01 23:37:04.802453||measurement||price||2015-12-01 23:36:58.269484@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:37:09.181365||measurement||price||2015-12-01 23:37:03.787276@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:37:11.705307||measurement||price||2015-12-01 23:36:54.005475@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:37:12.407202||measurement||price||2015-12-01 23:36:52.916320@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:37:17.105838||error||collecting ads||Error||1||0
+2015-12-01 23:37:17.744169||measurement||price||2015-12-01 23:36:58.269484@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:37:18.208364||measurement||price||2015-12-01 23:37:11.336373@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:37:18.818783||measurement||loadtime||0:00:27.137890||2||0
+2015-12-01 23:37:19.633565||measurement||loadtime||0:00:28.921879||5||1
+2015-12-01 23:37:21.529004||measurement||price||2015-12-01 23:37:03.787276@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:37:24.943152||measurement||loadtime||0:00:28.857057||3||1
+2015-12-01 23:37:28.639827||measurement||loadtime||0:00:27.104880||4||0
+2015-12-01 23:37:31.043979||measurement||price||2015-12-01 23:37:11.336373@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:37:31.387499||measurement||price||2015-12-01 23:37:25.968066@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:37:38.272472||measurement||loadtime||0:00:29.173315||0||1
+2015-12-01 23:37:38.623506||measurement||price||2015-12-01 23:37:32.173743@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:37:39.669348||error||collecting ads||Error||1||0
+2015-12-01 23:37:43.549514||error||collecting ads||Error||5||1
+2015-12-01 23:37:43.682472||measurement||price||2015-12-01 23:37:25.968066@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:37:50.767183||measurement||loadtime||0:00:26.943182||2||0
+2015-12-01 23:37:51.268554||error||collecting ads||Error||4||0
+2015-12-01 23:37:51.638078||measurement||price||2015-12-01 23:37:32.173743@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:37:52.261469||measurement||price||2015-12-01 23:37:46.892935@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:37:52.775100||measurement||price||2015-12-01 23:37:45.824348@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:37:57.326681||measurement||price||2015-12-01 23:37:50.838213@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:37:58.835165||measurement||loadtime||0:00:28.890065||3||1
+2015-12-01 23:38:03.158362||measurement||price||2015-12-01 23:37:57.825657@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:38:04.072021||measurement||price||2015-12-01 23:37:58.610951@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:38:04.610673||measurement||price||2015-12-01 23:37:46.892935@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:38:05.796209||measurement||price||2015-12-01 23:37:45.824348@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:38:10.187548||measurement||price||2015-12-01 23:37:50.838213@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:38:11.731785||measurement||loadtime||0:00:27.058087||1||0
+2015-12-01 23:38:12.525478||measurement||price||2015-12-01 23:38:06.016866@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:38:13.196975||measurement||loadtime||0:00:29.919268||0||1
+2015-12-01 23:38:15.471940||measurement||price||2015-12-01 23:37:57.825657@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:38:16.409349||measurement||price||2015-12-01 23:37:58.610951@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:38:17.415161||measurement||loadtime||0:00:28.861624||5||1
+2015-12-01 23:38:22.579168||measurement||loadtime||0:00:26.806743||2||0
+2015-12-01 23:38:23.518538||measurement||loadtime||0:00:27.248028||4||0
+2015-12-01 23:38:24.262464||measurement||price||2015-12-01 23:38:18.886831@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:38:25.512677||measurement||price||2015-12-01 23:38:06.016866@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:38:31.177950||measurement||price||2015-12-01 23:38:24.571612@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:38:32.709179||measurement||loadtime||0:00:28.868804||3||1
+2015-12-01 23:38:35.042876||measurement||price||2015-12-01 23:38:29.637172@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:38:36.592493||measurement||price||2015-12-01 23:38:18.886831@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:38:37.364351||error||collecting ads||Error||0||1
+2015-12-01 23:38:43.703139||measurement||loadtime||0:00:26.966452||1||0
+2015-12-01 23:38:44.062949||measurement||price||2015-12-01 23:38:24.571612@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:38:46.217867||error||collecting ads||Error||4||0
+2015-12-01 23:38:46.416003||measurement||price||2015-12-01 23:38:39.999463@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:38:47.379187||measurement||price||2015-12-01 23:38:29.637172@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:38:51.293482||measurement||loadtime||0:00:28.873139||5||1
+2015-12-01 23:38:54.487144||measurement||loadtime||0:00:26.906882||2||0
+2015-12-01 23:38:56.237472||measurement||price||2015-12-01 23:38:50.833639@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:38:58.862515||measurement||price||2015-12-01 23:38:53.460711@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:38:59.255429||measurement||price||2015-12-01 23:38:39.999463@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:39:01.341523||error||collecting ads||Error||0||1
+2015-12-01 23:39:06.474688||measurement||loadtime||0:00:28.760279||3||1
+2015-12-01 23:39:06.994898||measurement||price||2015-12-01 23:39:01.569584@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:39:08.560625||measurement||price||2015-12-01 23:38:50.833639@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:39:11.198886||measurement||price||2015-12-01 23:38:53.460711@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:39:15.004111||error||collecting ads||Error||5||1
+2015-12-01 23:39:15.671177||measurement||loadtime||0:00:26.964042||1||0
+2015-12-01 23:39:18.307144||measurement||loadtime||0:00:27.084681||4||0
+2015-12-01 23:39:19.312970||measurement||price||2015-12-01 23:39:01.569584@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:39:25.414120||error||collecting ads||Error||0||1
+2015-12-01 23:39:26.427195||measurement||loadtime||0:00:26.936031||2||0
+2015-12-01 23:39:28.279880||measurement||price||2015-12-01 23:39:22.833084@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:39:28.614524||measurement||price||2015-12-01 23:39:22.157025@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:39:30.208786||error||collecting ads||Error||3||1
+2015-12-01 23:39:31.309840||measurement||price||2015-12-01 23:39:25.904822@|3M Littmann@|$85.00 - $234.56@|3M Littmann Classic III Stethoscope (Multiple Colors)||4||0
+2015-12-01 23:39:39.480570||measurement||price||2015-12-01 23:39:32.770214@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:39:40.603357||measurement||price||2015-12-01 23:39:22.833084@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:39:41.430482||measurement||price||2015-12-01 23:39:22.157025@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:39:43.640384||measurement||price||2015-12-01 23:39:25.904822@|3M Littmann@|$62.96 - $319.00@|3M Littmann Classic II S.E. Stethoscope (Multiple Colors)||4||0
+2015-12-01 23:39:43.991839||measurement||price||2015-12-01 23:39:37.434789@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:39:47.707620||measurement||loadtime||0:00:27.032485||1||0
+2015-12-01 23:39:48.623213||measurement||loadtime||0:00:28.616056||5||1
+2015-12-01 23:39:48.911240||error||collecting ads||Error||2||0
+2015-12-01 23:39:50.750130||measurement||loadtime||0:00:27.438990||4||0
+2015-12-01 23:39:52.361514||measurement||price||2015-12-01 23:39:32.770214@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:39:56.961089||measurement||price||2015-12-01 23:39:37.434789@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:39:59.546763||measurement||loadtime||0:00:29.127475||0||1
+2015-12-01 23:40:01.471562||measurement||price||2015-12-01 23:39:56.054404@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:40:04.180896||measurement||loadtime||0:00:28.966819||3||1
+2015-12-01 23:40:10.372442||error||collecting ads||Error||1||0
+2015-12-01 23:40:10.372534||event||progress-marker||measurement-end||1||0
+2015-12-01 23:40:12.590921||error||collecting ads||Error||5||1
+2015-12-01 23:40:13.527380||error||collecting ads||Error||4||0
+2015-12-01 23:40:13.527482||event||progress-marker||measurement-end||4||0
+2015-12-01 23:40:13.791479||measurement||price||2015-12-01 23:39:56.054404@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:40:17.728505||measurement||price||2015-12-01 23:40:11.329257@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:40:20.892112||measurement||loadtime||0:00:26.975610||2||0
+2015-12-01 23:40:20.892242||event||progress-marker||measurement-end||2||0
+2015-12-01 23:40:23.310777||error||collecting ads||Error||0||1
+2015-12-01 23:40:26.336865||measurement||price||2015-12-01 23:40:19.868461@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:40:30.596483||measurement||price||2015-12-01 23:40:11.329257@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:40:37.795202||measurement||loadtime||0:00:28.609115||3||1
+2015-12-01 23:40:39.190871||measurement||price||2015-12-01 23:40:19.868461@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:40:46.423621||measurement||loadtime||0:00:28.828470||5||1
+2015-12-01 23:40:47.295909||error||collecting ads||Error||0||1
+2015-12-01 23:41:00.458437||measurement||price||2015-12-01 23:40:53.665280@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:41:01.428892||error||collecting ads||Error||3||1
+2015-12-01 23:41:11.119240||error||collecting ads||Error||0||1
+2015-12-01 23:41:13.239641||measurement||price||2015-12-01 23:40:53.665280@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:41:20.459265||measurement||loadtime||0:00:29.030513||5||1
+2015-12-01 23:41:25.145295||measurement||price||2015-12-01 23:41:18.420722@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:41:25.475302||error||collecting ads||Error||3||1
+2015-12-01 23:41:37.951560||measurement||price||2015-12-01 23:41:18.420722@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:41:39.266278||measurement||price||2015-12-01 23:41:32.675046@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:41:44.136050||error||collecting ads||Error||5||1
+2015-12-01 23:41:45.143155||measurement||loadtime||0:00:29.020018||0||1
+2015-12-01 23:41:52.235556||measurement||price||2015-12-01 23:41:32.675046@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:41:57.951645||measurement||price||2015-12-01 23:41:51.802910@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||5||1
+2015-12-01 23:41:59.250777||measurement||price||2015-12-01 23:41:52.430012@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:41:59.453814||measurement||loadtime||0:00:28.973750||3||1
+2015-12-01 23:42:10.751540||measurement||price||2015-12-01 23:41:51.802910@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||5||1
+2015-12-01 23:42:12.048356||measurement||price||2015-12-01 23:41:52.430012@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:42:13.160443||measurement||price||2015-12-01 23:42:06.601102@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:42:17.976917||measurement||loadtime||0:00:28.837593||5||1
+2015-12-01 23:42:19.230579||measurement||loadtime||0:00:29.083439||0||1
+2015-12-01 23:42:19.230687||event||progress-marker||measurement-end||0||1
+2015-12-01 23:42:26.051138||measurement||price||2015-12-01 23:42:06.601102@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:42:33.262307||measurement||loadtime||0:00:28.803314||3||1
+2015-12-01 23:42:41.373843||error||collecting ads||Error||5||1
+2015-12-01 23:42:46.798534||measurement||price||2015-12-01 23:42:40.431169@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:42:55.016911||measurement||price||2015-12-01 23:42:48.728308@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:42:59.534564||measurement||price||2015-12-01 23:42:40.431169@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:43:06.731179||measurement||loadtime||0:00:28.463611||3||1
+2015-12-01 23:43:06.731312||event||progress-marker||measurement-end||3||1
+2015-12-01 23:43:07.923932||measurement||price||2015-12-01 23:42:48.728308@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:43:15.149704||measurement||loadtime||0:00:28.770660||5||1
+2015-12-01 23:43:15.149813||event||progress-marker||measurement-end||5||1
+2015-12-01 23:43:15.671606||meta||block_id end||11
+2015-12-01 23:43:15.671882||meta||block_id start||12
+2015-12-01 23:43:15.671900||meta||assignment||4@|2@|1@|0@|5@|3
+2015-12-01 23:43:17.276829||event||progress-marker||training-start||1||0
+2015-12-01 23:43:17.297513||event||progress-marker||training-start||2||0
+2015-12-01 23:43:17.335193||event||progress-marker||training-start||4||0
+2015-12-01 23:43:24.113693||treatment||visit website||http://irs.gov||4||0
+2015-12-01 23:43:24.131100||treatment||visit website||http://irs.gov||2||0
+2015-12-01 23:43:24.196809||treatment||visit website||http://irs.gov||1||0
+2015-12-01 23:43:31.859095||treatment||visit website||http://deloitte.com||2||0
+2015-12-01 23:43:31.875106||treatment||visit website||http://deloitte.com||1||0
+2015-12-01 23:43:31.880852||treatment||visit website||http://deloitte.com||4||0
+2015-12-01 23:43:47.484648||treatment||visit website||http://pwc.com||4||0
+2015-12-01 23:43:47.516324||treatment||visit website||http://pwc.com||1||0
+2015-12-01 23:43:47.534475||treatment||visit website||http://pwc.com||2||0
+2015-12-01 23:43:53.341734||treatment||visit website||http://ey.com||4||0
+2015-12-01 23:43:53.419091||treatment||visit website||http://ey.com||2||0
+2015-12-01 23:43:53.635824||treatment||visit website||http://ey.com||1||0
+2015-12-01 23:44:00.029539||treatment||visit website||http://kpmg.com||4||0
+2015-12-01 23:44:00.029660||event||progress-marker||training-end||4||0
+2015-12-01 23:44:00.381751||treatment||visit website||http://kpmg.com||2||0
+2015-12-01 23:44:00.381933||event||progress-marker||training-end||2||0
+2015-12-01 23:44:00.459118||treatment||visit website||http://kpmg.com||1||0
+2015-12-01 23:44:00.459246||event||progress-marker||training-end||1||0
+2015-12-01 23:44:05.061503||event||progress-marker||measurement-start||4||0
+2015-12-01 23:44:05.413449||event||progress-marker||measurement-start||2||0
+2015-12-01 23:44:05.497627||event||progress-marker||measurement-start||1||0
+2015-12-01 23:44:18.692328||measurement||price||2015-12-01 23:44:12.721341@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:44:19.819158||event||progress-marker||training-start||3||1
+2015-12-01 23:44:26.505120||treatment||visit website||http://irs.gov||3||1
+2015-12-01 23:44:28.513671||error||collecting ads||Error||4||0
+2015-12-01 23:44:28.926967||error||collecting ads||Error||2||0
+2015-12-01 23:44:31.048910||measurement||price||2015-12-01 23:44:12.721341@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:44:33.066071||treatment||visit website||http://deloitte.com||3||1
+2015-12-01 23:44:38.156592||measurement||loadtime||0:00:27.653754||1||0
+2015-12-01 23:44:40.890974||measurement||price||2015-12-01 23:44:35.287542@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:44:41.914723||treatment||visit website||http://pwc.com||3||1
+2015-12-01 23:44:47.811478||treatment||visit website||http://ey.com||3||1
+2015-12-01 23:44:50.599393||measurement||price||2015-12-01 23:44:44.754377@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:44:51.670010||error||collecting ads||Error||2||0
+2015-12-01 23:44:53.220871||measurement||price||2015-12-01 23:44:35.287542@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:44:54.523328||treatment||visit website||http://kpmg.com||3||1
+2015-12-01 23:44:54.523464||event||progress-marker||training-end||3||1
+2015-12-01 23:44:56.220740||event||progress-marker||training-start||0||1
+2015-12-01 23:45:00.331172||measurement||loadtime||0:00:26.814390||4||0
+2015-12-01 23:45:02.928573||measurement||price||2015-12-01 23:44:44.754377@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:45:03.132034||treatment||visit website||http://irs.gov||0||1
+2015-12-01 23:45:04.670105||measurement||price||2015-12-01 23:44:59.308023@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||2||0
+2015-12-01 23:45:09.712482||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 23:45:10.030377||measurement||loadtime||0:00:26.870033||1||0
+2015-12-01 23:45:12.627542||measurement||price||2015-12-01 23:45:07.064722@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:45:17.009414||measurement||price||2015-12-01 23:44:59.308023@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 23:45:22.264038||measurement||price||2015-12-01 23:45:16.727685@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:45:24.118853||measurement||loadtime||0:00:27.444795||2||0
+2015-12-01 23:45:24.948431||measurement||price||2015-12-01 23:45:07.064722@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:45:32.047999||measurement||loadtime||0:00:26.712823||4||0
+2015-12-01 23:45:34.592192||measurement||price||2015-12-01 23:45:16.727685@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:45:36.661025||measurement||price||2015-12-01 23:45:31.223965@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:45:41.696371||measurement||loadtime||0:00:26.661217||1||0
+2015-12-01 23:45:48.998402||measurement||price||2015-12-01 23:45:31.223965@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:45:49.734383||error||website timeout||http://pwc.com||0||1
+2015-12-01 23:45:52.300402||event||progress-marker||training-start||5||1
+2015-12-01 23:45:54.296870||error||collecting ads||Error||4||0
+2015-12-01 23:45:54.346441||measurement||price||2015-12-01 23:45:48.766232@|Coast@|$9.95@|Coast HP1 Focusing 220 Lumen LED Flashlight||1||0
+2015-12-01 23:45:54.780103||treatment||visit website||http://ey.com||0||1
+2015-12-01 23:45:56.112947||measurement||loadtime||0:00:26.988905||2||0
+2015-12-01 23:45:58.774936||treatment||visit website||http://irs.gov||5||1
+2015-12-01 23:46:02.331111||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 23:46:02.331240||event||progress-marker||training-end||0||1
+2015-12-01 23:46:06.051296||treatment||visit website||http://deloitte.com||5||1
+2015-12-01 23:46:06.570814||measurement||price||2015-12-01 23:46:00.946091@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:46:06.710465||measurement||price||2015-12-01 23:45:48.766232@|Coast@|$31.41@|Coast HL7 Focusing 285 Lumen LED Headlamp||1||0
+2015-12-01 23:46:08.863473||measurement||price||2015-12-01 23:46:03.380346@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:46:13.819162||measurement||loadtime||0:00:27.119839||1||0
+2015-12-01 23:46:18.907904||measurement||price||2015-12-01 23:46:00.946091@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:46:21.208331||measurement||price||2015-12-01 23:46:03.380346@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:46:26.027151||measurement||loadtime||0:00:26.728008||4||0
+2015-12-01 23:46:26.063592||measurement||price||2015-12-01 23:46:20.467141@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:46:28.324523||measurement||loadtime||0:00:27.206408||2||0
+2015-12-01 23:46:38.308989||measurement||price||2015-12-01 23:46:32.751169@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:46:38.388172||measurement||price||2015-12-01 23:46:20.467141@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:46:41.182354||measurement||price||2015-12-01 23:46:35.815624@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-01 23:46:45.495161||measurement||loadtime||0:00:26.672021||1||0
+2015-12-01 23:46:47.042116||treatment||visit website||http://pwc.com||5||1
+2015-12-01 23:46:50.638700||measurement||price||2015-12-01 23:46:32.751169@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:46:52.962755||treatment||visit website||http://ey.com||5||1
+2015-12-01 23:46:53.512795||measurement||price||2015-12-01 23:46:35.815624@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-01 23:46:57.725491||measurement||price||2015-12-01 23:46:52.084676@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:46:57.751159||measurement||loadtime||0:00:26.720038||4||0
+2015-12-01 23:47:00.631149||measurement||loadtime||0:00:27.303975||2||0
+2015-12-01 23:47:10.051869||measurement||price||2015-12-01 23:46:52.084676@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:47:11.536385||treatment||visit website||http://kpmg.com||5||1
+2015-12-01 23:47:11.536531||event||progress-marker||training-end||5||1
+2015-12-01 23:47:12.619400||event||progress-marker||measurement-start||0||1
+2015-12-01 23:47:13.139177||measurement||price||2015-12-01 23:47:07.699361@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:47:15.056638||event||progress-marker||measurement-start||3||1
+2015-12-01 23:47:16.578764||event||progress-marker||measurement-start||5||1
+2015-12-01 23:47:17.158569||measurement||loadtime||0:00:26.658229||1||0
+2015-12-01 23:47:19.971173||error||collecting ads||Error||4||0
+2015-12-01 23:47:25.472935||measurement||price||2015-12-01 23:47:07.699361@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:47:31.278166||measurement||price||2015-12-01 23:47:24.981967@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:47:32.279010||measurement||price||2015-12-01 23:47:26.554851@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:47:32.552080||measurement||loadtime||0:00:26.918115||2||0
+2015-12-01 23:47:37.094543||error||collecting ads||Error||0||1
+2015-12-01 23:47:39.508538||error||collecting ads||Error||1||0
+2015-12-01 23:47:39.661194||error||collecting ads||Error||3||1
+2015-12-01 23:47:44.141588||measurement||price||2015-12-01 23:47:24.981967@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:47:44.621092||measurement||price||2015-12-01 23:47:26.554851@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:47:45.830074||measurement||price||2015-12-01 23:47:40.157744@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:47:50.804575||measurement||price||2015-12-01 23:47:44.636025@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:47:51.327166||measurement||loadtime||0:00:29.747914||5||1
+2015-12-01 23:47:51.743895||measurement||loadtime||0:00:26.768759||4||0
+2015-12-01 23:47:51.856587||measurement||price||2015-12-01 23:47:46.197445@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:47:53.502251||measurement||price||2015-12-01 23:47:47.276309@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:47:58.211608||measurement||price||2015-12-01 23:47:40.157744@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:48:03.817333||measurement||price||2015-12-01 23:47:44.636025@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:48:04.184111||measurement||price||2015-12-01 23:47:46.197445@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:48:05.335013||measurement||loadtime||0:00:27.777743||2||0
+2015-12-01 23:48:06.356882||measurement||price||2015-12-01 23:47:47.276309@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:48:11.002034||measurement||loadtime||0:00:28.902264||0||1
+2015-12-01 23:48:11.291394||measurement||loadtime||0:00:26.777668||1||0
+2015-12-01 23:48:13.589764||measurement||loadtime||0:00:28.925381||3||1
+2015-12-01 23:48:14.771430||error||collecting ads||Error||4||0
+2015-12-01 23:48:15.480944||error||collecting ads||Error||5||1
+2015-12-01 23:48:17.900047||measurement||price||2015-12-01 23:48:12.476866@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:48:23.563111||measurement||price||2015-12-01 23:48:18.012622@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:48:25.098890||measurement||price||2015-12-01 23:48:18.943088@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:48:27.208955||measurement||price||2015-12-01 23:48:21.563662@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:48:27.320699||measurement||price||2015-12-01 23:48:21.252491@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:48:30.248817||measurement||price||2015-12-01 23:48:12.476866@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:48:35.884228||measurement||price||2015-12-01 23:48:18.012622@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:48:37.367641||measurement||loadtime||0:00:27.030875||2||0
+2015-12-01 23:48:38.156974||measurement||price||2015-12-01 23:48:18.943088@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:48:39.555496||measurement||price||2015-12-01 23:48:21.563662@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:48:39.872710||error||collecting ads||Error||5||1
+2015-12-01 23:48:40.116143||measurement||price||2015-12-01 23:48:21.252491@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:48:42.989207||measurement||loadtime||0:00:26.692528||1||0
+2015-12-01 23:48:45.351672||measurement||loadtime||0:00:29.345958||0||1
+2015-12-01 23:48:46.663146||measurement||loadtime||0:00:26.888078||4||0
+2015-12-01 23:48:47.315961||measurement||loadtime||0:00:28.724831||3||1
+2015-12-01 23:48:49.945641||measurement||price||2015-12-01 23:48:44.540612@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:48:55.070037||measurement||price||2015-12-01 23:48:49.119563@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:48:56.042219||measurement||price||2015-12-01 23:48:50.369882@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:48:59.408758||measurement||price||2015-12-01 23:48:53.194731@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:48:59.920063||measurement||price||2015-12-01 23:48:54.065598@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:49:01.698182||measurement||price||2015-12-01 23:48:55.536540@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:49:02.287714||measurement||price||2015-12-01 23:48:44.540612@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:49:08.111103||measurement||price||2015-12-01 23:48:49.119563@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:49:08.344678||measurement||price||2015-12-01 23:48:50.369882@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:49:09.404311||measurement||loadtime||0:00:27.031500||2||0
+2015-12-01 23:49:12.263336||measurement||price||2015-12-01 23:48:54.065598@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:49:12.349742||measurement||price||2015-12-01 23:48:53.194731@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:49:14.795045||measurement||price||2015-12-01 23:48:55.536540@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:49:15.366174||measurement||loadtime||0:00:30.491018||5||1
+2015-12-01 23:49:15.427145||measurement||loadtime||0:00:27.435827||1||0
+2015-12-01 23:49:19.356626||measurement||loadtime||0:00:27.689500||4||0
+2015-12-01 23:49:19.560328||measurement||loadtime||0:00:29.205146||0||1
+2015-12-01 23:49:21.887604||measurement||price||2015-12-01 23:49:16.486853@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:49:21.995167||measurement||loadtime||0:00:29.676430||3||1
+2015-12-01 23:49:27.980523||measurement||price||2015-12-01 23:49:22.408595@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||0
+2015-12-01 23:49:29.327477||measurement||price||2015-12-01 23:49:23.006093@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:49:31.581209||measurement||price||2015-12-01 23:49:26.007265@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:49:33.573856||measurement||price||2015-12-01 23:49:27.306099@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:49:34.228358||measurement||price||2015-12-01 23:49:16.486853@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:49:35.730552||measurement||price||2015-12-01 23:49:29.703248@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:49:40.247762||measurement||price||2015-12-01 23:49:22.408595@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||0
+2015-12-01 23:49:41.335700||measurement||loadtime||0:00:26.931156||2||0
+2015-12-01 23:49:42.166642||measurement||price||2015-12-01 23:49:23.006093@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:49:43.848729||measurement||price||2015-12-01 23:49:26.007265@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:49:46.494270||measurement||price||2015-12-01 23:49:27.306099@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:49:47.330395||measurement||loadtime||0:00:26.898071||1||0
+2015-12-01 23:49:48.649208||measurement||price||2015-12-01 23:49:29.703248@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:49:49.363175||measurement||loadtime||0:00:28.995777||5||1
+2015-12-01 23:49:50.934796||measurement||loadtime||0:00:26.572991||4||0
+2015-12-01 23:49:53.705460||measurement||loadtime||0:00:29.142324||0||1
+2015-12-01 23:49:53.834867||measurement||price||2015-12-01 23:49:48.443889@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:49:55.867139||measurement||loadtime||0:00:28.866798||3||1
+2015-12-01 23:50:03.200678||measurement||price||2015-12-01 23:49:56.986339@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:50:06.173564||measurement||price||2015-12-01 23:49:48.443889@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:50:07.511694||measurement||price||2015-12-01 23:50:01.259390@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:50:09.580352||measurement||price||2015-12-01 23:50:03.499639@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:50:09.592045||error||collecting ads||Error||1||0
+2015-12-01 23:50:13.224614||error||collecting ads||Error||4||0
+2015-12-01 23:50:13.279128||measurement||loadtime||0:00:26.941992||2||0
+2015-12-01 23:50:16.044481||measurement||price||2015-12-01 23:49:56.986339@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:50:20.435973||measurement||price||2015-12-01 23:50:01.259390@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:50:21.814190||measurement||price||2015-12-01 23:50:16.309891@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:50:22.422877||measurement||price||2015-12-01 23:50:03.499639@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:50:23.248852||measurement||loadtime||0:00:28.881717||5||1
+2015-12-01 23:50:25.592169||measurement||price||2015-12-01 23:50:19.990024@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:50:25.994832||measurement||price||2015-12-01 23:50:20.471695@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:50:27.651144||measurement||loadtime||0:00:28.944006||0||1
+2015-12-01 23:50:29.639725||measurement||loadtime||0:00:28.768555||3||1
+2015-12-01 23:50:34.149136||measurement||price||2015-12-01 23:50:16.309891@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:50:37.917165||measurement||price||2015-12-01 23:50:19.990024@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:50:38.330744||measurement||price||2015-12-01 23:50:20.471695@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:50:41.262327||measurement||loadtime||0:00:26.666684||1||0
+2015-12-01 23:50:41.534668||measurement||price||2015-12-01 23:50:35.445116@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:50:43.160504||measurement||price||2015-12-01 23:50:37.118861@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:50:45.039937||measurement||loadtime||0:00:26.810109||4||0
+2015-12-01 23:50:45.442110||measurement||loadtime||0:00:27.158979||2||0
+2015-12-01 23:50:47.016206||error||collecting ads||Error||5||1
+2015-12-01 23:50:53.544347||measurement||price||2015-12-01 23:50:47.999806@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:50:54.412241||measurement||price||2015-12-01 23:50:35.445116@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:50:55.966521||measurement||price||2015-12-01 23:50:37.118861@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:50:57.421583||measurement||price||2015-12-01 23:50:51.735692@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:51:01.592683||measurement||loadtime||0:00:28.937534||0||1
+2015-12-01 23:51:03.185848||measurement||loadtime||0:00:28.540908||3||1
+2015-12-01 23:51:05.879662||measurement||price||2015-12-01 23:50:47.999806@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:51:08.125907||error||collecting ads||Error||2||0
+2015-12-01 23:51:09.748013||measurement||price||2015-12-01 23:50:51.735692@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:51:10.904087||error||collecting ads||Error||5||1
+2015-12-01 23:51:12.991942||measurement||loadtime||0:00:26.724807||1||0
+2015-12-01 23:51:16.826888||measurement||price||2015-12-01 23:51:10.845930@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:51:16.859147||measurement||loadtime||0:00:26.814020||4||0
+2015-12-01 23:51:20.666205||measurement||price||2015-12-01 23:51:15.213265@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:51:25.415954||measurement||price||2015-12-01 23:51:19.785152@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:51:25.692925||error||collecting ads||Error||0||1
+2015-12-01 23:51:29.174248||measurement||price||2015-12-01 23:51:23.598449@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:51:29.692502||measurement||price||2015-12-01 23:51:10.845930@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:51:33.008658||measurement||price||2015-12-01 23:51:15.213265@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:51:34.506607||error||collecting ads||Error||5||1
+2015-12-01 23:51:36.894082||measurement||loadtime||0:00:28.704215||3||1
+2015-12-01 23:51:37.744393||measurement||price||2015-12-01 23:51:19.785152@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:51:40.127147||measurement||loadtime||0:00:26.999009||2||0
+2015-12-01 23:51:41.504519||measurement||price||2015-12-01 23:51:23.598449@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:51:44.851137||measurement||loadtime||0:00:26.856004||1||0
+2015-12-01 23:51:48.292896||measurement||price||2015-12-01 23:51:42.159143@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:51:48.618055||measurement||loadtime||0:00:26.754916||4||0
+2015-12-01 23:51:49.454050||error||collecting ads||Error||0||1
+2015-12-01 23:51:50.607342||measurement||price||2015-12-01 23:51:44.460087@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:51:52.780322||measurement||price||2015-12-01 23:51:47.364708@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 23:52:00.949729||measurement||price||2015-12-01 23:51:55.339835@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:52:01.243522||measurement||price||2015-12-01 23:51:42.159143@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:52:03.226874||measurement||price||2015-12-01 23:51:57.122813@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:52:03.595468||measurement||price||2015-12-01 23:51:44.460087@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:52:05.102277||measurement||price||2015-12-01 23:51:47.364708@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 23:52:07.017901||error||collecting ads||Error||1||0
+2015-12-01 23:52:08.427160||measurement||loadtime||0:00:28.915354||5||1
+2015-12-01 23:52:10.805480||measurement||loadtime||0:00:28.906359||3||1
+2015-12-01 23:52:12.209874||measurement||loadtime||0:00:27.078748||2||0
+2015-12-01 23:52:13.271104||measurement||price||2015-12-01 23:51:55.339835@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:52:16.111579||measurement||price||2015-12-01 23:51:57.122813@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:52:19.344684||measurement||price||2015-12-01 23:52:13.663838@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:52:20.375390||measurement||loadtime||0:00:26.752148||4||0
+2015-12-01 23:52:22.238057||measurement||price||2015-12-01 23:52:16.156135@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:52:23.312632||measurement||loadtime||0:00:28.853483||0||1
+2015-12-01 23:52:24.423047||measurement||price||2015-12-01 23:52:18.307976@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:52:31.684116||measurement||price||2015-12-01 23:52:13.663838@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:52:32.763234||measurement||price||2015-12-01 23:52:27.186367@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:52:34.825819||error||collecting ads||Error||2||0
+2015-12-01 23:52:35.140160||measurement||price||2015-12-01 23:52:16.156135@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:52:37.106055||measurement||price||2015-12-01 23:52:30.957440@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:52:37.316541||measurement||price||2015-12-01 23:52:18.307976@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:52:38.807843||measurement||loadtime||0:00:26.784705||1||0
+2015-12-01 23:52:42.318492||measurement||loadtime||0:00:28.886117||5||1
+2015-12-01 23:52:44.534510||measurement||loadtime||0:00:28.723858||3||1
+2015-12-01 23:52:45.097829||measurement||price||2015-12-01 23:52:27.186367@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:52:47.541789||measurement||price||2015-12-01 23:52:42.122871@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:52:50.004119||measurement||price||2015-12-01 23:52:30.957440@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:52:52.218135||measurement||loadtime||0:00:26.837562||4||0
+2015-12-01 23:52:56.261531||measurement||price||2015-12-01 23:52:49.972248@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:52:57.190404||measurement||loadtime||0:00:28.875263||0||1
+2015-12-01 23:52:58.704762||measurement||price||2015-12-01 23:52:52.576876@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||3||1
+2015-12-01 23:52:59.875363||measurement||price||2015-12-01 23:52:42.122871@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:53:01.071588||error||collecting ads||Error||1||0
+2015-12-01 23:53:04.491899||measurement||price||2015-12-01 23:52:58.964722@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 23:53:07.007814||measurement||loadtime||0:00:27.176773||2||0
+2015-12-01 23:53:09.210194||measurement||price||2015-12-01 23:52:49.972248@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:53:10.897444||measurement||price||2015-12-01 23:53:04.796280@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:53:11.735245||measurement||price||2015-12-01 23:52:52.576876@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||3||1
+2015-12-01 23:53:13.359308||measurement||price||2015-12-01 23:53:07.765808@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 23:53:16.408890||measurement||loadtime||0:00:29.085748||5||1
+2015-12-01 23:53:16.833909||measurement||price||2015-12-01 23:52:58.964722@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 23:53:18.986021||measurement||loadtime||0:00:29.446335||3||1
+2015-12-01 23:53:19.544300||measurement||price||2015-12-01 23:53:14.133154@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 23:53:23.774660||measurement||price||2015-12-01 23:53:04.796280@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:53:23.941772||measurement||loadtime||0:00:26.718458||4||0
+2015-12-01 23:53:25.688923||measurement||price||2015-12-01 23:53:07.765808@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 23:53:30.117795||measurement||price||2015-12-01 23:53:24.040296@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:53:30.976817||measurement||loadtime||0:00:28.781201||0||1
+2015-12-01 23:53:31.839065||measurement||price||2015-12-01 23:53:14.133154@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 23:53:32.734954||measurement||price||2015-12-01 23:53:26.612796@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:53:32.803141||measurement||loadtime||0:00:26.728016||1||0
+2015-12-01 23:53:36.874592||measurement||price||2015-12-01 23:53:31.215980@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 23:53:38.931318||measurement||loadtime||0:00:26.918290||2||0
+2015-12-01 23:53:43.088581||measurement||price||2015-12-01 23:53:24.040296@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:53:45.108795||measurement||price||2015-12-01 23:53:39.595408@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 23:53:45.710510||measurement||price||2015-12-01 23:53:26.612796@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:53:49.220060||measurement||price||2015-12-01 23:53:31.215980@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 23:53:50.271215||measurement||loadtime||0:00:28.857094||5||1
+2015-12-01 23:53:52.947667||measurement||loadtime||0:00:28.956473||3||1
+2015-12-01 23:53:54.801210||error||collecting ads||Error||0||1
+2015-12-01 23:53:56.327282||measurement||loadtime||0:00:27.380807||4||0
+2015-12-01 23:53:56.327380||event||progress-marker||measurement-end||4||0
+2015-12-01 23:53:57.425957||measurement||price||2015-12-01 23:53:39.595408@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 23:54:02.159578||error||collecting ads||Error||2||0
+2015-12-01 23:54:02.159687||event||progress-marker||measurement-end||2||0
+2015-12-01 23:54:04.078902||measurement||price||2015-12-01 23:53:57.967668@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:54:04.543155||measurement||loadtime||0:00:26.734802||1||0
+2015-12-01 23:54:04.543262||event||progress-marker||measurement-end||1||0
+2015-12-01 23:54:06.493214||measurement||price||2015-12-01 23:54:00.526580@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:54:08.638819||measurement||price||2015-12-01 23:54:02.384636@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:54:16.879266||measurement||price||2015-12-01 23:53:57.967668@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:54:19.356067||measurement||price||2015-12-01 23:54:00.526580@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:54:21.472102||measurement||price||2015-12-01 23:54:02.384636@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:54:24.063272||measurement||loadtime||0:00:28.788126||5||1
+2015-12-01 23:54:26.544731||measurement||loadtime||0:00:28.591874||3||1
+2015-12-01 23:54:28.689617||measurement||loadtime||0:00:28.883198||0||1
+2015-12-01 23:54:37.696476||measurement||price||2015-12-01 23:54:31.606860@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 23:54:42.867000||measurement||price||2015-12-01 23:54:36.848293@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:54:50.070536||error||collecting ads||Error||3||1
+2015-12-01 23:54:50.500505||measurement||price||2015-12-01 23:54:31.606860@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 23:54:55.744463||measurement||price||2015-12-01 23:54:36.848293@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:54:57.695140||measurement||loadtime||0:00:28.626669||5||1
+2015-12-01 23:55:02.987166||measurement||loadtime||0:00:29.293244||0||1
+2015-12-01 23:55:03.669202||measurement||price||2015-12-01 23:54:57.596399@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:55:16.516737||measurement||price||2015-12-01 23:54:57.596399@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:55:17.435747||measurement||price||2015-12-01 23:55:11.464550@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:55:21.584097||error||collecting ads||Error||5||1
+2015-12-01 23:55:23.743170||measurement||loadtime||0:00:28.667411||3||1
+2015-12-01 23:55:30.403624||measurement||price||2015-12-01 23:55:11.464550@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:55:37.756837||measurement||loadtime||0:00:29.764471||0||1
+2015-12-01 23:55:45.889707||error||collecting ads||Error||5||1
+2015-12-01 23:55:47.391663||error||collecting ads||Error||3||1
+2015-12-01 23:56:01.514899||error||collecting ads||Error||0||1
+2015-12-01 23:56:09.679517||error||collecting ads||Error||5||1
+2015-12-01 23:56:10.908771||error||collecting ads||Error||3||1
+2015-12-01 23:56:15.054429||measurement||price||2015-12-01 23:56:08.998679@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:56:23.481393||measurement||price||2015-12-01 23:56:17.210655@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 23:56:24.416218||measurement||price||2015-12-01 23:56:18.312003@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 23:56:27.878771||measurement||price||2015-12-01 23:56:08.998679@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:56:35.075542||measurement||loadtime||0:00:28.555434||0||1
+2015-12-01 23:56:36.312282||measurement||price||2015-12-01 23:56:17.210655@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 23:56:37.260374||measurement||price||2015-12-01 23:56:18.312003@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 23:56:43.523165||measurement||loadtime||0:00:28.839898||5||1
+2015-12-01 23:56:44.487132||measurement||loadtime||0:00:28.573190||3||1
+2015-12-01 23:56:48.873425||measurement||price||2015-12-01 23:56:42.835570@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 23:56:58.261168||measurement||price||2015-12-01 23:56:52.101146@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 23:57:01.698496||measurement||price||2015-12-01 23:56:42.835570@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 23:57:07.359053||error||collecting ads||Error||5||1
+2015-12-01 23:57:07.359161||event||progress-marker||measurement-end||5||1
+2015-12-01 23:57:08.891046||measurement||loadtime||0:00:28.810220||0||1
+2015-12-01 23:57:11.095417||measurement||price||2015-12-01 23:56:52.101146@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 23:57:18.295709||measurement||loadtime||0:00:28.803418||3||1
+2015-12-01 23:57:22.673428||measurement||price||2015-12-01 23:57:16.610742@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 23:57:35.482648||measurement||price||2015-12-01 23:57:16.610742@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 23:57:41.861834||error||collecting ads||Error||3||1
+2015-12-01 23:57:41.861976||event||progress-marker||measurement-end||3||1
+2015-12-01 23:57:42.667853||measurement||loadtime||0:00:28.771685||0||1
+2015-12-01 23:57:42.667988||event||progress-marker||measurement-end||0||1
+2015-12-01 23:57:43.236221||meta||block_id end||12
+2015-12-01 23:57:43.236515||meta||block_id start||13
+2015-12-01 23:57:43.236542||meta||assignment||5@|3@|4@|0@|1@|2
+2015-12-01 23:57:44.868211||event||progress-marker||training-start||4||0
+2015-12-01 23:57:44.884473||event||progress-marker||training-start||5||0
+2015-12-01 23:57:44.921333||event||progress-marker||training-start||3||0
+2015-12-01 23:57:49.385005||event||progress-marker||training-start||0||1
+2015-12-01 23:57:51.511106||treatment||visit website||http://irs.gov||3||0
+2015-12-01 23:57:51.612243||treatment||visit website||http://irs.gov||4||0
+2015-12-01 23:57:51.655135||treatment||visit website||http://irs.gov||5||0
+2015-12-01 23:57:55.834318||treatment||visit website||http://irs.gov||0||1
+2015-12-01 23:57:58.506273||treatment||visit website||http://deloitte.com||4||0
+2015-12-01 23:57:58.506748||treatment||visit website||http://deloitte.com||5||0
+2015-12-01 23:58:04.396715||treatment||visit website||http://deloitte.com||0||1
+2015-12-01 23:58:07.011485||treatment||visit website||http://pwc.com||5||0
+2015-12-01 23:58:12.850337||treatment||visit website||http://ey.com||5||0
+2015-12-01 23:58:19.540655||treatment||visit website||http://kpmg.com||5||0
+2015-12-01 23:58:19.540872||event||progress-marker||training-end||5||0
+2015-12-01 23:58:19.703624||treatment||visit website||http://pwc.com||0||1
+2015-12-01 23:58:25.883851||treatment||visit website||http://ey.com||0||1
+2015-12-01 23:58:31.832173||error||website timeout||http://deloitte.com||3||0
+2015-12-01 23:58:32.763110||treatment||visit website||http://kpmg.com||0||1
+2015-12-01 23:58:32.763204||event||progress-marker||training-end||0||1
+2015-12-01 23:58:38.646593||error||website timeout||http://pwc.com||4||0
+2015-12-01 23:58:44.414554||treatment||visit website||http://ey.com||4||0
+2015-12-01 23:58:51.654352||event||progress-marker||training-start||1||1
+2015-12-01 23:58:58.946458||treatment||visit website||http://irs.gov||1||1
+2015-12-01 23:59:00.536322||treatment||visit website||http://kpmg.com||4||0
+2015-12-01 23:59:00.536442||event||progress-marker||training-end||4||0
+2015-12-01 23:59:05.493929||treatment||visit website||http://deloitte.com||1||1
+2015-12-01 23:59:11.943957||error||website timeout||http://pwc.com||3||0
+2015-12-01 23:59:14.148058||treatment||visit website||http://pwc.com||1||1
+2015-12-01 23:59:17.791157||treatment||visit website||http://ey.com||3||0
+2015-12-01 23:59:20.104791||treatment||visit website||http://ey.com||1||1
+2015-12-01 23:59:24.179099||treatment||visit website||http://kpmg.com||3||0
+2015-12-01 23:59:24.179225||event||progress-marker||training-end||3||0
+2015-12-01 23:59:26.640301||treatment||visit website||http://kpmg.com||1||1
+2015-12-01 23:59:26.640407||event||progress-marker||training-end||1||1
+2015-12-01 23:59:27.999971||event||progress-marker||measurement-start||0||1
+2015-12-01 23:59:29.209610||event||progress-marker||measurement-start||3||0
+2015-12-01 23:59:29.845524||event||progress-marker||measurement-start||5||0
+2015-12-01 23:59:30.663394||event||progress-marker||measurement-start||4||0
+2015-12-01 23:59:31.674004||event||progress-marker||measurement-start||1||1
+2015-12-01 23:59:42.613588||measurement||price||2015-12-01 23:59:36.771059@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 23:59:43.034677||measurement||price||2015-12-01 23:59:37.555996@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 23:59:44.137040||measurement||price||2015-12-01 23:59:38.401703@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 23:59:46.785220||measurement||price||2015-12-01 23:59:40.307713@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-01 23:59:52.886897||event||progress-marker||training-start||2||1
+2015-12-01 23:59:53.291927||error||collecting ads||Error||0||1
+2015-12-01 23:59:54.950534||measurement||price||2015-12-01 23:59:36.771059@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 23:59:55.398100||measurement||price||2015-12-01 23:59:37.555996@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 23:59:56.495562||measurement||price||2015-12-01 23:59:38.401703@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 23:59:59.351101||treatment||visit website||http://irs.gov||2||1
+2015-12-01 23:59:59.652806||measurement||price||2015-12-01 23:59:40.307713@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 00:00:02.059528||measurement||loadtime||0:00:27.844708||3||0
+2015-12-02 00:00:02.499832||measurement||loadtime||0:00:27.652664||5||0
+2015-12-02 00:00:03.599200||measurement||loadtime||0:00:27.932057||4||0
+2015-12-02 00:00:05.859065||treatment||visit website||http://deloitte.com||2||1
+2015-12-02 00:00:06.832918||measurement||loadtime||0:00:30.153774||1||1
+2015-12-02 00:00:08.611564||measurement||price||2015-12-02 00:00:01.073282@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||1
+2015-12-02 00:00:15.016655||measurement||price||2015-12-02 00:00:09.621622@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||3||0
+2015-12-02 00:00:15.147169||measurement||price||2015-12-02 00:00:09.687186@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||0
+2015-12-02 00:00:16.167399||measurement||price||2015-12-02 00:00:10.714888@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:00:20.576946||measurement||price||2015-12-02 00:00:14.397113@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:00:21.720710||measurement||price||2015-12-02 00:00:01.073282@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||1
+2015-12-02 00:00:27.339481||measurement||price||2015-12-02 00:00:09.621622@|Electronic Arts@| $59.00   @|Star Wars: Battlefront - Standard Edition - Xbox One||3||0
+2015-12-02 00:00:27.444209||measurement||price||2015-12-02 00:00:09.687186@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||0
+2015-12-02 00:00:28.489367||measurement||price||2015-12-02 00:00:10.714888@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:00:28.937259||measurement||loadtime||0:00:30.642125||0||1
+2015-12-02 00:00:33.592787||measurement||price||2015-12-02 00:00:14.397113@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:00:34.447093||measurement||loadtime||0:00:27.382320||3||0
+2015-12-02 00:00:34.536038||measurement||loadtime||0:00:27.032886||5||0
+2015-12-02 00:00:35.595145||measurement||loadtime||0:00:26.992010||4||0
+2015-12-02 00:00:40.783151||measurement||loadtime||0:00:28.945055||1||1
+2015-12-02 00:00:42.893448||treatment||visit website||http://pwc.com||2||1
+2015-12-02 00:00:47.058598||measurement||price||2015-12-02 00:00:41.455215@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||0
+2015-12-02 00:00:47.184523||measurement||price||2015-12-02 00:00:41.783694@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-02 00:00:48.163743||measurement||price||2015-12-02 00:00:42.717659@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:00:48.911202||treatment||visit website||http://ey.com||2||1
+2015-12-02 00:00:52.805834||error||collecting ads||Error||0||1
+2015-12-02 00:00:54.478233||measurement||price||2015-12-02 00:00:48.389701@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 00:00:55.471096||treatment||visit website||http://kpmg.com||2||1
+2015-12-02 00:00:55.471198||event||progress-marker||training-end||2||1
+2015-12-02 00:00:59.354102||measurement||price||2015-12-02 00:00:41.455215@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||0
+2015-12-02 00:00:59.513435||measurement||price||2015-12-02 00:00:41.783694@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-02 00:01:00.469633||measurement||price||2015-12-02 00:00:42.717659@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:01:00.501937||event||progress-marker||measurement-start||2||1
+2015-12-02 00:01:06.459176||measurement||loadtime||0:00:27.010823||3||0
+2015-12-02 00:01:06.621002||measurement||loadtime||0:00:27.079756||5||0
+2015-12-02 00:01:06.753021||measurement||price||2015-12-02 00:01:00.121325@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||1
+2015-12-02 00:01:07.363895||measurement||price||2015-12-02 00:00:48.389701@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 00:01:07.559153||measurement||loadtime||0:00:26.960001||4||0
+2015-12-02 00:01:14.555992||measurement||loadtime||0:00:28.767658||1||1
+2015-12-02 00:01:14.810710||measurement||price||2015-12-02 00:01:08.641645@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||1
+2015-12-02 00:01:19.052500||measurement||price||2015-12-02 00:01:13.598797@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-02 00:01:19.246669||measurement||price||2015-12-02 00:01:13.772193@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-02 00:01:19.691789||measurement||price||2015-12-02 00:01:00.121325@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||1
+2015-12-02 00:01:20.270227||measurement||price||2015-12-02 00:01:14.833237@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||0
+2015-12-02 00:01:26.886759||measurement||loadtime||0:00:29.075706||0||1
+2015-12-02 00:01:27.734087||measurement||price||2015-12-02 00:01:08.641645@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||1
+2015-12-02 00:01:28.588570||measurement||price||2015-12-02 00:01:22.399566@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:01:31.371122||measurement||price||2015-12-02 00:01:13.598797@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-02 00:01:31.564597||measurement||price||2015-12-02 00:01:13.772193@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-02 00:01:32.608567||measurement||price||2015-12-02 00:01:14.833237@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||0
+2015-12-02 00:01:34.936229||measurement||loadtime||0:00:29.430183||2||1
+2015-12-02 00:01:38.480672||measurement||loadtime||0:00:27.016201||3||0
+2015-12-02 00:01:38.675393||measurement||loadtime||0:00:27.049186||5||0
+2015-12-02 00:01:39.719137||measurement||loadtime||0:00:27.156022||4||0
+2015-12-02 00:01:41.111658||measurement||price||2015-12-02 00:01:35.241795@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||1
+2015-12-02 00:01:41.491827||measurement||price||2015-12-02 00:01:22.399566@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:01:48.692244||measurement||loadtime||0:00:29.131006||1||1
+2015-12-02 00:01:49.153025||measurement||price||2015-12-02 00:01:42.710000@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 00:01:51.169087||measurement||price||2015-12-02 00:01:45.520202@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||0
+2015-12-02 00:01:52.320394||measurement||price||2015-12-02 00:01:46.475560@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-02 00:01:53.995179||measurement||price||2015-12-02 00:01:35.241795@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||1
+2015-12-02 00:02:01.200075||measurement||loadtime||0:00:29.308090||0||1
+2015-12-02 00:02:01.429789||error||collecting ads||Error||5||0
+2015-12-02 00:02:02.239661||measurement||price||2015-12-02 00:01:42.710000@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 00:02:02.611201||measurement||price||2015-12-02 00:01:56.330345@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:02:03.487804||measurement||price||2015-12-02 00:01:45.520202@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||0
+2015-12-02 00:02:04.601622||measurement||price||2015-12-02 00:01:46.475560@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-02 00:02:09.447150||measurement||loadtime||0:00:29.505748||2||1
+2015-12-02 00:02:10.591151||measurement||loadtime||0:00:27.107316||3||0
+2015-12-02 00:02:11.687297||measurement||loadtime||0:00:26.964158||4||0
+2015-12-02 00:02:15.575276||measurement||price||2015-12-02 00:01:56.330345@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:02:15.668309||measurement||price||2015-12-02 00:02:09.250989@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||1
+2015-12-02 00:02:22.779159||measurement||loadtime||0:00:29.081703||1||1
+2015-12-02 00:02:23.115972||measurement||price||2015-12-02 00:02:17.677110@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||0
+2015-12-02 00:02:23.431810||measurement||price||2015-12-02 00:02:17.143153@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 00:02:23.963854||error||collecting ads||Error||5||0
+2015-12-02 00:02:28.804199||measurement||price||2015-12-02 00:02:09.250989@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||1
+2015-12-02 00:02:34.300645||error||collecting ads||Error||4||0
+2015-12-02 00:02:35.430781||measurement||price||2015-12-02 00:02:17.677110@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||0
+2015-12-02 00:02:36.156947||measurement||loadtime||0:00:29.951647||0||1
+2015-12-02 00:02:36.424998||measurement||price||2015-12-02 00:02:17.143153@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 00:02:36.652954||measurement||price||2015-12-02 00:02:30.344218@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:02:36.725531||measurement||price||2015-12-02 00:02:31.165853@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||5||0
+2015-12-02 00:02:42.519173||measurement||loadtime||0:00:26.922798||3||0
+2015-12-02 00:02:43.651152||measurement||loadtime||0:00:29.199943||2||1
+2015-12-02 00:02:46.838894||measurement||price||2015-12-02 00:02:41.398178@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-02 00:02:49.781890||measurement||price||2015-12-02 00:02:30.344218@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:02:50.308982||measurement||price||2015-12-02 00:02:43.468262@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||1
+2015-12-02 00:02:55.030733||measurement||price||2015-12-02 00:02:49.600707@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 00:02:57.018340||measurement||loadtime||0:00:29.233983||1||1
+2015-12-02 00:02:57.691605||measurement||price||2015-12-02 00:02:51.536809@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 00:02:59.086503||error||collecting ads||Error||5||0
+2015-12-02 00:02:59.166062||measurement||price||2015-12-02 00:02:41.398178@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-02 00:03:03.163625||measurement||price||2015-12-02 00:02:43.468262@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||1
+2015-12-02 00:03:06.271162||measurement||loadtime||0:00:26.968425||4||0
+2015-12-02 00:03:07.330563||measurement||price||2015-12-02 00:02:49.600707@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 00:03:10.379135||measurement||loadtime||0:00:29.216985||0||1
+2015-12-02 00:03:10.568803||measurement||price||2015-12-02 00:02:51.536809@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 00:03:10.855954||measurement||price||2015-12-02 00:03:04.669012@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:03:11.681965||measurement||price||2015-12-02 00:03:06.292957@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:03:14.431580||measurement||loadtime||0:00:26.909298||3||0
+2015-12-02 00:03:17.775151||measurement||loadtime||0:00:29.120928||2||1
+2015-12-02 00:03:18.633200||measurement||price||2015-12-02 00:03:13.306149@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||0
+2015-12-02 00:03:23.957283||measurement||price||2015-12-02 00:03:04.669012@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:03:24.009391||measurement||price||2015-12-02 00:03:06.292957@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:03:24.302879||measurement||price||2015-12-02 00:03:17.679082@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||1
+2015-12-02 00:03:30.961393||measurement||price||2015-12-02 00:03:13.306149@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||0
+2015-12-02 00:03:31.123147||measurement||loadtime||0:00:27.032001||5||0
+2015-12-02 00:03:31.193926||measurement||loadtime||0:00:29.170543||1||1
+2015-12-02 00:03:31.584399||measurement||price||2015-12-02 00:03:25.441745@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||1
+2015-12-02 00:03:36.825663||error||collecting ads||Error||3||0
+2015-12-02 00:03:37.284466||measurement||price||2015-12-02 00:03:17.679082@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||1
+2015-12-02 00:03:38.066899||measurement||loadtime||0:00:26.793700||4||0
+2015-12-02 00:03:44.046478||measurement||price||2015-12-02 00:03:38.692665@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||5||0
+2015-12-02 00:03:44.469430||measurement||price||2015-12-02 00:03:25.441745@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||1
+2015-12-02 00:03:44.487183||measurement||loadtime||0:00:29.106869||0||1
+2015-12-02 00:03:45.101543||measurement||price||2015-12-02 00:03:38.959833@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:03:49.255559||measurement||price||2015-12-02 00:03:43.878818@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:03:50.633988||measurement||price||2015-12-02 00:03:45.223693@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||0
+2015-12-02 00:03:51.703154||measurement||loadtime||0:00:28.924037||2||1
+2015-12-02 00:03:56.403291||measurement||price||2015-12-02 00:03:38.692665@|Electronic Arts@| $59.00   @|Star Wars: Battlefront - Standard Edition - Xbox One||5||0
+2015-12-02 00:03:58.112005||measurement||price||2015-12-02 00:03:38.959833@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:03:58.344496||measurement||price||2015-12-02 00:03:51.965272@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||1
+2015-12-02 00:04:01.589454||measurement||price||2015-12-02 00:03:43.878818@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:04:02.962178||measurement||price||2015-12-02 00:03:45.223693@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||0
+2015-12-02 00:04:03.513966||measurement||loadtime||0:00:27.386835||5||0
+2015-12-02 00:04:05.331501||measurement||loadtime||0:00:29.132412||1||1
+2015-12-02 00:04:08.691207||measurement||loadtime||0:00:26.860313||3||0
+2015-12-02 00:04:10.067182||measurement||loadtime||0:00:26.995097||4||0
+2015-12-02 00:04:11.214794||measurement||price||2015-12-02 00:03:51.965272@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||1
+2015-12-02 00:04:15.373340||error||collecting ads||Error||2||1
+2015-12-02 00:04:16.027754||measurement||price||2015-12-02 00:04:10.622735@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-02 00:04:18.432024||measurement||loadtime||0:00:28.939952||0||1
+2015-12-02 00:04:19.301287||measurement||price||2015-12-02 00:04:13.102138@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:04:21.188980||measurement||price||2015-12-02 00:04:15.753888@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||0
+2015-12-02 00:04:22.480151||measurement||price||2015-12-02 00:04:17.054718@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-02 00:04:28.368628||measurement||price||2015-12-02 00:04:10.622735@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-02 00:04:29.265205||measurement||price||2015-12-02 00:04:22.987509@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||1
+2015-12-02 00:04:32.234012||measurement||price||2015-12-02 00:04:13.102138@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:04:32.521091||measurement||price||2015-12-02 00:04:26.354627@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||0||1
+2015-12-02 00:04:33.511271||measurement||price||2015-12-02 00:04:15.753888@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||0
+2015-12-02 00:04:34.797720||measurement||price||2015-12-02 00:04:17.054718@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-02 00:04:35.484334||measurement||loadtime||0:00:26.965192||5||0
+2015-12-02 00:04:39.421854||measurement||loadtime||0:00:29.089798||1||1
+2015-12-02 00:04:40.612552||measurement||loadtime||0:00:26.917396||3||0
+2015-12-02 00:04:41.900954||measurement||loadtime||0:00:26.829817||4||0
+2015-12-02 00:04:42.130082||measurement||price||2015-12-02 00:04:22.987509@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||1
+2015-12-02 00:04:48.002177||measurement||price||2015-12-02 00:04:42.620201@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:04:49.323173||measurement||loadtime||0:00:28.948942||2||1
+2015-12-02 00:04:53.194395||measurement||price||2015-12-02 00:04:47.772231@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 00:04:53.481269||measurement||price||2015-12-02 00:04:47.203926@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||1
+2015-12-02 00:04:55.353429||error||collecting ads||Error||0||1
+2015-12-02 00:05:00.335686||measurement||price||2015-12-02 00:04:42.620201@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:05:03.148758||measurement||price||2015-12-02 00:04:57.001352@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 00:05:04.383922||error||collecting ads||Error||4||0
+2015-12-02 00:05:05.481027||measurement||price||2015-12-02 00:04:47.772231@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 00:05:06.390214||measurement||price||2015-12-02 00:04:47.203926@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||1
+2015-12-02 00:05:07.444723||measurement||loadtime||0:00:26.959073||5||0
+2015-12-02 00:05:09.322832||measurement||price||2015-12-02 00:05:02.707235@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||1
+2015-12-02 00:05:12.562684||measurement||loadtime||0:00:26.947553||3||0
+2015-12-02 00:05:13.607145||measurement||loadtime||0:00:29.180097||1||1
+2015-12-02 00:05:15.992134||measurement||price||2015-12-02 00:04:57.001352@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 00:05:16.804827||measurement||price||2015-12-02 00:05:11.433037@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:05:19.891711||measurement||price||2015-12-02 00:05:14.489372@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-02 00:05:22.172365||measurement||price||2015-12-02 00:05:02.707235@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||1
+2015-12-02 00:05:23.189566||measurement||loadtime||0:00:28.861191||2||1
+2015-12-02 00:05:24.938576||measurement||price||2015-12-02 00:05:19.575430@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:05:27.283566||measurement||price||2015-12-02 00:05:21.226831@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 00:05:29.129824||measurement||price||2015-12-02 00:05:11.433037@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:05:29.372678||measurement||loadtime||0:00:29.016637||0||1
+2015-12-02 00:05:32.238653||measurement||price||2015-12-02 00:05:14.489372@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-02 00:05:36.223147||measurement||loadtime||0:00:26.836023||4||0
+2015-12-02 00:05:36.923176||measurement||price||2015-12-02 00:05:30.829891@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||1
+2015-12-02 00:05:37.228582||measurement||price||2015-12-02 00:05:19.575430@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:05:39.352809||measurement||loadtime||0:00:26.902904||5||0
+2015-12-02 00:05:40.270835||measurement||price||2015-12-02 00:05:21.226831@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 00:05:44.314811||measurement||loadtime||0:00:26.747702||3||0
+2015-12-02 00:05:47.463172||measurement||loadtime||0:00:28.852027||1||1
+2015-12-02 00:05:48.611492||measurement||price||2015-12-02 00:05:43.269171@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:05:49.791740||measurement||price||2015-12-02 00:05:30.829891@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||1
+2015-12-02 00:05:51.866292||measurement||price||2015-12-02 00:05:46.498212@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:05:53.168012||error||collecting ads||Error||0||1
+2015-12-02 00:05:56.735953||measurement||price||2015-12-02 00:05:50.933851@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:05:56.999165||measurement||loadtime||0:00:28.805255||2||1
+2015-12-02 00:06:00.891333||measurement||price||2015-12-02 00:05:43.269171@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:06:01.669013||measurement||price||2015-12-02 00:05:55.561161@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||1||1
+2015-12-02 00:06:04.239446||measurement||price||2015-12-02 00:05:46.498212@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:06:07.971311||measurement||loadtime||0:00:26.744182||4||0
+2015-12-02 00:06:09.021568||measurement||price||2015-12-02 00:05:50.933851@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:06:10.846918||measurement||price||2015-12-02 00:06:04.689690@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||1
+2015-12-02 00:06:11.359233||measurement||loadtime||0:00:27.004086||5||0
+2015-12-02 00:06:14.740423||measurement||price||2015-12-02 00:05:55.561161@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||1
+2015-12-02 00:06:16.108723||measurement||loadtime||0:00:26.788672||3||0
+2015-12-02 00:06:16.582839||error||collecting ads||Error||0||1
+2015-12-02 00:06:20.367074||measurement||price||2015-12-02 00:06:14.982428@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||0
+2015-12-02 00:06:21.949079||measurement||loadtime||0:00:29.481938||1||1
+2015-12-02 00:06:23.683428||measurement||price||2015-12-02 00:06:04.689690@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||1
+2015-12-02 00:06:23.881508||measurement||price||2015-12-02 00:06:18.458833@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||0
+2015-12-02 00:06:28.978437||measurement||price||2015-12-02 00:06:23.634922@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||3||0
+2015-12-02 00:06:30.539512||measurement||price||2015-12-02 00:06:23.953703@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-02 00:06:30.906009||measurement||loadtime||0:00:28.901580||2||1
+2015-12-02 00:06:32.684407||measurement||price||2015-12-02 00:06:14.982428@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||0
+2015-12-02 00:06:35.707594||measurement||price||2015-12-02 00:06:29.615976@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 00:06:36.236277||measurement||price||2015-12-02 00:06:18.458833@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||0
+2015-12-02 00:06:39.792854||measurement||loadtime||0:00:26.816321||4||0
+2015-12-02 00:06:41.269431||measurement||price||2015-12-02 00:06:23.634922@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||3||0
+2015-12-02 00:06:43.354836||measurement||loadtime||0:00:26.990388||5||0
+2015-12-02 00:06:43.421783||measurement||price||2015-12-02 00:06:23.953703@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-02 00:06:44.749669||measurement||price||2015-12-02 00:06:38.647822@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 00:06:48.371383||measurement||loadtime||0:00:27.260272||3||0
+2015-12-02 00:06:48.580818||measurement||price||2015-12-02 00:06:29.615976@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 00:06:50.639132||measurement||loadtime||0:00:29.051104||0||1
+2015-12-02 00:06:52.175447||measurement||price||2015-12-02 00:06:46.793499@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:06:55.779166||measurement||loadtime||0:00:28.824895||1||1
+2015-12-02 00:06:55.969758||measurement||price||2015-12-02 00:06:50.533530@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-02 00:06:57.631320||measurement||price||2015-12-02 00:06:38.647822@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 00:07:04.384964||measurement||price||2015-12-02 00:06:57.901927@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||1
+2015-12-02 00:07:04.519168||measurement||price||2015-12-02 00:06:46.793499@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:07:04.849945||measurement||loadtime||0:00:28.938809||2||1
+2015-12-02 00:07:08.312395||measurement||price||2015-12-02 00:06:50.533530@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-02 00:07:09.695510||measurement||price||2015-12-02 00:07:03.498252@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:07:10.776646||error||collecting ads||Error||3||0
+2015-12-02 00:07:11.634655||measurement||loadtime||0:00:26.836564||4||0
+2015-12-02 00:07:15.421382||measurement||loadtime||0:00:27.064155||5||0
+2015-12-02 00:07:17.254890||measurement||price||2015-12-02 00:06:57.901927@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||1
+2015-12-02 00:07:22.703078||measurement||price||2015-12-02 00:07:03.498252@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:07:23.297690||measurement||price||2015-12-02 00:07:17.867787@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||0
+2015-12-02 00:07:24.464300||measurement||loadtime||0:00:28.819990||0||1
+2015-12-02 00:07:25.253044||measurement||price||2015-12-02 00:07:19.855983@|Mr Beams@|$23.99@|Mr. Beams MB723 Battery-Powered Motion-Sensing LED Stick-Any...||4||0
+2015-12-02 00:07:28.064954||measurement||price||2015-12-02 00:07:22.630528@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:07:28.647288||error||collecting ads||Error||2||1
+2015-12-02 00:07:29.894695||measurement||loadtime||0:00:29.111558||1||1
+2015-12-02 00:07:35.642419||measurement||price||2015-12-02 00:07:17.867787@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||0
+2015-12-02 00:07:37.604264||measurement||price||2015-12-02 00:07:19.855983@|Mr. Beams@|$29.99@|Mr Beams MB390 300-Lumen Weatherproof Wireless Battery Power...||4||0
+2015-12-02 00:07:38.306427||measurement||price||2015-12-02 00:07:31.749192@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||1
+2015-12-02 00:07:40.390057||measurement||price||2015-12-02 00:07:22.630528@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:07:42.455394||measurement||price||2015-12-02 00:07:36.301506@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||1
+2015-12-02 00:07:42.759198||measurement||loadtime||0:00:26.982218||3||0
+2015-12-02 00:07:43.710444||measurement||price||2015-12-02 00:07:37.662798@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:07:44.714284||measurement||loadtime||0:00:28.074865||4||0
+2015-12-02 00:07:47.502018||measurement||loadtime||0:00:27.077504||5||0
+2015-12-02 00:07:51.151909||measurement||price||2015-12-02 00:07:31.749192@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||1
+2015-12-02 00:07:55.113406||measurement||price||2015-12-02 00:07:49.705527@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:07:55.358927||measurement||price||2015-12-02 00:07:36.301506@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||1
+2015-12-02 00:07:56.712654||measurement||price||2015-12-02 00:07:37.662798@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:07:57.246584||measurement||price||2015-12-02 00:07:51.794617@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-02 00:07:58.370694||measurement||loadtime||0:00:28.901170||0||1
+2015-12-02 00:08:00.795355||measurement||price||2015-12-02 00:07:55.297243@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:08:02.591195||measurement||loadtime||0:00:28.938695||2||1
+2015-12-02 00:08:03.896988||measurement||loadtime||0:00:28.997105||1||1
+2015-12-02 00:08:07.438357||measurement||price||2015-12-02 00:07:49.705527@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:08:09.578655||measurement||price||2015-12-02 00:07:51.794617@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-02 00:08:12.174974||measurement||price||2015-12-02 00:08:05.730426@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||1
+2015-12-02 00:08:13.111773||measurement||price||2015-12-02 00:07:55.297243@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:08:14.547879||measurement||loadtime||0:00:26.783466||3||0
+2015-12-02 00:08:16.408200||measurement||price||2015-12-02 00:08:10.331811@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 00:08:16.695553||measurement||loadtime||0:00:26.976385||4||0
+2015-12-02 00:08:17.745767||measurement||price||2015-12-02 00:08:11.566111@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:08:20.191150||measurement||loadtime||0:00:27.683987||5||0
+2015-12-02 00:08:25.047219||measurement||price||2015-12-02 00:08:05.730426@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||1
+2015-12-02 00:08:29.144024||measurement||price||2015-12-02 00:08:23.766031@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-02 00:08:29.262031||measurement||price||2015-12-02 00:08:10.331811@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 00:08:30.659753||measurement||price||2015-12-02 00:08:11.566111@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:08:32.278157||measurement||loadtime||0:00:28.902255||0||1
+2015-12-02 00:08:36.465811||measurement||loadtime||0:00:28.872769||2||1
+2015-12-02 00:08:36.915245||error||collecting ads||Error||3||0
+2015-12-02 00:08:37.859156||measurement||loadtime||0:00:28.960020||1||1
+2015-12-02 00:08:41.432575||measurement||price||2015-12-02 00:08:23.766031@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-02 00:08:42.770548||error||collecting ads||Error||5||0
+2015-12-02 00:08:46.095501||measurement||price||2015-12-02 00:08:39.537539@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||1
+2015-12-02 00:08:48.538836||measurement||loadtime||0:00:26.839698||4||0
+2015-12-02 00:08:49.464555||measurement||price||2015-12-02 00:08:44.044975@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:08:50.353872||measurement||price||2015-12-02 00:08:44.168761@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||1
+2015-12-02 00:08:51.807878||measurement||price||2015-12-02 00:08:45.511388@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 00:08:55.319153||measurement||price||2015-12-02 00:08:49.896030@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||0
+2015-12-02 00:08:58.955710||measurement||price||2015-12-02 00:08:39.537539@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||1
+2015-12-02 00:09:00.961246||measurement||price||2015-12-02 00:08:55.579150@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-02 00:09:01.795860||measurement||price||2015-12-02 00:08:44.044975@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:09:03.201690||measurement||price||2015-12-02 00:08:44.168761@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||1
+2015-12-02 00:09:04.663408||measurement||price||2015-12-02 00:08:45.511388@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 00:09:06.151386||measurement||loadtime||0:00:28.868022||0||1
+2015-12-02 00:09:07.651402||measurement||price||2015-12-02 00:08:49.896030@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||0
+2015-12-02 00:09:08.903172||measurement||loadtime||0:00:26.985058||3||0
+2015-12-02 00:09:10.400267||measurement||loadtime||0:00:28.929241||2||1
+2015-12-02 00:09:11.877690||measurement||loadtime||0:00:29.013344||1||1
+2015-12-02 00:09:13.288563||measurement||price||2015-12-02 00:08:55.579150@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-02 00:09:14.763197||measurement||loadtime||0:00:26.990810||5||0
+2015-12-02 00:09:19.906832||measurement||price||2015-12-02 00:09:13.438184@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-02 00:09:20.399146||measurement||loadtime||0:00:26.855113||4||0
+2015-12-02 00:09:21.429139||measurement||price||2015-12-02 00:09:15.988264@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||3||0
+2015-12-02 00:09:24.185413||measurement||price||2015-12-02 00:09:18.106381@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-02 00:09:25.911427||measurement||price||2015-12-02 00:09:19.620826@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 00:09:27.284858||measurement||price||2015-12-02 00:09:21.891003@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:09:32.791010||measurement||price||2015-12-02 00:09:13.438184@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-02 00:09:32.895827||measurement||price||2015-12-02 00:09:27.442901@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-02 00:09:33.721472||measurement||price||2015-12-02 00:09:15.988264@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||3||0
+2015-12-02 00:09:36.964533||measurement||price||2015-12-02 00:09:18.106381@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-02 00:09:38.725867||measurement||price||2015-12-02 00:09:19.620826@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 00:09:39.618440||measurement||price||2015-12-02 00:09:21.891003@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:09:39.984823||measurement||loadtime||0:00:28.828220||0||1
+2015-12-02 00:09:40.808985||measurement||loadtime||0:00:26.901847||3||0
+2015-12-02 00:09:40.809079||event||progress-marker||measurement-end||3||0
+2015-12-02 00:09:44.179618||measurement||loadtime||0:00:28.774173||2||1
+2015-12-02 00:09:45.220891||measurement||price||2015-12-02 00:09:27.442901@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-02 00:09:45.938936||measurement||loadtime||0:00:29.056056||1||1
+2015-12-02 00:09:46.726274||measurement||loadtime||0:00:26.957883||5||0
+2015-12-02 00:09:46.726387||event||progress-marker||measurement-end||5||0
+2015-12-02 00:09:52.331131||measurement||loadtime||0:00:26.926761||4||0
+2015-12-02 00:09:52.331225||event||progress-marker||measurement-end||4||0
+2015-12-02 00:09:53.841578||measurement||price||2015-12-02 00:09:47.239133@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||1
+2015-12-02 00:09:59.845438||measurement||price||2015-12-02 00:09:53.621344@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 00:10:06.754848||measurement||price||2015-12-02 00:09:47.239133@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||1
+2015-12-02 00:10:07.921190||error||collecting ads||Error||2||1
+2015-12-02 00:10:12.738114||measurement||price||2015-12-02 00:09:53.621344@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 00:10:13.931174||measurement||loadtime||0:00:28.942134||0||1
+2015-12-02 00:10:13.931277||event||progress-marker||measurement-end||0||1
+2015-12-02 00:10:19.931501||measurement||loadtime||0:00:28.987361||1||1
+2015-12-02 00:10:21.497918||measurement||price||2015-12-02 00:10:15.407876@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 00:10:33.757141||measurement||price||2015-12-02 00:10:27.637838@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 00:10:34.346023||measurement||price||2015-12-02 00:10:15.407876@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 00:10:41.556469||measurement||loadtime||0:00:28.633331||2||1
+2015-12-02 00:10:46.690280||measurement||price||2015-12-02 00:10:27.637838@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 00:10:53.872250||measurement||loadtime||0:00:28.935490||1||1
+2015-12-02 00:10:53.872361||event||progress-marker||measurement-end||1||1
+2015-12-02 00:10:55.513967||measurement||price||2015-12-02 00:10:49.272119@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 00:11:08.328072||measurement||price||2015-12-02 00:10:49.272119@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 00:11:15.540835||measurement||loadtime||0:00:28.983245||2||1
+2015-12-02 00:11:29.228111||measurement||price||2015-12-02 00:11:23.105147@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 00:11:42.048155||measurement||price||2015-12-02 00:11:23.105147@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 00:11:49.230474||measurement||loadtime||0:00:28.684432||2||1
+2015-12-02 00:11:49.230605||event||progress-marker||measurement-end||2||1
+2015-12-02 00:11:49.802532||meta||block_id end||13
+2015-12-02 00:11:49.802767||meta||block_id start||14
+2015-12-02 00:11:49.802785||meta||assignment||4@|2@|0@|1@|5@|3
+2015-12-02 00:11:51.436539||event||progress-marker||training-start||0||0
+2015-12-02 00:11:51.506216||event||progress-marker||training-start||4||0
+2015-12-02 00:11:51.529309||event||progress-marker||training-start||2||0
+2015-12-02 00:11:58.203164||treatment||visit website||http://irs.gov||4||0
+2015-12-02 00:11:58.219916||treatment||visit website||http://irs.gov||2||0
+2015-12-02 00:11:58.279204||treatment||visit website||http://irs.gov||0||0
+2015-12-02 00:12:05.624664||treatment||visit website||http://deloitte.com||2||0
+2015-12-02 00:12:05.624848||treatment||visit website||http://deloitte.com||4||0
+2015-12-02 00:12:05.636476||treatment||visit website||http://deloitte.com||0||0
+2015-12-02 00:12:10.032918||event||progress-marker||training-start||5||1
+2015-12-02 00:12:16.852885||treatment||visit website||http://irs.gov||5||1
+2015-12-02 00:12:23.871107||treatment||visit website||http://deloitte.com||5||1
+2015-12-02 00:12:41.484067||treatment||visit website||http://pwc.com||2||0
+2015-12-02 00:12:41.599140||treatment||visit website||http://pwc.com||4||0
+2015-12-02 00:12:41.932080||treatment||visit website||http://pwc.com||0||0
+2015-12-02 00:12:47.528048||treatment||visit website||http://ey.com||2||0
+2015-12-02 00:12:47.575124||treatment||visit website||http://ey.com||4||0
+2015-12-02 00:12:47.730039||treatment||visit website||http://ey.com||0||0
+2015-12-02 00:12:54.449521||treatment||visit website||http://kpmg.com||0||0
+2015-12-02 00:12:54.449671||event||progress-marker||training-end||0||0
+2015-12-02 00:12:54.609900||treatment||visit website||http://kpmg.com||4||0
+2015-12-02 00:12:54.610007||event||progress-marker||training-end||4||0
+2015-12-02 00:12:54.683129||treatment||visit website||http://kpmg.com||2||0
+2015-12-02 00:12:54.683249||event||progress-marker||training-end||2||0
+2015-12-02 00:13:03.892115||error||website timeout||http://pwc.com||5||1
+2015-12-02 00:13:08.931113||treatment||visit website||http://ey.com||5||1
+2015-12-02 00:13:16.197761||treatment||visit website||http://kpmg.com||5||1
+2015-12-02 00:13:16.197917||event||progress-marker||training-end||5||1
+2015-12-02 00:13:19.578841||event||progress-marker||measurement-start||0||0
+2015-12-02 00:13:19.722847||event||progress-marker||measurement-start||4||0
+2015-12-02 00:13:19.816764||event||progress-marker||measurement-start||2||0
+2015-12-02 00:13:21.242442||event||progress-marker||measurement-start||5||1
+2015-12-02 00:13:33.329922||measurement||price||2015-12-02 00:13:27.195185@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 00:13:33.482502||measurement||price||2015-12-02 00:13:28.005281@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-02 00:13:34.063426||measurement||price||2015-12-02 00:13:27.394504@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||0
+2015-12-02 00:13:45.691079||measurement||price||2015-12-02 00:13:27.195185@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 00:13:45.851515||measurement||price||2015-12-02 00:13:28.005281@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-02 00:13:46.029972||error||collecting ads||Error||5||1
+2015-12-02 00:13:46.443731||measurement||price||2015-12-02 00:13:27.394504@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||0
+2015-12-02 00:13:52.781447||measurement||loadtime||0:00:28.197390||0||0
+2015-12-02 00:13:52.942789||measurement||loadtime||0:00:28.123641||2||0
+2015-12-02 00:13:53.555170||measurement||loadtime||0:00:28.828027||4||0
+2015-12-02 00:13:58.929500||event||progress-marker||training-start||3||1
+2015-12-02 00:13:59.058956||event||progress-marker||training-start||1||1
+2015-12-02 00:13:59.665627||measurement||price||2015-12-02 00:13:53.432799@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 00:14:05.318567||measurement||price||2015-12-02 00:13:59.532760@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 00:14:05.673864||treatment||visit website||http://irs.gov||3||1
+2015-12-02 00:14:05.683822||treatment||visit website||http://irs.gov||1||1
+2015-12-02 00:14:06.661609||measurement||price||2015-12-02 00:14:01.218218@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:14:12.174837||treatment||visit website||http://deloitte.com||3||1
+2015-12-02 00:14:12.652928||measurement||price||2015-12-02 00:13:53.432799@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 00:14:14.183104||treatment||visit website||http://deloitte.com||1||1
+2015-12-02 00:14:16.109768||error||collecting ads||Error||2||0
+2015-12-02 00:14:17.661240||measurement||price||2015-12-02 00:13:59.532760@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 00:14:19.003615||measurement||price||2015-12-02 00:14:01.218218@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:14:19.910173||measurement||loadtime||0:00:28.874966||5||1
+2015-12-02 00:14:24.768431||measurement||loadtime||0:00:26.981785||0||0
+2015-12-02 00:14:26.110081||measurement||loadtime||0:00:27.550933||4||0
+2015-12-02 00:14:28.759559||measurement||price||2015-12-02 00:14:23.363757@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:14:33.709105||measurement||price||2015-12-02 00:14:27.521534@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-02 00:14:36.988901||measurement||price||2015-12-02 00:14:31.385967@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||0||0
+2015-12-02 00:14:39.390237||measurement||price||2015-12-02 00:14:33.934854@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||4||0
+2015-12-02 00:14:41.081575||measurement||price||2015-12-02 00:14:23.363757@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:14:46.523005||measurement||price||2015-12-02 00:14:27.521534@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-02 00:14:48.202733||measurement||loadtime||0:00:27.087774||2||0
+2015-12-02 00:14:49.284051||measurement||price||2015-12-02 00:14:31.385967@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||0||0
+2015-12-02 00:14:51.709414||measurement||price||2015-12-02 00:14:33.934854@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||4||0
+2015-12-02 00:14:52.198729||error||website timeout||http://pwc.com||3||1
+2015-12-02 00:14:53.751180||measurement||loadtime||0:00:28.836035||5||1
+2015-12-02 00:14:54.205478||error||website timeout||http://pwc.com||1||1
+2015-12-02 00:14:56.367560||measurement||loadtime||0:00:26.593907||0||0
+2015-12-02 00:14:57.237004||treatment||visit website||http://ey.com||3||1
+2015-12-02 00:14:58.795182||measurement||loadtime||0:00:27.680041||4||0
+2015-12-02 00:14:59.259097||treatment||visit website||http://ey.com||1||1
+2015-12-02 00:15:00.915217||measurement||price||2015-12-02 00:14:55.486164@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:15:04.105383||treatment||visit website||http://kpmg.com||3||1
+2015-12-02 00:15:04.105510||event||progress-marker||training-end||3||1
+2015-12-02 00:15:05.743963||treatment||visit website||http://kpmg.com||1||1
+2015-12-02 00:15:05.744088||event||progress-marker||training-end||1||1
+2015-12-02 00:15:07.302324||measurement||price||2015-12-02 00:15:01.208574@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 00:15:09.139056||event||progress-marker||measurement-start||3||1
+2015-12-02 00:15:10.784397||event||progress-marker||measurement-start||1||1
+2015-12-02 00:15:13.254466||measurement||price||2015-12-02 00:14:55.486164@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:15:18.552972||error||collecting ads||Error||0||0
+2015-12-02 00:15:20.098872||measurement||price||2015-12-02 00:15:01.208574@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 00:15:20.363174||measurement||loadtime||0:00:27.155214||2||0
+2015-12-02 00:15:21.407164||error||collecting ads||Error||4||0
+2015-12-02 00:15:23.201747||measurement||price||2015-12-02 00:15:16.997765@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-02 00:15:25.045828||measurement||price||2015-12-02 00:15:18.899302@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:15:27.315162||measurement||loadtime||0:00:28.558776||5||1
+2015-12-02 00:15:30.785814||measurement||price||2015-12-02 00:15:25.235920@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:15:34.295998||measurement||price||2015-12-02 00:15:28.933695@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:15:36.015977||measurement||price||2015-12-02 00:15:16.997765@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-02 00:15:37.880829||measurement||price||2015-12-02 00:15:18.899302@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:15:40.808101||measurement||price||2015-12-02 00:15:34.828981@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||1
+2015-12-02 00:15:42.890442||error||collecting ads||Error||2||0
+2015-12-02 00:15:43.102146||measurement||price||2015-12-02 00:15:25.235920@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:15:43.245023||measurement||loadtime||0:00:29.100746||3||1
+2015-12-02 00:15:45.131171||measurement||loadtime||0:00:29.345337||1||1
+2015-12-02 00:15:46.595390||measurement||price||2015-12-02 00:15:28.933695@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:15:50.215158||measurement||loadtime||0:00:26.656988||0||0
+2015-12-02 00:15:53.591047||measurement||price||2015-12-02 00:15:34.828981@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||1
+2015-12-02 00:15:53.697160||measurement||loadtime||0:00:27.284817||4||0
+2015-12-02 00:15:57.031255||measurement||price||2015-12-02 00:15:50.674866@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-02 00:15:59.231453||measurement||price||2015-12-02 00:15:53.000628@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:16:00.811181||measurement||loadtime||0:00:28.490894||5||1
+2015-12-02 00:16:02.414245||measurement||price||2015-12-02 00:15:56.781395@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 00:16:05.699905||error||collecting ads||Error||2||0
+2015-12-02 00:16:06.400254||measurement||price||2015-12-02 00:16:00.963212@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||0
+2015-12-02 00:16:09.900645||measurement||price||2015-12-02 00:15:50.674866@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-02 00:16:12.266774||measurement||price||2015-12-02 00:15:53.000628@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:16:14.514611||measurement||price||2015-12-02 00:16:08.360626@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:16:14.737148||measurement||price||2015-12-02 00:15:56.781395@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 00:16:17.119391||measurement||loadtime||0:00:28.872268||3||1
+2015-12-02 00:16:18.367925||measurement||price||2015-12-02 00:16:12.946325@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:16:18.765948||measurement||price||2015-12-02 00:16:00.963212@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||0
+2015-12-02 00:16:19.534116||measurement||loadtime||0:00:29.398233||1||1
+2015-12-02 00:16:21.856814||measurement||loadtime||0:00:26.637297||0||0
+2015-12-02 00:16:25.887153||measurement||loadtime||0:00:27.185155||4||0
+2015-12-02 00:16:27.346532||measurement||price||2015-12-02 00:16:08.360626@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:16:30.698700||measurement||price||2015-12-02 00:16:12.946325@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:16:30.766388||measurement||price||2015-12-02 00:16:24.319728@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-02 00:16:33.338946||measurement||price||2015-12-02 00:16:27.183065@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:16:34.187689||measurement||price||2015-12-02 00:16:28.574246@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:16:34.553708||measurement||loadtime||0:00:28.738582||5||1
+2015-12-02 00:16:37.812171||measurement||loadtime||0:00:27.107049||2||0
+2015-12-02 00:16:38.524391||measurement||price||2015-12-02 00:16:33.143514@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:16:43.553514||measurement||price||2015-12-02 00:16:24.319728@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-02 00:16:46.183276||measurement||price||2015-12-02 00:16:27.183065@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:16:46.510965||measurement||price||2015-12-02 00:16:28.574246@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:16:50.478182||measurement||price||2015-12-02 00:16:45.102188@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 00:16:50.789767||measurement||loadtime||0:00:28.668340||3||1
+2015-12-02 00:16:50.859289||measurement||price||2015-12-02 00:16:33.143514@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:16:53.403159||measurement||loadtime||0:00:28.864028||1||1
+2015-12-02 00:16:53.628378||measurement||loadtime||0:00:26.770620||0||0
+2015-12-02 00:16:57.967164||measurement||loadtime||0:00:27.074924||4||0
+2015-12-02 00:16:58.203845||error||collecting ads||Error||5||1
+2015-12-02 00:17:02.815619||measurement||price||2015-12-02 00:16:45.102188@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 00:17:04.662888||measurement||price||2015-12-02 00:16:57.990237@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||1
+2015-12-02 00:17:06.625526||measurement||price||2015-12-02 00:17:00.925942@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 00:17:07.202240||measurement||price||2015-12-02 00:17:01.024637@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:17:09.935264||measurement||loadtime||0:00:27.120120||2||0
+2015-12-02 00:17:11.962415||measurement||price||2015-12-02 00:17:05.797510@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 00:17:17.572827||measurement||price||2015-12-02 00:16:57.990237@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||1
+2015-12-02 00:17:18.928822||measurement||price||2015-12-02 00:17:00.925942@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 00:17:19.998567||measurement||price||2015-12-02 00:17:01.024637@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:17:20.571102||error||collecting ads||Error||4||0
+2015-12-02 00:17:22.660570||measurement||price||2015-12-02 00:17:17.278776@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 00:17:24.795141||measurement||loadtime||0:00:29.000192||3||1
+2015-12-02 00:17:24.831214||measurement||price||2015-12-02 00:17:05.797510@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 00:17:26.015171||measurement||loadtime||0:00:27.381584||0||0
+2015-12-02 00:17:27.231910||measurement||loadtime||0:00:28.824781||1||1
+2015-12-02 00:17:32.055125||measurement||loadtime||0:00:28.849760||5||1
+2015-12-02 00:17:33.166626||measurement||price||2015-12-02 00:17:27.775409@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:17:34.982477||measurement||price||2015-12-02 00:17:17.278776@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 00:17:38.727621||measurement||price||2015-12-02 00:17:33.226354@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 00:17:38.790411||measurement||price||2015-12-02 00:17:32.029304@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||3||1
+2015-12-02 00:17:40.936894||measurement||price||2015-12-02 00:17:34.821939@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:17:42.100808||measurement||loadtime||0:00:27.160344||2||0
+2015-12-02 00:17:45.512656||measurement||price||2015-12-02 00:17:27.775409@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:17:45.801600||measurement||price||2015-12-02 00:17:39.639588@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:17:51.001870||measurement||price||2015-12-02 00:17:33.226354@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 00:17:51.797823||measurement||price||2015-12-02 00:17:32.029304@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||3||1
+2015-12-02 00:17:52.619143||measurement||loadtime||0:00:27.042820||4||0
+2015-12-02 00:17:53.809133||measurement||price||2015-12-02 00:17:34.821939@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:17:54.737094||measurement||price||2015-12-02 00:17:49.354190@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||0
+2015-12-02 00:17:58.083244||measurement||loadtime||0:00:27.064015||0||0
+2015-12-02 00:17:58.577231||measurement||price||2015-12-02 00:17:39.639588@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:17:59.007155||measurement||loadtime||0:00:29.208035||3||1
+2015-12-02 00:18:01.012026||measurement||loadtime||0:00:28.779733||1||1
+2015-12-02 00:18:05.795148||measurement||loadtime||0:00:28.739465||5||1
+2015-12-02 00:18:07.080790||measurement||price||2015-12-02 00:17:49.354190@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||0
+2015-12-02 00:18:14.190037||measurement||loadtime||0:00:27.084198||2||0
+2015-12-02 00:18:27.578973||measurement||price||2015-12-02 00:18:22.271768@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:18:39.843282||measurement||price||2015-12-02 00:18:22.271768@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:18:43.649881||measurement||price||2015-12-02 00:18:38.342848@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||0
+2015-12-02 00:18:46.929985||measurement||loadtime||0:00:27.734718||2||0
+2015-12-02 00:18:53.367248||measurement||price||2015-12-02 00:18:47.300266@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:18:54.915229||error||collecting ads||Error||3||1
+2015-12-02 00:18:55.981249||measurement||price||2015-12-02 00:18:38.342848@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||0
+2015-12-02 00:19:00.007989||error||collecting ads||Error||0||0
+2015-12-02 00:19:00.449395||measurement||price||2015-12-02 00:18:55.076673@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:19:03.081476||measurement||loadtime||0:01:05.458353||4||0
+2015-12-02 00:19:03.453680||error||collecting ads||Error||1||1
+2015-12-02 00:19:06.355909||measurement||price||2015-12-02 00:18:47.300266@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:19:12.783487||measurement||price||2015-12-02 00:18:55.076673@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:19:12.800879||measurement||price||2015-12-02 00:19:07.252955@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:19:13.595162||measurement||loadtime||0:01:02.794807||5||1
+2015-12-02 00:19:16.120937||measurement||price||2015-12-02 00:19:10.767180@|@|$274.95@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||4||0
+2015-12-02 00:19:19.323254||error||collecting ads||Error||3||1
+2015-12-02 00:19:19.887171||measurement||loadtime||0:00:27.951993||2||0
+2015-12-02 00:19:25.124220||measurement||price||2015-12-02 00:19:07.252955@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:19:27.548144||error||collecting ads||Error||1||1
+2015-12-02 00:19:28.395218||measurement||price||2015-12-02 00:19:10.767180@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||4||0
+2015-12-02 00:19:32.224385||measurement||loadtime||0:00:27.213244||0||0
+2015-12-02 00:19:33.137967||measurement||price||2015-12-02 00:19:27.770947@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:19:33.909744||measurement||price||2015-12-02 00:19:27.109824@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-02 00:19:35.475150||measurement||loadtime||0:00:27.392014||4||0
+2015-12-02 00:19:38.145837||error||collecting ads||Error||5||1
+2015-12-02 00:19:41.924269||measurement||price||2015-12-02 00:19:35.454127@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:19:45.262593||measurement||price||2015-12-02 00:19:39.981174@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:19:45.434558||measurement||price||2015-12-02 00:19:27.770947@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:19:46.920788||measurement||price||2015-12-02 00:19:27.109824@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-02 00:19:52.373629||measurement||price||2015-12-02 00:19:46.254588@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:19:52.519164||measurement||loadtime||0:00:27.630861||2||0
+2015-12-02 00:19:54.195309||measurement||loadtime||0:00:29.867652||3||1
+2015-12-02 00:19:54.975427||measurement||price||2015-12-02 00:19:35.454127@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:19:57.552641||measurement||price||2015-12-02 00:19:39.981174@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:19:58.615671||error||collecting ads||Error||4||0
+2015-12-02 00:20:02.231620||measurement||loadtime||0:00:29.680492||1||1
+2015-12-02 00:20:04.639148||measurement||loadtime||0:00:27.412011||0||0
+2015-12-02 00:20:05.367951||measurement||price||2015-12-02 00:19:46.254588@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:20:05.747824||measurement||price||2015-12-02 00:20:00.398425@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:20:08.667153||measurement||price||2015-12-02 00:20:02.021154@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-02 00:20:11.880031||measurement||price||2015-12-02 00:20:06.501120@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:20:12.651171||measurement||loadtime||0:00:29.504029||5||1
+2015-12-02 00:20:16.621759||measurement||price||2015-12-02 00:20:10.389471@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:20:18.031861||measurement||price||2015-12-02 00:20:00.398425@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:20:21.620556||measurement||price||2015-12-02 00:20:02.021154@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-02 00:20:24.223623||measurement||price||2015-12-02 00:20:06.501120@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:20:25.115151||measurement||loadtime||0:00:27.592011||2||0
+2015-12-02 00:20:27.389053||measurement||price||2015-12-02 00:20:21.096361@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:20:27.597695||error||collecting ads||Error||0||0
+2015-12-02 00:20:28.887174||measurement||loadtime||0:00:29.686634||3||1
+2015-12-02 00:20:29.636099||measurement||price||2015-12-02 00:20:10.389471@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:20:31.313020||measurement||loadtime||0:00:27.692110||4||0
+2015-12-02 00:20:36.895135||measurement||loadtime||0:00:29.660006||1||1
+2015-12-02 00:20:40.349984||measurement||price||2015-12-02 00:20:21.096361@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:20:43.479497||measurement||price||2015-12-02 00:20:36.854271@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-02 00:20:47.614631||measurement||loadtime||0:00:29.958242||5||1
+2015-12-02 00:20:48.225760||error||collecting ads||Error||2||0
+2015-12-02 00:20:50.413955||error||collecting ads||Error||0||0
+2015-12-02 00:20:51.260208||measurement||price||2015-12-02 00:20:44.943629@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:20:54.514802||error||collecting ads||Error||4||0
+2015-12-02 00:20:56.492581||measurement||price||2015-12-02 00:20:36.854271@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-02 00:21:01.444826||measurement||price||2015-12-02 00:20:56.001385@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:21:03.254638||measurement||price||2015-12-02 00:20:57.792407@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:21:03.792969||measurement||loadtime||0:00:29.901667||3||1
+2015-12-02 00:21:04.414755||measurement||price||2015-12-02 00:20:44.943629@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:21:11.671150||measurement||loadtime||0:00:29.770841||1||1
+2015-12-02 00:21:12.137332||error||collecting ads||Error||5||1
+2015-12-02 00:21:13.756509||measurement||price||2015-12-02 00:20:56.001385@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:21:15.557804||measurement||price||2015-12-02 00:20:57.792407@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:21:17.793654||error||collecting ads||Error||4||0
+2015-12-02 00:21:18.394476||measurement||price||2015-12-02 00:21:12.033310@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||1
+2015-12-02 00:21:20.852642||measurement||loadtime||0:00:27.625508||2||0
+2015-12-02 00:21:22.648573||measurement||loadtime||0:00:27.229442||0||0
+2015-12-02 00:21:26.154972||measurement||price||2015-12-02 00:21:19.764754@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:21:26.289944||measurement||price||2015-12-02 00:21:20.278962@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:21:30.933190||measurement||price||2015-12-02 00:21:25.569457@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-02 00:21:31.603908||measurement||price||2015-12-02 00:21:12.033310@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||1
+2015-12-02 00:21:35.418911||measurement||price||2015-12-02 00:21:29.855341@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||0||0
+2015-12-02 00:21:38.827384||measurement||loadtime||0:00:30.032231||3||1
+2015-12-02 00:21:39.239944||measurement||price||2015-12-02 00:21:19.764754@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:21:39.385450||measurement||price||2015-12-02 00:21:20.278962@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:21:43.224281||measurement||price||2015-12-02 00:21:25.569457@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-02 00:21:44.600637||error||collecting ads||Error||2||0
+2015-12-02 00:21:46.654678||measurement||loadtime||0:00:29.982205||1||1
+2015-12-02 00:21:46.675409||measurement||loadtime||0:00:29.536481||5||1
+2015-12-02 00:21:47.697886||measurement||price||2015-12-02 00:21:29.855341@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||0||0
+2015-12-02 00:21:50.319170||measurement||loadtime||0:00:27.524012||4||0
+2015-12-02 00:21:53.174479||measurement||price||2015-12-02 00:21:46.552680@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-02 00:21:54.783165||measurement||loadtime||0:00:27.130012||0||0
+2015-12-02 00:21:57.619364||measurement||price||2015-12-02 00:21:52.186255@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:22:01.512321||measurement||price||2015-12-02 00:21:55.289328@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 00:22:01.566741||measurement||price||2015-12-02 00:21:55.184133@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 00:22:06.498429||measurement||price||2015-12-02 00:21:46.552680@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-02 00:22:07.504439||measurement||price||2015-12-02 00:22:02.086812@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 00:22:09.942351||measurement||price||2015-12-02 00:21:52.186255@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:22:13.518138||error||collecting ads||Error||4||0
+2015-12-02 00:22:13.805690||measurement||loadtime||0:00:29.973102||3||1
+2015-12-02 00:22:14.566322||measurement||price||2015-12-02 00:21:55.289328@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 00:22:14.674122||measurement||price||2015-12-02 00:21:55.184133@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 00:22:17.043693||measurement||loadtime||0:00:27.439033||2||0
+2015-12-02 00:22:19.799495||measurement||price||2015-12-02 00:22:02.086812@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 00:22:21.818051||measurement||loadtime||0:00:30.138898||5||1
+2015-12-02 00:22:21.947164||measurement||loadtime||0:00:30.287226||1||1
+2015-12-02 00:22:26.734850||measurement||price||2015-12-02 00:22:21.371175@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-02 00:22:26.885314||measurement||loadtime||0:00:27.098166||0||0
+2015-12-02 00:22:28.179468||measurement||price||2015-12-02 00:22:21.591411@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-02 00:22:30.254587||measurement||price||2015-12-02 00:22:24.926150@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:22:35.900363||measurement||price||2015-12-02 00:22:29.843362@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:22:36.143121||measurement||price||2015-12-02 00:22:29.725445@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||1
+2015-12-02 00:22:39.054447||measurement||price||2015-12-02 00:22:21.371175@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-02 00:22:39.589683||measurement||price||2015-12-02 00:22:33.904398@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:22:41.246992||measurement||price||2015-12-02 00:22:21.591411@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-02 00:22:42.575753||measurement||price||2015-12-02 00:22:24.926150@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:22:46.147748||measurement||loadtime||0:00:27.624391||4||0
+2015-12-02 00:22:48.506423||measurement||loadtime||0:00:29.695568||3||1
+2015-12-02 00:22:48.817747||measurement||price||2015-12-02 00:22:29.843362@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:22:49.453277||measurement||price||2015-12-02 00:22:29.725445@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||1
+2015-12-02 00:22:49.671217||measurement||loadtime||0:00:27.623622||2||0
+2015-12-02 00:22:51.863493||measurement||price||2015-12-02 00:22:33.904398@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:22:56.055154||measurement||loadtime||0:00:29.102800||1||1
+2015-12-02 00:22:56.745800||measurement||loadtime||0:00:29.922641||5||1
+2015-12-02 00:22:58.955557||measurement||loadtime||0:00:27.068412||0||0
+2015-12-02 00:22:59.294728||measurement||price||2015-12-02 00:22:54.039787@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||0
+2015-12-02 00:23:02.861573||measurement||price||2015-12-02 00:22:57.525498@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:23:03.209646||measurement||price||2015-12-02 00:22:56.430851@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||1
+2015-12-02 00:23:11.165987||measurement||price||2015-12-02 00:23:04.911811@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 00:23:11.598397||measurement||price||2015-12-02 00:22:54.039787@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||0
+2015-12-02 00:23:11.827813||measurement||price||2015-12-02 00:23:06.357623@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 00:23:15.163267||measurement||price||2015-12-02 00:22:57.525498@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:23:16.330195||measurement||price||2015-12-02 00:22:56.430851@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||1
+2015-12-02 00:23:18.679212||measurement||loadtime||0:00:27.528082||4||0
+2015-12-02 00:23:20.700285||error||collecting ads||Error||1||1
+2015-12-02 00:23:22.247946||measurement||loadtime||0:00:27.572799||2||0
+2015-12-02 00:23:22.248094||event||progress-marker||measurement-end||2||0
+2015-12-02 00:23:23.568053||measurement||loadtime||0:00:30.056918||3||1
+2015-12-02 00:23:24.107912||measurement||price||2015-12-02 00:23:06.357623@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 00:23:24.175700||measurement||price||2015-12-02 00:23:04.911811@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 00:23:31.187855||measurement||loadtime||0:00:27.229481||0||0
+2015-12-02 00:23:31.269160||measurement||price||2015-12-02 00:23:25.898561@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||0
+2015-12-02 00:23:31.444703||measurement||loadtime||0:00:29.693736||5||1
+2015-12-02 00:23:34.176168||measurement||price||2015-12-02 00:23:28.200565@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:23:37.283670||measurement||price||2015-12-02 00:23:30.781872@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-02 00:23:43.554614||measurement||price||2015-12-02 00:23:25.898561@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||0
+2015-12-02 00:23:45.870438||measurement||price||2015-12-02 00:23:39.599365@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:23:46.965264||measurement||price||2015-12-02 00:23:28.200565@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:23:50.127663||measurement||price||2015-12-02 00:23:30.781872@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-02 00:23:50.635155||measurement||loadtime||0:00:26.952161||4||0
+2015-12-02 00:23:50.635245||event||progress-marker||measurement-end||4||0
+2015-12-02 00:23:53.992797||error||collecting ads||Error||0||0
+2015-12-02 00:23:53.992903||event||progress-marker||measurement-end||0||0
+2015-12-02 00:23:54.183147||measurement||loadtime||0:00:28.480009||1||1
+2015-12-02 00:23:57.329075||measurement||loadtime||0:00:28.757843||3||1
+2015-12-02 00:23:58.864414||measurement||price||2015-12-02 00:23:39.599365@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:24:06.103167||measurement||loadtime||0:00:29.656034||5||1
+2015-12-02 00:24:07.849644||measurement||price||2015-12-02 00:24:01.646554@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||1
+2015-12-02 00:24:10.919758||measurement||price||2015-12-02 00:24:04.580776@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-02 00:24:19.555321||measurement||price||2015-12-02 00:24:13.579923@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-02 00:24:20.798590||measurement||price||2015-12-02 00:24:01.646554@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||1
+2015-12-02 00:24:23.723753||measurement||price||2015-12-02 00:24:04.580776@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-02 00:24:27.999144||measurement||loadtime||0:00:28.810813||1||1
+2015-12-02 00:24:30.939379||measurement||loadtime||0:00:28.608241||3||1
+2015-12-02 00:24:32.564824||measurement||price||2015-12-02 00:24:13.579923@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-02 00:24:39.775158||measurement||loadtime||0:00:28.668031||5||1
+2015-12-02 00:24:39.775266||event||progress-marker||measurement-end||5||1
+2015-12-02 00:24:41.536405||measurement||price||2015-12-02 00:24:35.430360@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:24:54.413087||measurement||price||2015-12-02 00:24:35.430360@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:24:54.493600||error||collecting ads||Error||3||1
+2015-12-02 00:25:01.621911||measurement||loadtime||0:00:28.618762||1||1
+2015-12-02 00:25:08.193618||measurement||price||2015-12-02 00:25:01.627501@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||1
+2015-12-02 00:25:15.491627||measurement||price||2015-12-02 00:25:09.139333@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||1
+2015-12-02 00:25:20.978212||measurement||price||2015-12-02 00:25:01.627501@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||1
+2015-12-02 00:25:28.192157||measurement||loadtime||0:00:28.696594||3||1
+2015-12-02 00:25:28.312455||measurement||price||2015-12-02 00:25:09.139333@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||1
+2015-12-02 00:25:35.516254||measurement||loadtime||0:00:28.889129||1||1
+2015-12-02 00:25:41.776823||measurement||price||2015-12-02 00:25:35.397082@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||1
+2015-12-02 00:25:49.697439||measurement||price||2015-12-02 00:25:43.711883@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:25:54.538948||measurement||price||2015-12-02 00:25:35.397082@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||1
+2015-12-02 00:26:01.748122||measurement||loadtime||0:00:28.550738||3||1
+2015-12-02 00:26:02.604502||measurement||price||2015-12-02 00:25:43.711883@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:26:09.823647||measurement||loadtime||0:00:29.302193||1||1
+2015-12-02 00:26:15.308677||measurement||price||2015-12-02 00:26:08.993630@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-02 00:26:23.578583||measurement||price||2015-12-02 00:26:17.434545@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:26:28.079975||measurement||price||2015-12-02 00:26:08.993630@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-02 00:26:35.306166||measurement||loadtime||0:00:28.552824||3||1
+2015-12-02 00:26:35.306333||event||progress-marker||measurement-end||3||1
+2015-12-02 00:26:36.399832||measurement||price||2015-12-02 00:26:17.434545@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:26:43.602277||measurement||loadtime||0:00:28.773440||1||1
+2015-12-02 00:26:43.602389||event||progress-marker||measurement-end||1||1
+2015-12-02 00:26:44.168002||meta||block_id end||14
+2015-12-02 00:26:44.168296||meta||block_id start||15
+2015-12-02 00:26:44.168324||meta||assignment||2@|5@|0@|4@|3@|1
+2015-12-02 00:26:45.784861||event||progress-marker||training-start||2||0
+2015-12-02 00:26:45.800952||event||progress-marker||training-start||0||0
+2015-12-02 00:26:45.839603||event||progress-marker||training-start||5||0
+2015-12-02 00:26:52.527118||treatment||visit website||http://irs.gov||0||0
+2015-12-02 00:26:52.547122||treatment||visit website||http://irs.gov||5||0
+2015-12-02 00:26:52.688034||treatment||visit website||http://irs.gov||2||0
+2015-12-02 00:26:54.025186||event||progress-marker||training-start||1||1
+2015-12-02 00:27:00.568969||treatment||visit website||http://deloitte.com||5||0
+2015-12-02 00:27:00.571839||treatment||visit website||http://deloitte.com||0||0
+2015-12-02 00:27:00.747131||treatment||visit website||http://deloitte.com||2||0
+2015-12-02 00:27:00.980384||treatment||visit website||http://irs.gov||1||1
+2015-12-02 00:27:08.474939||treatment||visit website||http://deloitte.com||1||1
+2015-12-02 00:27:11.159109||treatment||visit website||http://pwc.com||5||0
+2015-12-02 00:27:11.183117||treatment||visit website||http://pwc.com||2||0
+2015-12-02 00:27:11.195109||treatment||visit website||http://pwc.com||0||0
+2015-12-02 00:27:17.126338||treatment||visit website||http://pwc.com||1||1
+2015-12-02 00:27:17.155098||treatment||visit website||http://ey.com||5||0
+2015-12-02 00:27:17.159127||treatment||visit website||http://ey.com||2||0
+2015-12-02 00:27:17.795132||treatment||visit website||http://ey.com||0||0
+2015-12-02 00:27:23.067014||treatment||visit website||http://ey.com||1||1
+2015-12-02 00:27:23.898690||treatment||visit website||http://kpmg.com||5||0
+2015-12-02 00:27:23.898878||event||progress-marker||training-end||5||0
+2015-12-02 00:27:23.972080||treatment||visit website||http://kpmg.com||2||0
+2015-12-02 00:27:23.972207||event||progress-marker||training-end||2||0
+2015-12-02 00:27:24.450385||treatment||visit website||http://kpmg.com||0||0
+2015-12-02 00:27:24.450482||event||progress-marker||training-end||0||0
+2015-12-02 00:27:30.686986||treatment||visit website||http://kpmg.com||1||1
+2015-12-02 00:27:30.687108||event||progress-marker||training-end||1||1
+2015-12-02 00:27:33.960071||event||progress-marker||measurement-start||5||0
+2015-12-02 00:27:34.046475||event||progress-marker||measurement-start||2||0
+2015-12-02 00:27:34.518659||event||progress-marker||measurement-start||0||0
+2015-12-02 00:27:35.728596||event||progress-marker||measurement-start||1||1
+2015-12-02 00:27:47.556845||measurement||price||2015-12-02 00:27:42.147075@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:27:48.362716||measurement||price||2015-12-02 00:27:42.928634@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 00:27:50.771576||measurement||price||2015-12-02 00:27:44.486293@|Mitchell@|$73.90@|Mitchell 300 Pro Spinning Rod and Reel Combo, 7-Feet/Medium||1||1
+2015-12-02 00:27:57.648662||error||collecting ads||Error||5||0
+2015-12-02 00:27:59.929116||measurement||price||2015-12-02 00:27:42.147075@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:28:00.729684||measurement||price||2015-12-02 00:27:42.928634@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 00:28:03.581176||measurement||price||2015-12-02 00:27:44.486293@|Penn@|$89.65@|Penn Battle II Spinning Reel, 4000||1||1
+2015-12-02 00:28:07.019150||measurement||loadtime||0:00:27.968006||2||0
+2015-12-02 00:28:07.823689||measurement||loadtime||0:00:28.299749||0||0
+2015-12-02 00:28:10.798102||measurement||loadtime||0:00:30.066964||1||1
+2015-12-02 00:28:19.636374||measurement||price||2015-12-02 00:28:13.911594@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-02 00:28:20.070690||error||collecting ads||Error||5||0
+2015-12-02 00:28:20.497388||event||progress-marker||training-start||4||1
+2015-12-02 00:28:24.483930||measurement||price||2015-12-02 00:28:18.322849@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 00:28:26.911118||treatment||visit website||http://irs.gov||4||1
+2015-12-02 00:28:30.542813||error||collecting ads||Error||0||0
+2015-12-02 00:28:31.931356||measurement||price||2015-12-02 00:28:13.911594@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-02 00:28:32.245647||measurement||price||2015-12-02 00:28:26.649671@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||0
+2015-12-02 00:28:33.526277||treatment||visit website||http://deloitte.com||4||1
+2015-12-02 00:28:37.289813||measurement||price||2015-12-02 00:28:18.322849@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 00:28:39.006358||measurement||loadtime||0:00:26.983219||2||0
+2015-12-02 00:28:43.202559||measurement||price||2015-12-02 00:28:37.813021@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 00:28:44.514127||measurement||loadtime||0:00:28.662962||1||1
+2015-12-02 00:28:44.573978||measurement||price||2015-12-02 00:28:26.649671@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||0
+2015-12-02 00:28:51.428534||measurement||price||2015-12-02 00:28:46.027059@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||0
+2015-12-02 00:28:51.679168||measurement||loadtime||0:00:26.603261||5||0
+2015-12-02 00:28:54.651541||event||progress-marker||training-start||3||1
+2015-12-02 00:28:55.548629||measurement||price||2015-12-02 00:28:37.813021@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 00:29:01.286378||treatment||visit website||http://irs.gov||3||1
+2015-12-02 00:29:02.666788||measurement||loadtime||0:00:27.118781||0||0
+2015-12-02 00:29:03.768547||measurement||price||2015-12-02 00:28:46.027059@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||0
+2015-12-02 00:29:03.909808||measurement||price||2015-12-02 00:28:58.307192@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:29:08.400183||error||collecting ads||Error||1||1
+2015-12-02 00:29:09.768206||treatment||visit website||http://deloitte.com||3||1
+2015-12-02 00:29:10.874365||measurement||loadtime||0:00:26.862785||2||0
+2015-12-02 00:29:13.545613||error||website timeout||http://pwc.com||4||1
+2015-12-02 00:29:15.602646||measurement||price||2015-12-02 00:29:10.246833@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||0||0
+2015-12-02 00:29:16.211810||measurement||price||2015-12-02 00:28:58.307192@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:29:18.495091||treatment||visit website||http://pwc.com||3||1
+2015-12-02 00:29:18.583116||treatment||visit website||http://ey.com||4||1
+2015-12-02 00:29:22.187551||measurement||price||2015-12-02 00:29:15.710538@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:29:23.323156||measurement||loadtime||0:00:26.640002||5||0
+2015-12-02 00:29:23.776120||measurement||price||2015-12-02 00:29:18.386755@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-02 00:29:24.370377||treatment||visit website||http://ey.com||3||1
+2015-12-02 00:29:27.350716||treatment||visit website||http://kpmg.com||4||1
+2015-12-02 00:29:27.350834||event||progress-marker||training-end||4||1
+2015-12-02 00:29:27.917088||measurement||price||2015-12-02 00:29:10.246833@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-02 00:29:32.291124||treatment||visit website||http://kpmg.com||3||1
+2015-12-02 00:29:32.291229||event||progress-marker||training-end||3||1
+2015-12-02 00:29:32.389898||event||progress-marker||measurement-start||4||1
+2015-12-02 00:29:35.023130||measurement||loadtime||0:00:27.351999||0||0
+2015-12-02 00:29:35.045368||measurement||price||2015-12-02 00:29:15.710538@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:29:35.571817||measurement||price||2015-12-02 00:29:29.902243@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:29:36.108508||measurement||price||2015-12-02 00:29:18.386755@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-02 00:29:37.328741||event||progress-marker||measurement-start||3||1
+2015-12-02 00:29:42.255146||measurement||loadtime||0:00:28.849783||1||1
+2015-12-02 00:29:43.212292||measurement||loadtime||0:00:27.333152||2||0
+2015-12-02 00:29:46.937891||measurement||price||2015-12-02 00:29:40.347279@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 00:29:47.721680||measurement||price||2015-12-02 00:29:42.278473@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 00:29:47.895440||measurement||price||2015-12-02 00:29:29.902243@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:29:51.443672||measurement||price||2015-12-02 00:29:45.387902@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-02 00:29:54.991177||measurement||loadtime||0:00:26.662813||5||0
+2015-12-02 00:29:55.738390||measurement||price||2015-12-02 00:29:50.316161@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:29:56.093241||measurement||price||2015-12-02 00:29:49.538993@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:29:59.778038||measurement||price||2015-12-02 00:29:40.347279@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 00:30:00.069663||measurement||price||2015-12-02 00:29:42.278473@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 00:30:04.278794||measurement||price||2015-12-02 00:29:45.387902@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-02 00:30:06.969253||measurement||loadtime||0:00:29.574194||4||1
+2015-12-02 00:30:07.189702||measurement||loadtime||0:00:27.161380||0||0
+2015-12-02 00:30:08.067677||measurement||price||2015-12-02 00:29:50.316161@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:30:08.888115||measurement||price||2015-12-02 00:29:49.538993@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:30:11.481735||measurement||loadtime||0:00:29.150596||3||1
+2015-12-02 00:30:15.175173||measurement||loadtime||0:00:26.957664||2||0
+2015-12-02 00:30:16.099139||measurement||loadtime||0:00:28.840009||1||1
+2015-12-02 00:30:17.658527||error||collecting ads||Error||5||0
+2015-12-02 00:30:19.969739||measurement||price||2015-12-02 00:30:14.518021@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||0||0
+2015-12-02 00:30:20.980298||measurement||price||2015-12-02 00:30:14.463333@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-02 00:30:25.880645||measurement||price||2015-12-02 00:30:19.500793@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||1
+2015-12-02 00:30:27.647333||measurement||price||2015-12-02 00:30:22.193412@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 00:30:30.034507||measurement||price||2015-12-02 00:30:24.239272@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:30:30.114428||measurement||price||2015-12-02 00:30:23.406210@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:30:32.301187||measurement||price||2015-12-02 00:30:14.518021@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||0||0
+2015-12-02 00:30:33.800320||measurement||price||2015-12-02 00:30:14.463333@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-02 00:30:38.832961||measurement||price||2015-12-02 00:30:19.500793@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||1
+2015-12-02 00:30:39.411141||measurement||loadtime||0:00:27.216187||0||0
+2015-12-02 00:30:39.973585||measurement||price||2015-12-02 00:30:22.193412@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 00:30:41.018916||measurement||loadtime||0:00:29.044474||4||1
+2015-12-02 00:30:42.318421||measurement||price||2015-12-02 00:30:24.239272@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:30:42.926578||measurement||price||2015-12-02 00:30:23.406210@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:30:46.031150||measurement||loadtime||0:00:29.544242||3||1
+2015-12-02 00:30:47.079126||measurement||loadtime||0:00:26.898743||2||0
+2015-12-02 00:30:49.468391||measurement||loadtime||0:00:26.805251||5||0
+2015-12-02 00:30:50.143165||measurement||loadtime||0:00:29.040024||1||1
+2015-12-02 00:30:59.577199||measurement||price||2015-12-02 00:30:54.142296@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||0
+2015-12-02 00:30:59.659451||measurement||price||2015-12-02 00:30:53.503363@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||1
+2015-12-02 00:31:01.906285||measurement||price||2015-12-02 00:30:56.255684@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:31:01.993476||error||collecting ads||Error||0||0
+2015-12-02 00:31:04.139293||measurement||price||2015-12-02 00:30:57.439844@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:31:04.940702||error||collecting ads||Error||4||1
+2015-12-02 00:31:11.879584||measurement||price||2015-12-02 00:30:54.142296@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||0
+2015-12-02 00:31:12.719107||measurement||price||2015-12-02 00:30:53.503363@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||1
+2015-12-02 00:31:14.216339||measurement||price||2015-12-02 00:30:56.255684@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:31:14.889952||measurement||price||2015-12-02 00:31:09.467499@|Extech@|$17.75@|Extech MN35 Digital Mini MultiMeter||0||0
+2015-12-02 00:31:17.144245||measurement||price||2015-12-02 00:30:57.439844@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:31:18.964052||measurement||loadtime||0:00:26.884212||2||0
+2015-12-02 00:31:19.935173||measurement||loadtime||0:00:28.898826||3||1
+2015-12-02 00:31:21.327141||measurement||loadtime||0:00:26.856011||5||0
+2015-12-02 00:31:24.343819||measurement||loadtime||0:00:29.196694||1||1
+2015-12-02 00:31:27.209221||measurement||price||2015-12-02 00:31:09.467499@|Extech@|$39.99@|Extech CB10 Circuit Breaker Finder locates fuses/breakers, t...||0||0
+2015-12-02 00:31:28.864253||error||collecting ads||Error||4||1
+2015-12-02 00:31:31.885983||measurement||price||2015-12-02 00:31:26.460710@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:31:33.642657||measurement||price||2015-12-02 00:31:28.013031@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-02 00:31:34.312459||measurement||loadtime||0:00:27.317319||0||0
+2015-12-02 00:31:37.915018||measurement||price||2015-12-02 00:31:31.570692@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 00:31:42.891269||measurement||price||2015-12-02 00:31:36.202074@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 00:31:44.006107||error||collecting ads||Error||3||1
+2015-12-02 00:31:44.213516||measurement||price||2015-12-02 00:31:26.460710@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:31:45.990999||measurement||price||2015-12-02 00:31:28.013031@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-02 00:31:46.847875||measurement||price||2015-12-02 00:31:41.439010@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:31:50.875531||measurement||price||2015-12-02 00:31:31.570692@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 00:31:51.319169||measurement||loadtime||0:00:27.352012||2||0
+2015-12-02 00:31:53.102787||measurement||loadtime||0:00:26.770887||5||0
+2015-12-02 00:31:55.920413||measurement||price||2015-12-02 00:31:36.202074@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 00:31:57.468734||measurement||price||2015-12-02 00:31:51.423536@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||1
+2015-12-02 00:31:58.111166||measurement||loadtime||0:00:28.763086||1||1
+2015-12-02 00:31:59.144348||measurement||price||2015-12-02 00:31:41.439010@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:32:03.108871||measurement||loadtime||0:00:29.241728||4||1
+2015-12-02 00:32:04.291424||measurement||price||2015-12-02 00:31:58.861606@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:32:06.231159||measurement||loadtime||0:00:26.916027||0||0
+2015-12-02 00:32:10.386914||measurement||price||2015-12-02 00:31:51.423536@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||1
+2015-12-02 00:32:11.877062||measurement||price||2015-12-02 00:32:05.398715@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:32:15.796932||error||collecting ads||Error||5||0
+2015-12-02 00:32:16.621185||measurement||price||2015-12-02 00:31:58.861606@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:32:17.596212||measurement||loadtime||0:00:28.584897||3||1
+2015-12-02 00:32:23.707114||measurement||loadtime||0:00:27.382744||2||0
+2015-12-02 00:32:24.804074||measurement||price||2015-12-02 00:32:05.398715@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:32:27.227055||error||collecting ads||Error||4||1
+2015-12-02 00:32:28.441569||measurement||price||2015-12-02 00:32:22.919552@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:32:28.764359||error||collecting ads||Error||0||0
+2015-12-02 00:32:31.290816||measurement||price||2015-12-02 00:32:25.211960@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-02 00:32:32.023150||measurement||loadtime||0:00:28.910396||1||1
+2015-12-02 00:32:36.568252||measurement||price||2015-12-02 00:32:31.274620@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:32:40.733146||measurement||price||2015-12-02 00:32:22.919552@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:32:41.362357||measurement||price||2015-12-02 00:32:35.959475@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:32:41.450671||measurement||price||2015-12-02 00:32:34.424404@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-02 00:32:44.194873||measurement||price||2015-12-02 00:32:25.211960@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-02 00:32:45.744337||measurement||price||2015-12-02 00:32:39.363549@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:32:47.820240||measurement||loadtime||0:00:27.021078||5||0
+2015-12-02 00:32:48.878976||measurement||price||2015-12-02 00:32:31.274620@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:32:51.423168||measurement||loadtime||0:00:28.824023||3||1
+2015-12-02 00:32:53.696107||measurement||price||2015-12-02 00:32:35.959475@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:32:54.387419||measurement||price||2015-12-02 00:32:34.424404@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-02 00:32:55.967209||measurement||loadtime||0:00:27.254859||2||0
+2015-12-02 00:32:58.559158||measurement||price||2015-12-02 00:32:39.363549@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:33:00.674477||measurement||price||2015-12-02 00:32:55.291272@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||0
+2015-12-02 00:33:00.807175||measurement||loadtime||0:00:27.040035||0||0
+2015-12-02 00:33:01.587287||measurement||loadtime||0:00:29.356150||4||1
+2015-12-02 00:33:05.795151||measurement||loadtime||0:00:28.767724||1||1
+2015-12-02 00:33:13.005809||measurement||price||2015-12-02 00:32:55.291272@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||0
+2015-12-02 00:33:13.546646||measurement||price||2015-12-02 00:33:07.717930@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 00:33:15.105515||error||collecting ads||Error||3||1
+2015-12-02 00:33:15.766250||measurement||price||2015-12-02 00:33:09.025002@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-02 00:33:18.386033||error||collecting ads||Error||2||0
+2015-12-02 00:33:19.554633||measurement||price||2015-12-02 00:33:13.095680@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 00:33:20.105944||measurement||loadtime||0:00:27.283165||5||0
+2015-12-02 00:33:25.901432||measurement||price||2015-12-02 00:33:07.717930@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 00:33:28.751501||measurement||price||2015-12-02 00:33:22.562964@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-02 00:33:28.934938||measurement||price||2015-12-02 00:33:09.025002@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-02 00:33:30.903990||measurement||price||2015-12-02 00:33:25.464565@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-02 00:33:32.346871||measurement||price||2015-12-02 00:33:13.095680@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 00:33:33.013754||measurement||loadtime||0:00:27.201381||0||0
+2015-12-02 00:33:33.069583||measurement||price||2015-12-02 00:33:27.637367@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-02 00:33:36.141320||measurement||loadtime||0:00:29.552435||4||1
+2015-12-02 00:33:39.548440||measurement||loadtime||0:00:28.750348||1||1
+2015-12-02 00:33:41.763532||measurement||price||2015-12-02 00:33:22.562964@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-02 00:33:43.211978||measurement||price||2015-12-02 00:33:25.464565@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-02 00:33:45.430198||measurement||price||2015-12-02 00:33:27.637367@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-02 00:33:45.679660||measurement||price||2015-12-02 00:33:40.247795@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:33:48.963168||measurement||loadtime||0:00:28.856033||3||1
+2015-12-02 00:33:50.231714||measurement||price||2015-12-02 00:33:43.487482@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 00:33:50.303169||measurement||loadtime||0:00:26.911901||2||0
+2015-12-02 00:33:52.543315||measurement||loadtime||0:00:27.435554||5||0
+2015-12-02 00:33:53.354623||measurement||price||2015-12-02 00:33:46.843867@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:33:58.039863||measurement||price||2015-12-02 00:33:40.247795@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:34:02.725274||measurement||price||2015-12-02 00:33:56.548448@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||1
+2015-12-02 00:34:02.755086||measurement||price||2015-12-02 00:33:57.345655@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||0
+2015-12-02 00:34:03.105045||measurement||price||2015-12-02 00:33:43.487482@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 00:34:05.033236||measurement||price||2015-12-02 00:33:59.449295@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 00:34:05.169312||measurement||loadtime||0:00:27.150366||0||0
+2015-12-02 00:34:06.196436||measurement||price||2015-12-02 00:33:46.843867@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:34:10.307153||measurement||loadtime||0:00:29.160664||4||1
+2015-12-02 00:34:13.423423||measurement||loadtime||0:00:28.872268||1||1
+2015-12-02 00:34:15.096448||measurement||price||2015-12-02 00:33:57.345655@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||0
+2015-12-02 00:34:15.562669||measurement||price||2015-12-02 00:33:56.548448@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||1
+2015-12-02 00:34:17.349824||measurement||price||2015-12-02 00:33:59.449295@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 00:34:17.700292||measurement||price||2015-12-02 00:34:12.320427@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||0||0
+2015-12-02 00:34:22.187153||measurement||loadtime||0:00:26.878733||2||0
+2015-12-02 00:34:22.776990||measurement||loadtime||0:00:28.808548||3||1
+2015-12-02 00:34:24.195972||measurement||price||2015-12-02 00:34:17.720557@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-02 00:34:24.458472||measurement||loadtime||0:00:26.909705||5||0
+2015-12-02 00:34:27.119476||measurement||price||2015-12-02 00:34:20.725283@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:34:30.012003||measurement||price||2015-12-02 00:34:12.320427@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||0||0
+2015-12-02 00:34:34.538415||measurement||price||2015-12-02 00:34:29.152236@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-02 00:34:36.805318||measurement||price||2015-12-02 00:34:31.144267@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-02 00:34:37.103347||measurement||price||2015-12-02 00:34:17.720557@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-02 00:34:37.107245||measurement||loadtime||0:00:26.933112||0||0
+2015-12-02 00:34:39.994012||measurement||price||2015-12-02 00:34:20.725283@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:34:44.299164||measurement||loadtime||0:00:28.989981||4||1
+2015-12-02 00:34:46.655923||error||collecting ads||Error||3||1
+2015-12-02 00:34:46.865181||measurement||price||2015-12-02 00:34:29.152236@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-02 00:34:47.184412||measurement||loadtime||0:00:28.755780||1||1
+2015-12-02 00:34:49.137083||measurement||price||2015-12-02 00:34:31.144267@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-02 00:34:53.971152||measurement||loadtime||0:00:26.780009||2||0
+2015-12-02 00:34:56.244932||measurement||loadtime||0:00:26.781218||5||0
+2015-12-02 00:34:58.900814||measurement||price||2015-12-02 00:34:52.642290@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 00:35:00.444100||error||collecting ads||Error||0||0
+2015-12-02 00:35:01.577512||measurement||price||2015-12-02 00:34:55.101550@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-02 00:35:03.390222||measurement||price||2015-12-02 00:34:57.432703@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 00:35:08.633319||measurement||price||2015-12-02 00:35:02.992569@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:35:11.862304||measurement||price||2015-12-02 00:34:52.642290@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 00:35:13.054041||measurement||price||2015-12-02 00:35:07.636507@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 00:35:14.779562||measurement||price||2015-12-02 00:34:55.101550@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-02 00:35:16.340725||measurement||price||2015-12-02 00:34:57.432703@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 00:35:17.149369||error||collecting ads||Error||2||0
+2015-12-02 00:35:19.085923||measurement||loadtime||0:00:29.782775||4||1
+2015-12-02 00:35:20.958577||measurement||price||2015-12-02 00:35:02.992569@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:35:22.033559||measurement||loadtime||0:00:30.374705||3||1
+2015-12-02 00:35:23.586149||measurement||loadtime||0:00:31.399004||1||1
+2015-12-02 00:35:25.342302||measurement||price||2015-12-02 00:35:07.636507@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 00:35:28.075164||measurement||loadtime||0:00:26.828027||5||0
+2015-12-02 00:35:29.434125||measurement||price||2015-12-02 00:35:24.026469@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-02 00:35:32.447099||measurement||loadtime||0:00:26.997779||0||0
+2015-12-02 00:35:33.291477||measurement||price||2015-12-02 00:35:26.560212@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-02 00:35:35.734092||measurement||price||2015-12-02 00:35:29.712308@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-02 00:35:37.725131||measurement||price||2015-12-02 00:35:31.294561@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:35:40.325843||measurement||price||2015-12-02 00:35:34.710680@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||0
+2015-12-02 00:35:41.778068||measurement||price||2015-12-02 00:35:24.026469@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-02 00:35:45.342561||measurement||price||2015-12-02 00:35:39.985419@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:35:46.239929||measurement||price||2015-12-02 00:35:26.560212@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-02 00:35:48.659858||measurement||price||2015-12-02 00:35:29.712308@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-02 00:35:48.883225||measurement||loadtime||0:00:26.732056||2||0
+2015-12-02 00:35:50.609005||measurement||price||2015-12-02 00:35:31.294561@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:35:52.658578||measurement||price||2015-12-02 00:35:34.710680@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||0
+2015-12-02 00:35:53.487149||measurement||loadtime||0:00:29.398387||4||1
+2015-12-02 00:35:55.859143||measurement||loadtime||0:00:28.820576||3||1
+2015-12-02 00:35:57.670487||measurement||price||2015-12-02 00:35:39.985419@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:35:57.837764||measurement||loadtime||0:00:29.246430||1||1
+2015-12-02 00:35:59.779164||measurement||loadtime||0:00:26.700023||5||0
+2015-12-02 00:36:01.362317||measurement||price||2015-12-02 00:35:55.943660@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:36:04.778455||measurement||loadtime||0:00:27.327319||0||0
+2015-12-02 00:36:07.576536||measurement||price||2015-12-02 00:36:00.930082@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 00:36:09.521235||measurement||price||2015-12-02 00:36:03.345698@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||1
+2015-12-02 00:36:11.928181||measurement||price||2015-12-02 00:36:05.662407@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||1||1
+2015-12-02 00:36:12.088501||measurement||price||2015-12-02 00:36:06.455710@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||0
+2015-12-02 00:36:13.694282||measurement||price||2015-12-02 00:35:55.943660@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:36:17.416341||measurement||price||2015-12-02 00:36:12.002458@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:36:20.446780||measurement||price||2015-12-02 00:36:00.930082@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 00:36:20.801364||measurement||loadtime||0:00:26.914212||2||0
+2015-12-02 00:36:22.471537||measurement||price||2015-12-02 00:36:03.345698@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||1
+2015-12-02 00:36:24.428872||measurement||price||2015-12-02 00:36:06.455710@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||0
+2015-12-02 00:36:24.924766||measurement||price||2015-12-02 00:36:05.662407@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||1||1
+2015-12-02 00:36:27.649155||measurement||loadtime||0:00:29.156768||4||1
+2015-12-02 00:36:29.700264||measurement||loadtime||0:00:28.835902||3||1
+2015-12-02 00:36:29.754718||measurement||price||2015-12-02 00:36:12.002458@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:36:31.535150||measurement||loadtime||0:00:26.751568||5||0
+2015-12-02 00:36:32.139145||measurement||loadtime||0:00:29.296862||1||1
+2015-12-02 00:36:36.856278||measurement||loadtime||0:00:27.073133||0||0
+2015-12-02 00:36:41.717543||measurement||price||2015-12-02 00:36:35.153055@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 00:36:43.153653||error||collecting ads||Error||2||0
+2015-12-02 00:36:45.839586||measurement||price||2015-12-02 00:36:39.692271@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:36:49.495101||measurement||price||2015-12-02 00:36:44.098795@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||0||0
+2015-12-02 00:36:53.700959||error||collecting ads||Error||3||1
+2015-12-02 00:36:53.872719||error||collecting ads||Error||5||0
+2015-12-02 00:36:54.666472||measurement||price||2015-12-02 00:36:35.153055@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 00:36:55.637418||measurement||price||2015-12-02 00:36:50.166232@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 00:36:58.659110||measurement||price||2015-12-02 00:36:39.692271@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:37:01.856630||measurement||price||2015-12-02 00:36:44.098795@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||0||0
+2015-12-02 00:37:01.863171||measurement||loadtime||0:00:29.208810||4||1
+2015-12-02 00:37:05.891647||measurement||loadtime||0:00:28.748509||1||1
+2015-12-02 00:37:06.184305||measurement||price||2015-12-02 00:37:00.507594@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 00:37:07.410329||measurement||price||2015-12-02 00:37:01.268208@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-02 00:37:07.958858||measurement||price||2015-12-02 00:36:50.166232@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 00:37:08.941440||measurement||loadtime||0:00:27.082301||0||0
+2015-12-02 00:37:15.055160||measurement||loadtime||0:00:26.899598||2||0
+2015-12-02 00:37:16.040632||measurement||price||2015-12-02 00:37:09.224302@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||1
+2015-12-02 00:37:18.507220||measurement||price||2015-12-02 00:37:00.507594@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 00:37:19.721414||measurement||price||2015-12-02 00:37:13.117115@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:37:20.255828||measurement||price||2015-12-02 00:37:01.268208@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-02 00:37:25.594790||measurement||loadtime||0:00:26.719623||5||0
+2015-12-02 00:37:25.594889||event||progress-marker||measurement-end||5||0
+2015-12-02 00:37:27.451554||measurement||price||2015-12-02 00:37:22.129405@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-02 00:37:27.472334||measurement||loadtime||0:00:28.769212||3||1
+2015-12-02 00:37:28.945688||measurement||price||2015-12-02 00:37:09.224302@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||1
+2015-12-02 00:37:31.638181||error||collecting ads||Error||0||0
+2015-12-02 00:37:31.638288||event||progress-marker||measurement-end||0||0
+2015-12-02 00:37:32.550314||measurement||price||2015-12-02 00:37:13.117115@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:37:36.147467||measurement||loadtime||0:00:29.279072||4||1
+2015-12-02 00:37:39.747217||measurement||loadtime||0:00:28.852786||1||1
+2015-12-02 00:37:39.794456||measurement||price||2015-12-02 00:37:22.129405@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-02 00:37:41.216049||measurement||price||2015-12-02 00:37:34.987707@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-02 00:37:46.903344||measurement||loadtime||0:00:26.846522||2||0
+2015-12-02 00:37:46.903427||event||progress-marker||measurement-end||2||0
+2015-12-02 00:37:50.001269||measurement||price||2015-12-02 00:37:43.539480@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||1
+2015-12-02 00:37:53.650110||measurement||price||2015-12-02 00:37:47.663283@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:37:53.994254||measurement||price||2015-12-02 00:37:34.987707@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-02 00:38:01.219161||measurement||loadtime||0:00:28.744020||3||1
+2015-12-02 00:38:03.025183||measurement||price||2015-12-02 00:37:43.539480@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||1
+2015-12-02 00:38:06.438704||measurement||price||2015-12-02 00:37:47.663283@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:38:10.205583||measurement||loadtime||0:00:29.054379||4||1
+2015-12-02 00:38:13.670226||measurement||loadtime||0:00:28.919093||1||1
+2015-12-02 00:38:15.246078||measurement||price||2015-12-02 00:38:09.369969@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||1
+2015-12-02 00:38:24.213089||measurement||price||2015-12-02 00:38:17.446880@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||4||1
+2015-12-02 00:38:28.029318||measurement||price||2015-12-02 00:38:09.369969@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||1
+2015-12-02 00:38:35.238157||measurement||loadtime||0:00:29.018442||3||1
+2015-12-02 00:38:37.204998||measurement||price||2015-12-02 00:38:17.446880@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||4||1
+2015-12-02 00:38:37.242745||error||collecting ads||Error||1||1
+2015-12-02 00:38:37.242842||event||progress-marker||measurement-end||1||1
+2015-12-02 00:38:44.400054||measurement||loadtime||0:00:29.193703||4||1
+2015-12-02 00:38:48.634526||measurement||price||2015-12-02 00:38:42.704818@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||1
+2015-12-02 00:39:01.406838||measurement||price||2015-12-02 00:38:42.704818@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||1
+2015-12-02 00:39:08.605976||measurement||loadtime||0:00:28.362605||3||1
+2015-12-02 00:39:09.118482||error||collecting ads||Error||4||1
+2015-12-02 00:39:22.331549||measurement||price||2015-12-02 00:39:16.190495@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||1
+2015-12-02 00:39:23.139857||measurement||price||2015-12-02 00:39:16.553312@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||4||1
+2015-12-02 00:39:35.086491||measurement||price||2015-12-02 00:39:16.190495@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||1
+2015-12-02 00:39:35.917054||measurement||price||2015-12-02 00:39:16.553312@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||4||1
+2015-12-02 00:39:42.297953||measurement||loadtime||0:00:28.686689||3||1
+2015-12-02 00:39:43.142614||measurement||loadtime||0:00:29.018893||4||1
+2015-12-02 00:39:55.907925||measurement||price||2015-12-02 00:39:49.865301@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||1
+2015-12-02 00:39:56.987865||measurement||price||2015-12-02 00:39:50.540538@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 00:40:08.657390||measurement||price||2015-12-02 00:39:49.865301@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||1
+2015-12-02 00:40:09.870581||measurement||price||2015-12-02 00:39:50.540538@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 00:40:15.864618||measurement||loadtime||0:00:28.564595||3||1
+2015-12-02 00:40:15.864722||event||progress-marker||measurement-end||3||1
+2015-12-02 00:40:17.071652||measurement||loadtime||0:00:28.923836||4||1
+2015-12-02 00:40:17.071785||event||progress-marker||measurement-end||4||1
+2015-12-02 00:40:17.634314||meta||block_id end||15
+2015-12-02 00:40:17.634740||meta||block_id start||16
+2015-12-02 00:40:17.634768||meta||assignment||0@|3@|4@|2@|5@|1
+2015-12-02 00:40:19.265596||event||progress-marker||training-start||0||0
+2015-12-02 00:40:19.289463||event||progress-marker||training-start||4||0
+2015-12-02 00:40:19.340101||event||progress-marker||training-start||3||0
+2015-12-02 00:40:26.080870||treatment||visit website||http://irs.gov||3||0
+2015-12-02 00:40:26.095429||treatment||visit website||http://irs.gov||4||0
+2015-12-02 00:40:26.174873||treatment||visit website||http://irs.gov||0||0
+2015-12-02 00:40:33.392958||treatment||visit website||http://deloitte.com||0||0
+2015-12-02 00:40:33.395086||treatment||visit website||http://deloitte.com||3||0
+2015-12-02 00:40:33.399126||treatment||visit website||http://deloitte.com||4||0
+2015-12-02 00:40:41.540116||treatment||visit website||http://pwc.com||0||0
+2015-12-02 00:40:41.583102||treatment||visit website||http://pwc.com||3||0
+2015-12-02 00:40:41.643132||treatment||visit website||http://pwc.com||4||0
+2015-12-02 00:40:47.367095||treatment||visit website||http://ey.com||0||0
+2015-12-02 00:40:47.515096||treatment||visit website||http://ey.com||3||0
+2015-12-02 00:40:47.575097||treatment||visit website||http://ey.com||4||0
+2015-12-02 00:40:54.225445||treatment||visit website||http://kpmg.com||4||0
+2015-12-02 00:40:54.225541||event||progress-marker||training-end||4||0
+2015-12-02 00:40:54.345649||treatment||visit website||http://kpmg.com||3||0
+2015-12-02 00:40:54.345782||event||progress-marker||training-end||3||0
+2015-12-02 00:40:59.600858||treatment||visit website||http://kpmg.com||0||0
+2015-12-02 00:40:59.600986||event||progress-marker||training-end||0||0
+2015-12-02 00:41:04.298357||event||progress-marker||measurement-start||4||0
+2015-12-02 00:41:04.409273||event||progress-marker||measurement-start||3||0
+2015-12-02 00:41:04.649263||event||progress-marker||measurement-start||0||0
+2015-12-02 00:41:17.810326||measurement||price||2015-12-02 00:41:11.688790@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:41:17.864725||measurement||price||2015-12-02 00:41:11.744216@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 00:41:18.557160||measurement||price||2015-12-02 00:41:12.670635@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||0||0
+2015-12-02 00:41:23.909646||event||progress-marker||training-start||2||1
+2015-12-02 00:41:25.915070||event||progress-marker||training-start||1||1
+2015-12-02 00:41:26.847545||event||progress-marker||training-start||5||1
+2015-12-02 00:41:30.192226||measurement||price||2015-12-02 00:41:11.688790@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:41:30.215314||measurement||price||2015-12-02 00:41:11.744216@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 00:41:30.844156||treatment||visit website||http://irs.gov||2||1
+2015-12-02 00:41:30.956769||measurement||price||2015-12-02 00:41:12.670635@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-02 00:41:32.363098||treatment||visit website||http://irs.gov||1||1
+2015-12-02 00:41:33.419922||treatment||visit website||http://irs.gov||5||1
+2015-12-02 00:41:37.261901||treatment||visit website||http://deloitte.com||2||1
+2015-12-02 00:41:37.293622||measurement||loadtime||0:00:27.990452||4||0
+2015-12-02 00:41:37.327134||measurement||loadtime||0:00:27.912696||3||0
+2015-12-02 00:41:38.043134||measurement||loadtime||0:00:28.391996||0||0
+2015-12-02 00:41:38.974654||treatment||visit website||http://deloitte.com||1||1
+2015-12-02 00:41:39.815137||treatment||visit website||http://deloitte.com||5||1
+2015-12-02 00:41:49.749245||measurement||price||2015-12-02 00:41:44.353100@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-02 00:41:49.936465||measurement||price||2015-12-02 00:41:44.062441@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 00:41:50.680187||measurement||price||2015-12-02 00:41:45.301822@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:42:02.022674||measurement||price||2015-12-02 00:41:44.353100@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-02 00:42:02.264656||measurement||price||2015-12-02 00:41:44.062441@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 00:42:02.980944||measurement||price||2015-12-02 00:41:45.301822@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:42:09.114463||measurement||loadtime||0:00:26.816544||4||0
+2015-12-02 00:42:09.385250||measurement||loadtime||0:00:27.054093||3||0
+2015-12-02 00:42:10.090131||measurement||loadtime||0:00:27.042984||0||0
+2015-12-02 00:42:17.284566||error||website timeout||http://pwc.com||2||1
+2015-12-02 00:42:18.997858||error||website timeout||http://pwc.com||1||1
+2015-12-02 00:42:19.848938||error||website timeout||http://pwc.com||5||1
+2015-12-02 00:42:22.250158||measurement||price||2015-12-02 00:42:16.829819@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-02 00:42:22.338590||treatment||visit website||http://ey.com||2||1
+2015-12-02 00:42:23.296596||measurement||price||2015-12-02 00:42:17.885106@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:42:24.043125||treatment||visit website||http://ey.com||1||1
+2015-12-02 00:42:24.887113||treatment||visit website||http://ey.com||5||1
+2015-12-02 00:42:29.243987||treatment||visit website||http://kpmg.com||2||1
+2015-12-02 00:42:29.244110||event||progress-marker||training-end||2||1
+2015-12-02 00:42:30.588528||treatment||visit website||http://kpmg.com||1||1
+2015-12-02 00:42:30.588668||event||progress-marker||training-end||1||1
+2015-12-02 00:42:31.233788||treatment||visit website||http://kpmg.com||5||1
+2015-12-02 00:42:31.233960||event||progress-marker||training-end||5||1
+2015-12-02 00:42:32.526306||error||collecting ads||Error||3||0
+2015-12-02 00:42:34.286294||event||progress-marker||measurement-start||2||1
+2015-12-02 00:42:34.574792||measurement||price||2015-12-02 00:42:16.829819@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-02 00:42:35.623482||measurement||price||2015-12-02 00:42:17.885106@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:42:35.636421||event||progress-marker||measurement-start||1||1
+2015-12-02 00:42:36.274684||event||progress-marker||measurement-start||5||1
+2015-12-02 00:42:41.663155||measurement||loadtime||0:00:27.543509||4||0
+2015-12-02 00:42:42.699142||measurement||loadtime||0:00:27.604528||0||0
+2015-12-02 00:42:44.767936||measurement||price||2015-12-02 00:42:39.080988@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||0
+2015-12-02 00:42:48.594412||measurement||price||2015-12-02 00:42:42.406683@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-02 00:42:50.359187||measurement||price||2015-12-02 00:42:44.119852@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:42:50.948044||measurement||price||2015-12-02 00:42:44.676271@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||1
+2015-12-02 00:42:55.154515||measurement||price||2015-12-02 00:42:49.776735@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 00:42:57.061702||measurement||price||2015-12-02 00:42:39.080988@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||0
+2015-12-02 00:43:01.378054||measurement||price||2015-12-02 00:42:42.406683@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-02 00:43:03.228267||measurement||price||2015-12-02 00:42:44.119852@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:43:03.814423||measurement||price||2015-12-02 00:42:44.676271@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||1
+2015-12-02 00:43:04.025223||error||collecting ads||Error||4||0
+2015-12-02 00:43:04.147166||measurement||loadtime||0:00:26.618595||3||0
+2015-12-02 00:43:07.442346||measurement||price||2015-12-02 00:42:49.776735@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 00:43:08.612775||measurement||loadtime||0:00:29.321597||2||1
+2015-12-02 00:43:10.427225||measurement||loadtime||0:00:29.785601||1||1
+2015-12-02 00:43:11.015305||measurement||loadtime||0:00:29.738482||5||1
+2015-12-02 00:43:14.530753||measurement||loadtime||0:00:26.831406||0||0
+2015-12-02 00:43:16.422778||measurement||price||2015-12-02 00:43:11.006124@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||4||0
+2015-12-02 00:43:16.456642||measurement||price||2015-12-02 00:43:10.771075@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-02 00:43:22.524516||measurement||price||2015-12-02 00:43:16.164522@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 00:43:24.553630||measurement||price||2015-12-02 00:43:18.294794@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 00:43:25.440964||measurement||price||2015-12-02 00:43:19.300402@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||1
+2015-12-02 00:43:27.134654||measurement||price||2015-12-02 00:43:21.669890@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 00:43:28.751400||measurement||price||2015-12-02 00:43:11.006124@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||4||0
+2015-12-02 00:43:28.776245||measurement||price||2015-12-02 00:43:10.771075@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-02 00:43:35.319123||measurement||price||2015-12-02 00:43:16.164522@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 00:43:35.844324||measurement||loadtime||0:00:26.817197||4||0
+2015-12-02 00:43:35.889159||measurement||loadtime||0:00:26.737996||3||0
+2015-12-02 00:43:37.365125||measurement||price||2015-12-02 00:43:18.294794@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 00:43:38.341785||measurement||price||2015-12-02 00:43:19.300402@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||1
+2015-12-02 00:43:39.457881||measurement||price||2015-12-02 00:43:21.669890@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 00:43:42.551171||measurement||loadtime||0:00:28.936524||2||1
+2015-12-02 00:43:44.561099||measurement||loadtime||0:00:29.129969||1||1
+2015-12-02 00:43:45.576226||measurement||loadtime||0:00:29.557089||5||1
+2015-12-02 00:43:46.557802||measurement||loadtime||0:00:27.025579||0||0
+2015-12-02 00:43:48.188170||measurement||price||2015-12-02 00:43:42.438798@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 00:43:48.330703||measurement||price||2015-12-02 00:43:42.807785@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:43:58.860897||measurement||price||2015-12-02 00:43:52.569278@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||1
+2015-12-02 00:43:59.120781||measurement||price||2015-12-02 00:43:53.682280@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 00:43:59.630345||measurement||price||2015-12-02 00:43:53.411151@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-02 00:44:00.498521||measurement||price||2015-12-02 00:43:42.438798@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 00:44:00.658945||measurement||price||2015-12-02 00:43:42.807785@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:44:06.146913||error||collecting ads||Error||2||1
+2015-12-02 00:44:07.607151||measurement||loadtime||0:00:26.712757||3||0
+2015-12-02 00:44:07.770372||measurement||loadtime||0:00:26.924137||4||0
+2015-12-02 00:44:11.422070||measurement||price||2015-12-02 00:43:53.682280@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 00:44:11.669277||measurement||price||2015-12-02 00:43:52.569278@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||1
+2015-12-02 00:44:12.479074||measurement||price||2015-12-02 00:43:53.411151@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-02 00:44:18.499172||measurement||loadtime||0:00:26.936186||0||0
+2015-12-02 00:44:18.884913||measurement||loadtime||0:00:29.321757||1||1
+2015-12-02 00:44:19.691176||measurement||loadtime||0:00:29.112025||5||1
+2015-12-02 00:44:19.873411||measurement||price||2015-12-02 00:44:13.746130@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 00:44:20.060955||measurement||price||2015-12-02 00:44:14.416820@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||0
+2015-12-02 00:44:20.685916||measurement||price||2015-12-02 00:44:15.280696@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||4||0
+2015-12-02 00:44:31.082838||measurement||price||2015-12-02 00:44:25.659084@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 00:44:32.411970||measurement||price||2015-12-02 00:44:14.416820@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||0
+2015-12-02 00:44:32.773160||measurement||price||2015-12-02 00:44:26.662405@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 00:44:32.802602||measurement||price||2015-12-02 00:44:13.746130@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 00:44:33.026044||measurement||price||2015-12-02 00:44:15.280696@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||4||0
+2015-12-02 00:44:33.658770||measurement||price||2015-12-02 00:44:27.462159@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 00:44:39.522724||measurement||loadtime||0:00:26.911585||3||0
+2015-12-02 00:44:40.019130||measurement||loadtime||0:00:28.867018||2||1
+2015-12-02 00:44:40.141163||measurement||loadtime||0:00:27.366001||4||0
+2015-12-02 00:44:43.406641||measurement||price||2015-12-02 00:44:25.659084@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 00:44:45.788842||measurement||price||2015-12-02 00:44:26.662405@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 00:44:46.549264||measurement||price||2015-12-02 00:44:27.462159@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 00:44:50.508334||measurement||loadtime||0:00:27.007785||0||0
+2015-12-02 00:44:52.470306||measurement||price||2015-12-02 00:44:46.686400@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||3||0
+2015-12-02 00:44:52.749359||measurement||price||2015-12-02 00:44:47.309786@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-02 00:44:53.023182||measurement||loadtime||0:00:29.134989||1||1
+2015-12-02 00:44:53.776297||measurement||loadtime||0:00:29.081160||5||1
+2015-12-02 00:44:54.257104||measurement||price||2015-12-02 00:44:48.294528@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||1
+2015-12-02 00:45:02.939306||measurement||price||2015-12-02 00:44:57.514873@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:45:04.808815||measurement||price||2015-12-02 00:44:46.686400@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||3||0
+2015-12-02 00:45:05.089424||measurement||price||2015-12-02 00:44:47.309786@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-02 00:45:06.969647||measurement||price||2015-12-02 00:45:00.843568@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:45:07.326279||measurement||price||2015-12-02 00:44:48.294528@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||1
+2015-12-02 00:45:07.600560||measurement||price||2015-12-02 00:45:01.542329@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||1
+2015-12-02 00:45:11.915146||measurement||loadtime||0:00:27.387194||3||0
+2015-12-02 00:45:12.197828||measurement||loadtime||0:00:27.051456||4||0
+2015-12-02 00:45:14.544806||measurement||loadtime||0:00:29.520445||2||1
+2015-12-02 00:45:15.277036||measurement||price||2015-12-02 00:44:57.514873@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:45:19.897537||measurement||price||2015-12-02 00:45:00.843568@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:45:20.580275||measurement||price||2015-12-02 00:45:01.542329@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||1
+2015-12-02 00:45:22.390313||measurement||loadtime||0:00:26.876804||0||0
+2015-12-02 00:45:24.290618||measurement||price||2015-12-02 00:45:18.592658@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:45:24.706421||measurement||price||2015-12-02 00:45:19.204020@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:45:27.167714||measurement||loadtime||0:00:29.139337||1||1
+2015-12-02 00:45:27.798338||measurement||loadtime||0:00:29.016822||5||1
+2015-12-02 00:45:28.204815||measurement||price||2015-12-02 00:45:22.125654@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 00:45:34.945902||measurement||price||2015-12-02 00:45:29.505918@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 00:45:36.621401||measurement||price||2015-12-02 00:45:18.592658@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:45:37.004521||measurement||price||2015-12-02 00:45:19.204020@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:45:41.154010||measurement||price||2015-12-02 00:45:22.125654@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 00:45:41.163499||measurement||price||2015-12-02 00:45:34.979643@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:45:43.742985||measurement||loadtime||0:00:26.822643||3||0
+2015-12-02 00:45:44.095163||measurement||loadtime||0:00:26.896861||4||0
+2015-12-02 00:45:47.274177||measurement||price||2015-12-02 00:45:29.505918@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 00:45:48.364981||measurement||loadtime||0:00:28.816722||2||1
+2015-12-02 00:45:51.798445||error||collecting ads||Error||5||1
+2015-12-02 00:45:54.096993||measurement||price||2015-12-02 00:45:34.979643@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:45:54.367148||measurement||loadtime||0:00:26.974868||0||0
+2015-12-02 00:45:56.049995||measurement||price||2015-12-02 00:45:50.426343@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:45:56.556705||measurement||price||2015-12-02 00:45:51.117585@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||0
+2015-12-02 00:46:01.294579||measurement||loadtime||0:00:29.121746||1||1
+2015-12-02 00:46:01.894498||measurement||price||2015-12-02 00:45:55.851121@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||1
+2015-12-02 00:46:05.893601||measurement||price||2015-12-02 00:45:59.840698@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-02 00:46:07.464495||measurement||price||2015-12-02 00:46:02.110087@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 00:46:08.384272||measurement||price||2015-12-02 00:45:50.426343@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:46:08.890898||measurement||price||2015-12-02 00:45:51.117585@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||0
+2015-12-02 00:46:14.836036||measurement||price||2015-12-02 00:45:55.851121@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||1
+2015-12-02 00:46:15.495171||measurement||loadtime||0:00:26.748023||3||0
+2015-12-02 00:46:15.664959||measurement||price||2015-12-02 00:46:09.382373@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||1
+2015-12-02 00:46:15.999135||measurement||loadtime||0:00:26.899881||4||0
+2015-12-02 00:46:18.917712||measurement||price||2015-12-02 00:45:59.840698@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-02 00:46:19.806826||measurement||price||2015-12-02 00:46:02.110087@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 00:46:22.195150||measurement||loadtime||0:00:28.824986||2||1
+2015-12-02 00:46:26.155808||measurement||loadtime||0:00:29.352656||5||1
+2015-12-02 00:46:26.897335||measurement||loadtime||0:00:27.525017||0||0
+2015-12-02 00:46:27.849841||measurement||price||2015-12-02 00:46:22.194788@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 00:46:28.660459||measurement||price||2015-12-02 00:46:23.055837@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:46:28.735508||measurement||price||2015-12-02 00:46:09.382373@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||1
+2015-12-02 00:46:35.939174||measurement||loadtime||0:00:29.641294||1||1
+2015-12-02 00:46:35.965567||measurement||price||2015-12-02 00:46:29.795690@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 00:46:39.421690||measurement||price||2015-12-02 00:46:34.026560@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 00:46:39.930180||measurement||price||2015-12-02 00:46:33.784419@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:46:40.211047||measurement||price||2015-12-02 00:46:22.194788@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 00:46:40.988097||measurement||price||2015-12-02 00:46:23.055837@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:46:47.322831||measurement||loadtime||0:00:26.825499||3||0
+2015-12-02 00:46:48.106839||measurement||loadtime||0:00:27.103704||4||0
+2015-12-02 00:46:48.833023||measurement||price||2015-12-02 00:46:29.795690@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 00:46:49.829239||measurement||price||2015-12-02 00:46:43.704672@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:46:51.736461||measurement||price||2015-12-02 00:46:34.026560@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 00:46:52.754337||measurement||price||2015-12-02 00:46:33.784419@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:46:56.027339||measurement||loadtime||0:00:28.826956||2||1
+2015-12-02 00:46:58.808965||measurement||loadtime||0:00:26.906385||0||0
+2015-12-02 00:46:59.598483||measurement||price||2015-12-02 00:46:53.964805@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||3||0
+2015-12-02 00:46:59.945989||measurement||loadtime||0:00:28.786855||5||1
+2015-12-02 00:47:01.075980||measurement||price||2015-12-02 00:46:55.780159@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:47:02.751795||measurement||price||2015-12-02 00:46:43.704672@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:47:09.754119||measurement||price||2015-12-02 00:47:03.601497@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 00:47:09.945658||measurement||loadtime||0:00:29.004890||1||1
+2015-12-02 00:47:11.516756||measurement||price||2015-12-02 00:47:06.025596@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 00:47:11.932695||measurement||price||2015-12-02 00:46:53.964805@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||3||0
+2015-12-02 00:47:13.368374||measurement||price||2015-12-02 00:46:55.780159@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:47:13.851655||measurement||price||2015-12-02 00:47:07.736753@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 00:47:19.038968||measurement||loadtime||0:00:26.714376||3||0
+2015-12-02 00:47:20.444160||measurement||loadtime||0:00:27.332116||4||0
+2015-12-02 00:47:22.584737||measurement||price||2015-12-02 00:47:03.601497@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 00:47:23.847052||measurement||price||2015-12-02 00:47:06.025596@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 00:47:24.161645||measurement||price||2015-12-02 00:47:17.879635@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 00:47:26.726484||measurement||price||2015-12-02 00:47:07.736753@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 00:47:29.786269||measurement||loadtime||0:00:28.755148||2||1
+2015-12-02 00:47:30.939929||measurement||loadtime||0:00:27.127227||0||0
+2015-12-02 00:47:31.298784||measurement||price||2015-12-02 00:47:25.664567@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:47:32.739566||measurement||price||2015-12-02 00:47:27.374814@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:47:33.931121||measurement||loadtime||0:00:28.979850||5||1
+2015-12-02 00:47:37.224138||measurement||price||2015-12-02 00:47:17.879635@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 00:47:43.401338||measurement||price||2015-12-02 00:47:37.268216@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 00:47:43.577591||measurement||price||2015-12-02 00:47:38.164485@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 00:47:43.633254||measurement||price||2015-12-02 00:47:25.664567@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:47:44.452298||measurement||loadtime||0:00:29.501660||1||1
+2015-12-02 00:47:45.020332||measurement||price||2015-12-02 00:47:27.374814@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:47:47.739625||measurement||price||2015-12-02 00:47:41.684083@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 00:47:50.750165||measurement||loadtime||0:00:26.710638||3||0
+2015-12-02 00:47:52.103231||measurement||loadtime||0:00:26.654013||4||0
+2015-12-02 00:47:55.924419||measurement||price||2015-12-02 00:47:38.164485@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 00:47:56.215902||measurement||price||2015-12-02 00:47:37.268216@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 00:47:58.508197||measurement||price||2015-12-02 00:47:52.189275@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 00:48:00.612283||measurement||price||2015-12-02 00:47:41.684083@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 00:48:03.029916||measurement||price||2015-12-02 00:47:57.464767@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 00:48:03.035941||measurement||loadtime||0:00:27.089196||0||0
+2015-12-02 00:48:03.426142||measurement||loadtime||0:00:28.634663||2||1
+2015-12-02 00:48:04.653396||measurement||price||2015-12-02 00:47:59.218178@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||0
+2015-12-02 00:48:07.806356||measurement||loadtime||0:00:28.874961||5||1
+2015-12-02 00:48:11.383277||measurement||price||2015-12-02 00:47:52.189275@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 00:48:15.359654||measurement||price||2015-12-02 00:47:57.464767@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 00:48:16.018843||measurement||price||2015-12-02 00:48:10.605290@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||0||0
+2015-12-02 00:48:16.993474||measurement||price||2015-12-02 00:47:59.218178@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||0
+2015-12-02 00:48:17.877552||measurement||price||2015-12-02 00:48:11.953096@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-02 00:48:18.599252||measurement||loadtime||0:00:29.141742||1||1
+2015-12-02 00:48:21.575318||measurement||price||2015-12-02 00:48:15.437106@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 00:48:22.474728||measurement||loadtime||0:00:26.719374||3||0
+2015-12-02 00:48:24.111468||measurement||loadtime||0:00:27.002990||4||0
+2015-12-02 00:48:28.348194||measurement||price||2015-12-02 00:48:10.605290@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-02 00:48:30.803826||measurement||price||2015-12-02 00:48:11.953096@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-02 00:48:32.634169||measurement||price||2015-12-02 00:48:26.462885@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:48:34.412757||measurement||price||2015-12-02 00:48:15.437106@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 00:48:34.839810||measurement||price||2015-12-02 00:48:29.183775@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:48:35.466545||measurement||loadtime||0:00:27.425421||0||0
+2015-12-02 00:48:36.590885||measurement||price||2015-12-02 00:48:31.171889@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-02 00:48:38.033049||measurement||loadtime||0:00:29.601715||2||1
+2015-12-02 00:48:41.603150||measurement||loadtime||0:00:28.791618||5||1
+2015-12-02 00:48:45.490444||measurement||price||2015-12-02 00:48:26.462885@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:48:47.174183||measurement||price||2015-12-02 00:48:29.183775@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:48:48.013457||measurement||price||2015-12-02 00:48:42.516742@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 00:48:48.915593||measurement||price||2015-12-02 00:48:31.171889@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-02 00:48:52.723510||measurement||loadtime||0:00:29.119080||1||1
+2015-12-02 00:48:54.284971||measurement||loadtime||0:00:26.805056||3||0
+2015-12-02 00:48:55.852901||measurement||price||2015-12-02 00:48:49.330233@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||1
+2015-12-02 00:48:56.023735||measurement||loadtime||0:00:26.908605||4||0
+2015-12-02 00:49:00.345526||measurement||price||2015-12-02 00:48:42.516742@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 00:49:01.760664||error||collecting ads||Error||2||1
+2015-12-02 00:49:06.599166||measurement||price||2015-12-02 00:49:00.976739@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 00:49:06.790320||measurement||price||2015-12-02 00:49:00.451483@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:49:07.472798||measurement||loadtime||0:00:27.003563||0||0
+2015-12-02 00:49:08.480799||measurement||price||2015-12-02 00:49:03.085995@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:49:08.959193||measurement||price||2015-12-02 00:48:49.330233@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||1
+2015-12-02 00:49:15.381676||measurement||price||2015-12-02 00:49:09.321433@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 00:49:16.151150||measurement||loadtime||0:00:29.544026||5||1
+2015-12-02 00:49:18.924340||measurement||price||2015-12-02 00:49:00.976739@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 00:49:19.694570||measurement||price||2015-12-02 00:49:00.451483@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:49:20.010880||measurement||price||2015-12-02 00:49:14.618740@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:49:20.825301||measurement||price||2015-12-02 00:49:03.085995@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:49:26.032684||measurement||loadtime||0:00:26.742627||3||0
+2015-12-02 00:49:26.932796||measurement||loadtime||0:00:29.204102||1||1
+2015-12-02 00:49:27.939159||measurement||loadtime||0:00:26.912012||4||0
+2015-12-02 00:49:28.156142||measurement||price||2015-12-02 00:49:09.321433@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 00:49:29.979781||measurement||price||2015-12-02 00:49:23.898481@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 00:49:32.355653||measurement||price||2015-12-02 00:49:14.618740@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:49:35.371150||measurement||loadtime||0:00:28.608000||2||1
+2015-12-02 00:49:38.694723||measurement||price||2015-12-02 00:49:33.084183@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||0
+2015-12-02 00:49:39.460907||measurement||loadtime||0:00:26.982929||0||0
+2015-12-02 00:49:41.019770||measurement||price||2015-12-02 00:49:34.821026@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:49:42.889504||measurement||price||2015-12-02 00:49:23.898481@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 00:49:49.121687||measurement||price||2015-12-02 00:49:42.947760@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||1
+2015-12-02 00:49:50.111535||measurement||loadtime||0:00:28.956117||5||1
+2015-12-02 00:49:50.552903||error||collecting ads||Error||4||0
+2015-12-02 00:49:51.038926||measurement||price||2015-12-02 00:49:33.084183@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||0
+2015-12-02 00:49:51.970034||measurement||price||2015-12-02 00:49:46.574962@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:49:54.011090||measurement||price||2015-12-02 00:49:34.821026@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:49:58.143169||measurement||loadtime||0:00:27.105275||3||0
+2015-12-02 00:50:01.203888||measurement||loadtime||0:00:29.265860||1||1
+2015-12-02 00:50:01.971511||measurement||price||2015-12-02 00:49:42.947760@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||1
+2015-12-02 00:50:03.055134||measurement||price||2015-12-02 00:49:57.528823@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-02 00:50:03.954382||measurement||price||2015-12-02 00:49:57.855330@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 00:50:04.306865||measurement||price||2015-12-02 00:49:46.574962@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:50:09.169540||measurement||loadtime||0:00:28.793214||2||1
+2015-12-02 00:50:11.048091||measurement||price||2015-12-02 00:50:05.220477@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||0
+2015-12-02 00:50:11.422962||measurement||loadtime||0:00:26.956858||0||0
+2015-12-02 00:50:15.404762||measurement||price||2015-12-02 00:49:57.528823@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-02 00:50:16.901589||measurement||price||2015-12-02 00:49:57.855330@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 00:50:22.512994||measurement||loadtime||0:00:26.958338||4||0
+2015-12-02 00:50:23.375927||measurement||price||2015-12-02 00:50:05.220477@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||0
+2015-12-02 00:50:23.777306||measurement||price||2015-12-02 00:50:17.349560@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||2||1
+2015-12-02 00:50:24.102980||measurement||loadtime||0:00:28.986258||5||1
+2015-12-02 00:50:24.909351||error||collecting ads||Error||1||1
+2015-12-02 00:50:30.483170||measurement||loadtime||0:00:27.334788||3||0
+2015-12-02 00:50:34.083196||error||collecting ads||Error||0||0
+2015-12-02 00:50:34.992183||measurement||price||2015-12-02 00:50:29.583809@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||0
+2015-12-02 00:50:36.825040||measurement||price||2015-12-02 00:50:17.349560@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||2||1
+2015-12-02 00:50:37.945358||measurement||price||2015-12-02 00:50:31.879653@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 00:50:42.728825||measurement||price||2015-12-02 00:50:37.154493@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:50:44.078729||measurement||loadtime||0:00:29.907580||2||1
+2015-12-02 00:50:46.649683||measurement||price||2015-12-02 00:50:41.266446@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:50:47.303838||measurement||price||2015-12-02 00:50:29.583809@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||0
+2015-12-02 00:50:48.622727||error||collecting ads||Error||1||1
+2015-12-02 00:50:50.794639||measurement||price||2015-12-02 00:50:31.879653@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 00:50:54.415155||measurement||loadtime||0:00:26.899737||4||0
+2015-12-02 00:50:55.035603||measurement||price||2015-12-02 00:50:37.154493@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:50:57.978752||measurement||loadtime||0:00:28.872441||5||1
+2015-12-02 00:50:58.975867||measurement||price||2015-12-02 00:50:41.266446@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:50:59.755897||measurement||price||2015-12-02 00:50:53.731543@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 00:51:02.151139||measurement||loadtime||0:00:26.665416||3||0
+2015-12-02 00:51:03.018752||measurement||price||2015-12-02 00:50:57.079196@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:51:06.086400||measurement||loadtime||0:00:26.997982||0||0
+2015-12-02 00:51:06.820245||measurement||price||2015-12-02 00:51:01.421293@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-02 00:51:11.598047||measurement||price||2015-12-02 00:51:05.509105@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 00:51:12.845765||measurement||price||2015-12-02 00:50:53.731543@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 00:51:14.402072||measurement||price||2015-12-02 00:51:08.817507@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 00:51:15.988629||measurement||price||2015-12-02 00:50:57.079196@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:51:18.654873||measurement||price||2015-12-02 00:51:13.236706@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 00:51:19.162026||measurement||price||2015-12-02 00:51:01.421293@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-02 00:51:20.115062||measurement||loadtime||0:00:31.031708||2||1
+2015-12-02 00:51:23.232960||measurement||loadtime||0:00:29.604992||1||1
+2015-12-02 00:51:24.397789||measurement||price||2015-12-02 00:51:05.509105@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 00:51:26.275185||measurement||loadtime||0:00:26.858478||4||0
+2015-12-02 00:51:26.275283||event||progress-marker||measurement-end||4||0
+2015-12-02 00:51:26.737539||measurement||price||2015-12-02 00:51:08.817507@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 00:51:30.989452||measurement||price||2015-12-02 00:51:13.236706@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 00:51:31.598477||measurement||loadtime||0:00:28.615355||5||1
+2015-12-02 00:51:33.847195||measurement||loadtime||0:00:26.692074||3||0
+2015-12-02 00:51:33.847293||event||progress-marker||measurement-end||3||0
+2015-12-02 00:51:33.877365||measurement||price||2015-12-02 00:51:27.719847@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||1
+2015-12-02 00:51:37.042660||measurement||price||2015-12-02 00:51:30.853668@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 00:51:38.101270||measurement||loadtime||0:00:27.009705||0||0
+2015-12-02 00:51:38.101362||event||progress-marker||measurement-end||0||0
+2015-12-02 00:51:46.674636||measurement||price||2015-12-02 00:51:27.719847@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||1
+2015-12-02 00:51:49.987437||measurement||price||2015-12-02 00:51:30.853668@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 00:51:53.891143||measurement||loadtime||0:00:28.770892||2||1
+2015-12-02 00:51:55.457691||error||collecting ads||Error||5||1
+2015-12-02 00:51:57.314065||measurement||loadtime||0:00:29.075913||1||1
+2015-12-02 00:52:07.359057||measurement||price||2015-12-02 00:52:01.310859@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||1
+2015-12-02 00:52:09.365140||measurement||price||2015-12-02 00:52:03.098911@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||1
+2015-12-02 00:52:12.062124||measurement||price||2015-12-02 00:52:06.007392@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 00:52:20.197314||measurement||price||2015-12-02 00:52:01.310859@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||1
+2015-12-02 00:52:22.175363||measurement||price||2015-12-02 00:52:03.098911@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||1
+2015-12-02 00:52:25.052663||measurement||price||2015-12-02 00:52:06.007392@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 00:52:27.397892||measurement||loadtime||0:00:28.506272||2||1
+2015-12-02 00:52:29.368501||measurement||loadtime||0:00:28.905554||5||1
+2015-12-02 00:52:32.338135||measurement||loadtime||0:00:30.023151||1||1
+2015-12-02 00:52:41.094653||measurement||price||2015-12-02 00:52:34.934946@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||1
+2015-12-02 00:52:46.272817||measurement||price||2015-12-02 00:52:40.153537@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 00:52:53.236847||error||collecting ads||Error||5||1
+2015-12-02 00:52:53.876199||measurement||price||2015-12-02 00:52:34.934946@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||1
+2015-12-02 00:52:59.105609||measurement||price||2015-12-02 00:52:40.153537@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 00:53:01.078435||measurement||loadtime||0:00:28.676205||2||1
+2015-12-02 00:53:06.316751||measurement||loadtime||0:00:28.973732||1||1
+2015-12-02 00:53:06.820304||measurement||price||2015-12-02 00:53:00.765353@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 00:53:19.633188||measurement||price||2015-12-02 00:53:00.765353@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 00:53:20.742146||measurement||price||2015-12-02 00:53:14.452371@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||1||1
+2015-12-02 00:53:25.040125||error||collecting ads||Error||2||1
+2015-12-02 00:53:25.040271||event||progress-marker||measurement-end||2||1
+2015-12-02 00:53:26.831057||measurement||loadtime||0:00:28.588960||5||1
+2015-12-02 00:53:26.831193||event||progress-marker||measurement-end||5||1
+2015-12-02 00:53:33.591136||measurement||price||2015-12-02 00:53:14.452371@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||1||1
+2015-12-02 00:53:40.787727||measurement||loadtime||0:00:29.466683||1||1
+2015-12-02 00:53:40.787862||event||progress-marker||measurement-end||1||1
+2015-12-02 00:53:41.354964||meta||block_id end||16
+2015-12-02 00:53:41.355306||meta||block_id start||17
+2015-12-02 00:53:41.355334||meta||assignment||3@|0@|2@|5@|1@|4
+2015-12-02 00:53:42.957897||event||progress-marker||training-start||0||0
+2015-12-02 00:53:43.016028||event||progress-marker||training-start||2||0
+2015-12-02 00:53:43.067465||event||progress-marker||training-start||3||0
+2015-12-02 00:53:49.724860||treatment||visit website||http://irs.gov||0||0
+2015-12-02 00:53:49.858517||treatment||visit website||http://irs.gov||2||0
+2015-12-02 00:53:49.908153||treatment||visit website||http://irs.gov||3||0
+2015-12-02 00:53:56.941551||treatment||visit website||http://deloitte.com||0||0
+2015-12-02 00:53:56.944387||treatment||visit website||http://deloitte.com||3||0
+2015-12-02 00:53:56.968422||treatment||visit website||http://deloitte.com||2||0
+2015-12-02 00:54:04.863129||treatment||visit website||http://pwc.com||0||0
+2015-12-02 00:54:06.177523||treatment||visit website||http://pwc.com||2||0
+2015-12-02 00:54:09.255363||treatment||visit website||http://pwc.com||3||0
+2015-12-02 00:54:10.677265||treatment||visit website||http://ey.com||0||0
+2015-12-02 00:54:11.977659||treatment||visit website||http://ey.com||2||0
+2015-12-02 00:54:15.156048||treatment||visit website||http://ey.com||3||0
+2015-12-02 00:54:17.461419||treatment||visit website||http://kpmg.com||0||0
+2015-12-02 00:54:17.461554||event||progress-marker||training-end||0||0
+2015-12-02 00:54:18.383042||treatment||visit website||http://kpmg.com||2||0
+2015-12-02 00:54:18.383167||event||progress-marker||training-end||2||0
+2015-12-02 00:54:21.665568||treatment||visit website||http://kpmg.com||3||0
+2015-12-02 00:54:21.665723||event||progress-marker||training-end||3||0
+2015-12-02 00:54:22.517567||event||progress-marker||measurement-start||0||0
+2015-12-02 00:54:23.426762||event||progress-marker||measurement-start||2||0
+2015-12-02 00:54:26.712497||event||progress-marker||measurement-start||3||0
+2015-12-02 00:54:36.428703||measurement||price||2015-12-02 00:54:30.415177@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 00:54:37.680527||measurement||price||2015-12-02 00:54:31.867066@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 00:54:39.654869||measurement||price||2015-12-02 00:54:34.217759@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-02 00:54:48.764964||measurement||price||2015-12-02 00:54:30.415177@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 00:54:50.041104||measurement||price||2015-12-02 00:54:31.867066@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 00:54:52.027373||measurement||price||2015-12-02 00:54:34.217759@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-02 00:54:55.855150||measurement||loadtime||0:00:28.332373||0||0
+2015-12-02 00:54:57.144093||measurement||loadtime||0:00:28.715017||2||0
+2015-12-02 00:54:59.138769||measurement||loadtime||0:00:27.421728||3||0
+2015-12-02 00:55:08.673403||measurement||price||2015-12-02 00:55:02.806051@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 00:55:09.504685||measurement||price||2015-12-02 00:55:03.734243@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||0
+2015-12-02 00:55:11.703224||measurement||price||2015-12-02 00:55:06.330818@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 00:55:17.888735||event||progress-marker||training-start||5||1
+2015-12-02 00:55:20.954697||measurement||price||2015-12-02 00:55:02.806051@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 00:55:21.790098||measurement||price||2015-12-02 00:55:03.734243@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||0
+2015-12-02 00:55:24.031176||measurement||price||2015-12-02 00:55:06.330818@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 00:55:24.314267||treatment||visit website||http://irs.gov||5||1
+2015-12-02 00:55:28.036038||measurement||loadtime||0:00:27.176900||0||0
+2015-12-02 00:55:28.867941||measurement||loadtime||0:00:26.720806||2||0
+2015-12-02 00:55:31.139140||measurement||loadtime||0:00:26.995997||3||0
+2015-12-02 00:55:31.199086||treatment||visit website||http://deloitte.com||5||1
+2015-12-02 00:55:40.020120||treatment||visit website||http://pwc.com||5||1
+2015-12-02 00:55:40.355372||measurement||price||2015-12-02 00:55:34.695776@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 00:55:41.168706||measurement||price||2015-12-02 00:55:35.540355@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 00:55:44.356509||measurement||price||2015-12-02 00:55:38.617990@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||0
+2015-12-02 00:55:45.964891||treatment||visit website||http://ey.com||5||1
+2015-12-02 00:55:52.690794||measurement||price||2015-12-02 00:55:34.695776@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 00:55:52.912163||treatment||visit website||http://kpmg.com||5||1
+2015-12-02 00:55:52.912311||event||progress-marker||training-end||5||1
+2015-12-02 00:55:53.493234||measurement||price||2015-12-02 00:55:35.540355@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 00:55:56.691319||measurement||price||2015-12-02 00:55:38.617990@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||0
+2015-12-02 00:55:57.967953||event||progress-marker||measurement-start||5||1
+2015-12-02 00:55:59.803614||measurement||loadtime||0:00:26.764483||0||0
+2015-12-02 00:56:00.605576||measurement||loadtime||0:00:26.732450||2||0
+2015-12-02 00:56:03.779146||measurement||loadtime||0:00:27.636013||3||0
+2015-12-02 00:56:12.092029||measurement||price||2015-12-02 00:56:06.452848@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:56:12.535662||measurement||price||2015-12-02 00:56:05.879579@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 00:56:12.989756||measurement||price||2015-12-02 00:56:07.296662@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||0
+2015-12-02 00:56:16.255878||measurement||price||2015-12-02 00:56:10.884238@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:56:18.099894||event||progress-marker||training-start||4||1
+2015-12-02 00:56:18.100195||event||progress-marker||training-start||1||1
+2015-12-02 00:56:24.382786||measurement||price||2015-12-02 00:56:06.452848@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:56:24.553953||treatment||visit website||http://irs.gov||1||1
+2015-12-02 00:56:24.563112||treatment||visit website||http://irs.gov||4||1
+2015-12-02 00:56:25.314153||measurement||price||2015-12-02 00:56:07.296662@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||0
+2015-12-02 00:56:25.420814||measurement||price||2015-12-02 00:56:05.879579@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 00:56:28.539379||measurement||price||2015-12-02 00:56:10.884238@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:56:31.468728||measurement||loadtime||0:00:26.659916||0||0
+2015-12-02 00:56:31.474262||treatment||visit website||http://deloitte.com||1||1
+2015-12-02 00:56:31.495400||treatment||visit website||http://deloitte.com||4||1
+2015-12-02 00:56:32.429794||measurement||loadtime||0:00:26.820733||2||0
+2015-12-02 00:56:32.656220||measurement||loadtime||0:00:29.683169||5||1
+2015-12-02 00:56:35.623006||measurement||loadtime||0:00:26.839883||3||0
+2015-12-02 00:56:40.188358||treatment||visit website||http://pwc.com||1||1
+2015-12-02 00:56:40.270983||treatment||visit website||http://pwc.com||4||1
+2015-12-02 00:56:44.353766||measurement||price||2015-12-02 00:56:38.397388@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:56:44.934008||measurement||price||2015-12-02 00:56:39.166834@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-02 00:56:47.320587||treatment||visit website||http://ey.com||1||1
+2015-12-02 00:56:48.379936||treatment||visit website||http://ey.com||4||1
+2015-12-02 00:56:49.348937||measurement||price||2015-12-02 00:56:43.942390@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:56:54.976992||treatment||visit website||http://kpmg.com||4||1
+2015-12-02 00:56:54.977095||event||progress-marker||training-end||4||1
+2015-12-02 00:56:56.712261||measurement||price||2015-12-02 00:56:38.397388@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:56:57.294260||measurement||price||2015-12-02 00:56:39.166834@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-02 00:56:59.770265||error||collecting ads||Error||5||1
+2015-12-02 00:57:01.665600||measurement||price||2015-12-02 00:56:43.942390@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:57:03.819799||measurement||loadtime||0:00:27.345860||0||0
+2015-12-02 00:57:04.187126||treatment||visit website||http://kpmg.com||1||1
+2015-12-02 00:57:04.187255||event||progress-marker||training-end||1||1
+2015-12-02 00:57:04.397018||measurement||loadtime||0:00:26.962689||2||0
+2015-12-02 00:57:05.058037||event||progress-marker||measurement-start||4||1
+2015-12-02 00:57:08.772777||measurement||loadtime||0:00:28.145616||3||0
+2015-12-02 00:57:09.233475||event||progress-marker||measurement-start||1||1
+2015-12-02 00:57:13.882968||measurement||price||2015-12-02 00:57:07.068297@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 00:57:16.291883||measurement||price||2015-12-02 00:57:10.686624@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:57:16.768308||measurement||price||2015-12-02 00:57:11.078826@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||0
+2015-12-02 00:57:19.471326||measurement||price||2015-12-02 00:57:13.246237@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||4||1
+2015-12-02 00:57:21.912474||measurement||price||2015-12-02 00:57:16.230143@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 00:57:23.627711||measurement||price||2015-12-02 00:57:17.447334@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 00:57:26.743137||measurement||price||2015-12-02 00:57:07.068297@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 00:57:28.627160||measurement||price||2015-12-02 00:57:10.686624@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:57:29.074416||measurement||price||2015-12-02 00:57:11.078826@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||0
+2015-12-02 00:57:32.285486||measurement||price||2015-12-02 00:57:13.246237@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||4||1
+2015-12-02 00:57:33.956345||measurement||loadtime||0:00:29.180864||5||1
+2015-12-02 00:57:34.251328||measurement||price||2015-12-02 00:57:16.230143@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 00:57:35.735473||measurement||loadtime||0:00:26.910476||0||0
+2015-12-02 00:57:36.159414||measurement||loadtime||0:00:26.757579||2||0
+2015-12-02 00:57:36.402876||measurement||price||2015-12-02 00:57:17.447334@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 00:57:39.499165||measurement||loadtime||0:00:29.435942||4||1
+2015-12-02 00:57:41.365393||measurement||loadtime||0:00:27.587429||3||0
+2015-12-02 00:57:43.619224||measurement||loadtime||0:00:29.380522||1||1
+2015-12-02 00:57:47.512232||measurement||price||2015-12-02 00:57:41.182473@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||1
+2015-12-02 00:57:48.700065||measurement||price||2015-12-02 00:57:42.816548@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 00:57:48.989062||measurement||price||2015-12-02 00:57:42.957791@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 00:57:53.154992||measurement||price||2015-12-02 00:57:46.981920@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 00:57:57.348104||measurement||price||2015-12-02 00:57:51.194220@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 00:58:00.337670||measurement||price||2015-12-02 00:57:41.182473@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||1
+2015-12-02 00:58:01.078357||measurement||price||2015-12-02 00:57:42.816548@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 00:58:01.291379||measurement||price||2015-12-02 00:57:42.957791@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 00:58:04.231005||error||collecting ads||Error||3||0
+2015-12-02 00:58:05.995459||measurement||price||2015-12-02 00:57:46.981920@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 00:58:07.531454||measurement||loadtime||0:00:28.569905||5||1
+2015-12-02 00:58:08.198763||measurement||loadtime||0:00:27.458089||0||0
+2015-12-02 00:58:08.380870||measurement||loadtime||0:00:27.217713||2||0
+2015-12-02 00:58:10.230398||measurement||price||2015-12-02 00:57:51.194220@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 00:58:13.222462||measurement||loadtime||0:00:28.719339||4||1
+2015-12-02 00:58:16.810522||measurement||price||2015-12-02 00:58:11.407248@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 00:58:17.433768||measurement||loadtime||0:00:28.810636||1||1
+2015-12-02 00:58:20.601552||measurement||price||2015-12-02 00:58:14.961923@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:58:21.657699||measurement||price||2015-12-02 00:58:15.880132@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||2||0
+2015-12-02 00:58:27.055734||measurement||price||2015-12-02 00:58:21.080311@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 00:58:29.157187||measurement||price||2015-12-02 00:58:11.407248@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 00:58:31.112733||measurement||price||2015-12-02 00:58:24.984801@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 00:58:31.473942||error||collecting ads||Error||5||1
+2015-12-02 00:58:32.927300||measurement||price||2015-12-02 00:58:14.961923@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:58:34.013905||measurement||price||2015-12-02 00:58:15.880132@|Electronic Arts@| $59.00   @|Star Wars: Battlefront - Standard Edition - Xbox One||2||0
+2015-12-02 00:58:36.266386||measurement||loadtime||0:00:27.030145||3||0
+2015-12-02 00:58:39.942389||measurement||price||2015-12-02 00:58:21.080311@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 00:58:40.039444||measurement||loadtime||0:00:26.836310||0||0
+2015-12-02 00:58:41.106667||measurement||loadtime||0:00:27.722685||2||0
+2015-12-02 00:58:44.039597||measurement||price||2015-12-02 00:58:24.984801@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 00:58:47.150060||measurement||loadtime||0:00:28.922373||4||1
+2015-12-02 00:58:49.579605||measurement||price||2015-12-02 00:58:44.256846@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 00:58:51.238321||measurement||loadtime||0:00:28.799344||1||1
+2015-12-02 00:58:53.066236||measurement||price||2015-12-02 00:58:47.399061@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||0||0
+2015-12-02 00:58:53.896905||measurement||price||2015-12-02 00:58:48.538080@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||0
+2015-12-02 00:58:55.579235||error||collecting ads||Error||5||1
+2015-12-02 00:59:01.908950||measurement||price||2015-12-02 00:58:44.256846@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 00:59:05.371111||measurement||price||2015-12-02 00:58:47.399061@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||0||0
+2015-12-02 00:59:05.430319||measurement||price||2015-12-02 00:58:59.319364@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||1
+2015-12-02 00:59:06.225596||measurement||price||2015-12-02 00:58:48.538080@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||0
+2015-12-02 00:59:09.003584||measurement||loadtime||0:00:27.731986||3||0
+2015-12-02 00:59:09.379141||measurement||price||2015-12-02 00:59:02.830547@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 00:59:10.967548||error||collecting ads||Error||4||1
+2015-12-02 00:59:12.448291||measurement||loadtime||0:00:27.405144||0||0
+2015-12-02 00:59:13.315124||measurement||loadtime||0:00:27.205411||2||0
+2015-12-02 00:59:18.453301||measurement||price||2015-12-02 00:58:59.319364@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||1
+2015-12-02 00:59:22.234912||measurement||price||2015-12-02 00:59:02.830547@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 00:59:22.244244||measurement||price||2015-12-02 00:59:16.593681@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 00:59:24.711063||measurement||price||2015-12-02 00:59:19.084073@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 00:59:24.835821||measurement||price||2015-12-02 00:59:18.578779@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 00:59:25.518264||measurement||price||2015-12-02 00:59:19.923352@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-02 00:59:25.714444||measurement||loadtime||0:00:29.470912||1||1
+2015-12-02 00:59:29.436648||measurement||loadtime||0:00:28.852188||5||1
+2015-12-02 00:59:34.528933||measurement||price||2015-12-02 00:59:16.593681@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 00:59:36.975954||measurement||price||2015-12-02 00:59:19.084073@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 00:59:37.804084||measurement||price||2015-12-02 00:59:19.923352@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-02 00:59:37.840590||measurement||price||2015-12-02 00:59:18.578779@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 00:59:39.435758||measurement||price||2015-12-02 00:59:33.359649@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 00:59:41.614891||measurement||loadtime||0:00:27.608779||3||0
+2015-12-02 00:59:43.179791||measurement||price||2015-12-02 00:59:36.657992@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 00:59:44.060719||measurement||loadtime||0:00:26.609583||0||0
+2015-12-02 00:59:44.883135||measurement||loadtime||0:00:26.564003||2||0
+2015-12-02 00:59:45.077641||measurement||loadtime||0:00:29.106505||4||1
+2015-12-02 00:59:52.442273||measurement||price||2015-12-02 00:59:33.359649@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 00:59:54.082161||measurement||price||2015-12-02 00:59:48.755837@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||3||0
+2015-12-02 00:59:56.219738||measurement||price||2015-12-02 00:59:36.657992@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 00:59:57.256408||measurement||price||2015-12-02 00:59:51.576750@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||0
+2015-12-02 00:59:59.723621||measurement||loadtime||0:00:29.003956||1||1
+2015-12-02 00:59:59.745105||measurement||price||2015-12-02 00:59:53.409384@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:00:03.415158||measurement||loadtime||0:00:28.976521||5||1
+2015-12-02 01:00:06.376302||measurement||price||2015-12-02 00:59:48.755837@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||3||0
+2015-12-02 01:00:07.096628||error||collecting ads||Error||0||0
+2015-12-02 01:00:09.603860||measurement||price||2015-12-02 00:59:51.576750@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||0
+2015-12-02 01:00:12.730942||measurement||price||2015-12-02 00:59:53.409384@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:00:13.249875||measurement||price||2015-12-02 01:00:07.199972@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 01:00:13.459166||measurement||loadtime||0:00:26.839050||3||0
+2015-12-02 01:00:16.720211||measurement||loadtime||0:00:26.833060||2||0
+2015-12-02 01:00:17.188359||measurement||price||2015-12-02 01:00:10.721057@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||1
+2015-12-02 01:00:19.418650||measurement||price||2015-12-02 01:00:13.746172@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 01:00:20.015183||measurement||loadtime||0:00:29.932426||4||1
+2015-12-02 01:00:26.162186||measurement||price||2015-12-02 01:00:20.739828@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:00:26.166507||measurement||price||2015-12-02 01:00:07.199972@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 01:00:29.099493||measurement||price||2015-12-02 01:00:23.519534@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||0
+2015-12-02 01:00:30.105909||measurement||price||2015-12-02 01:00:10.721057@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||1
+2015-12-02 01:00:31.753040||measurement||price||2015-12-02 01:00:13.746172@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 01:00:33.383188||measurement||loadtime||0:00:28.655999||1||1
+2015-12-02 01:00:33.692005||measurement||price||2015-12-02 01:00:27.638477@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 01:00:37.279157||measurement||loadtime||0:00:28.861214||5||1
+2015-12-02 01:00:38.493906||measurement||price||2015-12-02 01:00:20.739828@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:00:38.858687||measurement||loadtime||0:00:26.756835||0||0
+2015-12-02 01:00:41.422098||measurement||price||2015-12-02 01:00:23.519534@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||0
+2015-12-02 01:00:45.607977||measurement||loadtime||0:00:27.144489||3||0
+2015-12-02 01:00:46.519855||measurement||price||2015-12-02 01:00:27.638477@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 01:00:47.007049||measurement||price||2015-12-02 01:00:40.826328@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 01:00:48.538279||measurement||loadtime||0:00:26.812867||2||0
+2015-12-02 01:00:51.146104||measurement||price||2015-12-02 01:00:45.598045@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 01:00:53.740399||measurement||loadtime||0:00:28.721249||4||1
+2015-12-02 01:00:59.985033||measurement||price||2015-12-02 01:00:40.826328@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 01:01:00.867537||measurement||price||2015-12-02 01:00:55.188920@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 01:01:01.112878||error||collecting ads||Error||5||1
+2015-12-02 01:01:03.456128||measurement||price||2015-12-02 01:00:45.598045@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 01:01:07.221676||measurement||loadtime||0:00:28.833261||1||1
+2015-12-02 01:01:07.791793||measurement||price||2015-12-02 01:01:01.782703@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:01:08.350805||error||collecting ads||Error||3||0
+2015-12-02 01:01:10.571945||measurement||loadtime||0:00:26.708048||0||0
+2015-12-02 01:01:13.194936||measurement||price||2015-12-02 01:00:55.188920@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 01:01:15.553145||measurement||price||2015-12-02 01:01:08.944567@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||5||1
+2015-12-02 01:01:20.307142||measurement||loadtime||0:00:26.767426||2||0
+2015-12-02 01:01:20.694954||measurement||price||2015-12-02 01:01:01.782703@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:01:21.079202||measurement||price||2015-12-02 01:01:15.615129@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 01:01:21.228170||measurement||price||2015-12-02 01:01:15.018766@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:01:22.952818||measurement||price||2015-12-02 01:01:17.371737@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:01:27.907141||measurement||loadtime||0:00:29.161532||4||1
+2015-12-02 01:01:28.444804||measurement||price||2015-12-02 01:01:08.944567@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||5||1
+2015-12-02 01:01:33.411447||measurement||price||2015-12-02 01:01:15.615129@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 01:01:34.253600||measurement||price||2015-12-02 01:01:15.018766@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:01:35.292688||measurement||price||2015-12-02 01:01:17.371737@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:01:35.659261||measurement||loadtime||0:00:29.542021||5||1
+2015-12-02 01:01:40.521807||measurement||loadtime||0:00:27.166652||3||0
+2015-12-02 01:01:41.489120||measurement||loadtime||0:00:29.262263||1||1
+2015-12-02 01:01:42.398986||measurement||loadtime||0:00:26.823836||0||0
+2015-12-02 01:01:42.513611||error||collecting ads||Error||2||0
+2015-12-02 01:01:49.678450||measurement||price||2015-12-02 01:01:42.918851@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-02 01:01:51.462121||error||collecting ads||Error||4||1
+2015-12-02 01:01:55.073310||measurement||price||2015-12-02 01:01:49.136288@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 01:01:55.791978||measurement||price||2015-12-02 01:01:50.015417@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||0
+2015-12-02 01:01:56.695414||measurement||price||2015-12-02 01:01:50.199483@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 01:02:02.573959||measurement||price||2015-12-02 01:01:42.918851@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-02 01:02:03.657230||error||collecting ads||Error||3||0
+2015-12-02 01:02:05.507702||measurement||price||2015-12-02 01:01:59.438690@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 01:02:07.374222||measurement||price||2015-12-02 01:01:49.136288@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 01:02:08.127247||measurement||price||2015-12-02 01:01:50.015417@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||0
+2015-12-02 01:02:09.721632||measurement||price||2015-12-02 01:01:50.199483@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 01:02:09.789115||measurement||loadtime||0:00:29.124644||5||1
+2015-12-02 01:02:14.466016||measurement||loadtime||0:00:27.061787||0||0
+2015-12-02 01:02:15.221540||measurement||loadtime||0:00:27.706378||2||0
+2015-12-02 01:02:16.198725||measurement||price||2015-12-02 01:02:10.769525@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||0
+2015-12-02 01:02:16.964603||measurement||loadtime||0:00:30.470501||1||1
+2015-12-02 01:02:18.488734||measurement||price||2015-12-02 01:01:59.438690@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 01:02:23.511786||measurement||price||2015-12-02 01:02:17.060102@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 01:02:25.776923||measurement||loadtime||0:00:29.312719||4||1
+2015-12-02 01:02:27.547288||measurement||price||2015-12-02 01:02:21.913775@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-02 01:02:28.521121||measurement||price||2015-12-02 01:02:10.769525@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||0
+2015-12-02 01:02:30.634665||measurement||price||2015-12-02 01:02:24.599398@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:02:35.613343||measurement||loadtime||0:00:26.954197||3||0
+2015-12-02 01:02:36.458952||measurement||price||2015-12-02 01:02:17.060102@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 01:02:36.837369||error||collecting ads||Error||0||0
+2015-12-02 01:02:39.278333||measurement||price||2015-12-02 01:02:33.336073@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 01:02:39.891606||measurement||price||2015-12-02 01:02:21.913775@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-02 01:02:43.431618||measurement||price||2015-12-02 01:02:24.599398@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:02:43.656507||measurement||loadtime||0:00:28.862199||5||1
+2015-12-02 01:02:46.978457||measurement||loadtime||0:00:26.751693||2||0
+2015-12-02 01:02:48.240951||measurement||price||2015-12-02 01:02:42.830278@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 01:02:49.247753||measurement||price||2015-12-02 01:02:43.515771@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 01:02:50.664668||measurement||loadtime||0:00:28.694900||1||1
+2015-12-02 01:02:52.080397||measurement||price||2015-12-02 01:02:33.336073@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 01:02:59.234788||measurement||price||2015-12-02 01:02:53.644250@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||0
+2015-12-02 01:02:59.315165||measurement||loadtime||0:00:28.536021||4||1
+2015-12-02 01:03:00.574588||measurement||price||2015-12-02 01:02:42.830278@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 01:03:01.585724||measurement||price||2015-12-02 01:02:43.515771@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 01:03:04.377294||measurement||price||2015-12-02 01:02:58.231320@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||1||1
+2015-12-02 01:03:07.253984||error||collecting ads||Error||5||1
+2015-12-02 01:03:07.683512||measurement||loadtime||0:00:27.064945||3||0
+2015-12-02 01:03:08.683011||measurement||loadtime||0:00:26.843160||0||0
+2015-12-02 01:03:11.569859||measurement||price||2015-12-02 01:02:53.644250@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||0
+2015-12-02 01:03:13.000002||measurement||price||2015-12-02 01:03:06.940357@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||4||1
+2015-12-02 01:03:17.193381||measurement||price||2015-12-02 01:02:58.231320@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||1||1
+2015-12-02 01:03:18.643146||measurement||loadtime||0:00:26.659463||2||0
+2015-12-02 01:03:20.344146||measurement||price||2015-12-02 01:03:14.974097@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||3||0
+2015-12-02 01:03:21.566057||measurement||price||2015-12-02 01:03:15.963533@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:03:21.605835||measurement||price||2015-12-02 01:03:14.756938@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 01:03:24.423151||measurement||loadtime||0:00:28.755807||1||1
+2015-12-02 01:03:25.845023||measurement||price||2015-12-02 01:03:06.940357@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||4||1
+2015-12-02 01:03:30.863427||measurement||price||2015-12-02 01:03:25.300469@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 01:03:32.645060||measurement||price||2015-12-02 01:03:14.974097@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||3||0
+2015-12-02 01:03:33.057289||measurement||loadtime||0:00:28.736893||4||1
+2015-12-02 01:03:33.841055||measurement||price||2015-12-02 01:03:15.963533@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:03:34.472970||measurement||price||2015-12-02 01:03:14.756938@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 01:03:38.089638||measurement||price||2015-12-02 01:03:31.960912@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 01:03:39.733133||measurement||loadtime||0:00:27.045998||3||0
+2015-12-02 01:03:40.919158||measurement||loadtime||0:00:27.230952||0||0
+2015-12-02 01:03:41.688994||measurement||loadtime||0:00:29.429733||5||1
+2015-12-02 01:03:43.177366||measurement||price||2015-12-02 01:03:25.300469@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 01:03:46.715313||measurement||price||2015-12-02 01:03:40.622755@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 01:03:50.279143||measurement||loadtime||0:00:26.630829||2||0
+2015-12-02 01:03:50.883695||measurement||price||2015-12-02 01:03:31.960912@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 01:03:52.527904||measurement||price||2015-12-02 01:03:47.048856@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||0
+2015-12-02 01:03:53.935162||measurement||price||2015-12-02 01:03:48.325789@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 01:03:55.805490||measurement||price||2015-12-02 01:03:49.091352@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 01:03:58.079148||measurement||loadtime||0:00:28.650786||1||1
+2015-12-02 01:03:59.532937||measurement||price||2015-12-02 01:03:40.622755@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 01:04:02.526709||measurement||price||2015-12-02 01:03:56.977929@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||0
+2015-12-02 01:04:04.868670||measurement||price||2015-12-02 01:03:47.048856@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||0
+2015-12-02 01:04:06.271251||measurement||price||2015-12-02 01:03:48.325789@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 01:04:06.743160||measurement||loadtime||0:00:28.680640||4||1
+2015-12-02 01:04:08.653897||measurement||price||2015-12-02 01:03:49.091352@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 01:04:11.677249||measurement||price||2015-12-02 01:04:05.530544@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||1
+2015-12-02 01:04:11.979158||measurement||loadtime||0:00:27.240837||3||0
+2015-12-02 01:04:13.364491||measurement||loadtime||0:00:27.440638||0||0
+2015-12-02 01:04:14.864764||measurement||price||2015-12-02 01:03:56.977929@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||0
+2015-12-02 01:04:15.852628||measurement||loadtime||0:00:29.159204||5||1
+2015-12-02 01:04:21.973509||measurement||loadtime||0:00:26.689166||2||0
+2015-12-02 01:04:24.463852||measurement||price||2015-12-02 01:04:05.530544@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||1
+2015-12-02 01:04:25.241144||measurement||price||2015-12-02 01:04:19.528545@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-02 01:04:25.751162||measurement||price||2015-12-02 01:04:20.071232@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 01:04:29.586222||measurement||price||2015-12-02 01:04:23.133149@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 01:04:30.377836||error||collecting ads||Error||4||1
+2015-12-02 01:04:31.701865||measurement||loadtime||0:00:28.617523||1||1
+2015-12-02 01:04:34.236286||measurement||price||2015-12-02 01:04:28.576871@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||0
+2015-12-02 01:04:37.625385||measurement||price||2015-12-02 01:04:19.528545@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-02 01:04:38.031750||measurement||price||2015-12-02 01:04:20.071232@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 01:04:42.536204||measurement||price||2015-12-02 01:04:23.133149@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 01:04:44.019380||measurement||price||2015-12-02 01:04:37.890577@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||1
+2015-12-02 01:04:44.744829||measurement||loadtime||0:00:27.760445||3||0
+2015-12-02 01:04:44.744956||event||progress-marker||measurement-end||3||0
+2015-12-02 01:04:45.116505||measurement||loadtime||0:00:26.746844||0||0
+2015-12-02 01:04:45.116598||event||progress-marker||measurement-end||0||0
+2015-12-02 01:04:45.579375||measurement||price||2015-12-02 01:04:39.520511@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:04:46.564475||measurement||price||2015-12-02 01:04:28.576871@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||0
+2015-12-02 01:04:49.715053||measurement||loadtime||0:00:28.857707||5||1
+2015-12-02 01:04:53.675291||measurement||loadtime||0:00:26.696590||2||0
+2015-12-02 01:04:53.675436||event||progress-marker||measurement-end||2||0
+2015-12-02 01:04:56.892560||measurement||price||2015-12-02 01:04:37.890577@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||1
+2015-12-02 01:04:58.446350||measurement||price||2015-12-02 01:04:39.520511@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:05:03.656828||measurement||price||2015-12-02 01:04:57.144410@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 01:05:04.079819||measurement||loadtime||0:00:28.700624||4||1
+2015-12-02 01:05:05.648348||measurement||loadtime||0:00:28.943273||1||1
+2015-12-02 01:05:16.605853||measurement||price||2015-12-02 01:04:57.144410@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 01:05:17.765494||measurement||price||2015-12-02 01:05:11.663606@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||4||1
+2015-12-02 01:05:19.301045||measurement||price||2015-12-02 01:05:13.214859@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||1||1
+2015-12-02 01:05:23.808833||measurement||loadtime||0:00:29.088577||5||1
+2015-12-02 01:05:30.541392||measurement||price||2015-12-02 01:05:11.663606@|Black  Decker@|$69.11@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||4||1
+2015-12-02 01:05:32.018068||measurement||price||2015-12-02 01:05:13.214859@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||1||1
+2015-12-02 01:05:37.483623||measurement||price||2015-12-02 01:05:31.015708@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 01:05:37.754899||measurement||loadtime||0:00:28.669842||4||1
+2015-12-02 01:05:39.229258||measurement||loadtime||0:00:28.578118||1||1
+2015-12-02 01:05:50.356890||measurement||price||2015-12-02 01:05:31.015708@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 01:05:52.036161||measurement||price||2015-12-02 01:05:45.908915@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:05:52.900157||measurement||price||2015-12-02 01:05:46.827416@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 01:05:57.540669||measurement||loadtime||0:00:28.726641||5||1
+2015-12-02 01:06:04.929463||measurement||price||2015-12-02 01:05:45.908915@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:06:05.759989||measurement||price||2015-12-02 01:05:46.827416@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 01:06:11.365545||measurement||price||2015-12-02 01:06:04.813293@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 01:06:12.200128||measurement||loadtime||0:00:29.440005||4||1
+2015-12-02 01:06:12.968918||measurement||loadtime||0:00:28.739434||1||1
+2015-12-02 01:06:24.329122||measurement||price||2015-12-02 01:06:04.813293@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 01:06:25.922885||measurement||price||2015-12-02 01:06:19.836280@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||1
+2015-12-02 01:06:26.505320||measurement||price||2015-12-02 01:06:20.519241@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:06:31.512456||measurement||loadtime||0:00:28.969348||5||1
+2015-12-02 01:06:31.512547||event||progress-marker||measurement-end||5||1
+2015-12-02 01:06:38.852272||measurement||price||2015-12-02 01:06:19.836280@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||1
+2015-12-02 01:06:39.337742||measurement||price||2015-12-02 01:06:20.519241@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:06:46.057146||measurement||loadtime||0:00:28.851800||4||1
+2015-12-02 01:06:46.567150||measurement||loadtime||0:00:28.594850||1||1
+2015-12-02 01:06:59.532119||measurement||price||2015-12-02 01:06:53.546858@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:07:00.634765||measurement||price||2015-12-02 01:06:54.462260@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 01:07:12.296529||measurement||price||2015-12-02 01:06:53.546858@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:07:13.411761||measurement||price||2015-12-02 01:06:54.462260@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 01:07:19.490362||measurement||loadtime||0:00:28.427965||4||1
+2015-12-02 01:07:20.630862||measurement||loadtime||0:00:29.059726||1||1
+2015-12-02 01:07:33.099008||measurement||price||2015-12-02 01:07:26.988303@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||1
+2015-12-02 01:07:34.372985||measurement||price||2015-12-02 01:07:28.175162@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:07:45.874332||measurement||price||2015-12-02 01:07:26.988303@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||1
+2015-12-02 01:07:47.158703||measurement||price||2015-12-02 01:07:28.175162@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:07:53.070379||measurement||loadtime||0:00:28.575237||4||1
+2015-12-02 01:07:53.070516||event||progress-marker||measurement-end||4||1
+2015-12-02 01:07:54.375825||measurement||loadtime||0:00:28.740647||1||1
+2015-12-02 01:08:17.974849||error||collecting ads||Error||1||1
+2015-12-02 01:08:17.974970||event||progress-marker||measurement-end||1||1
+2015-12-02 01:08:18.654143||meta||block_id end||17
+2015-12-02 01:08:18.654371||meta||block_id start||18
+2015-12-02 01:08:18.654389||meta||assignment||2@|0@|3@|1@|4@|5
+2015-12-02 01:08:20.293038||event||progress-marker||training-start||0||0
+2015-12-02 01:08:20.311497||event||progress-marker||training-start||2||0
+2015-12-02 01:08:20.383102||event||progress-marker||training-start||3||0
+2015-12-02 01:08:24.678159||event||progress-marker||training-start||5||1
+2015-12-02 01:08:27.072250||treatment||visit website||http://irs.gov||2||0
+2015-12-02 01:08:27.084848||treatment||visit website||http://irs.gov||3||0
+2015-12-02 01:08:27.109387||treatment||visit website||http://irs.gov||0||0
+2015-12-02 01:08:32.435949||treatment||visit website||http://irs.gov||5||1
+2015-12-02 01:08:34.425853||treatment||visit website||http://deloitte.com||3||0
+2015-12-02 01:08:34.428445||treatment||visit website||http://deloitte.com||2||0
+2015-12-02 01:08:34.435099||treatment||visit website||http://deloitte.com||0||0
+2015-12-02 01:08:38.831056||treatment||visit website||http://deloitte.com||5||1
+2015-12-02 01:08:42.329800||treatment||visit website||http://pwc.com||3||0
+2015-12-02 01:08:42.635100||treatment||visit website||http://pwc.com||0||0
+2015-12-02 01:08:42.667121||treatment||visit website||http://pwc.com||2||0
+2015-12-02 01:08:48.195130||treatment||visit website||http://ey.com||3||0
+2015-12-02 01:08:48.435512||treatment||visit website||http://ey.com||0||0
+2015-12-02 01:08:48.449650||treatment||visit website||http://ey.com||2||0
+2015-12-02 01:08:58.195074||treatment||visit website||http://kpmg.com||2||0
+2015-12-02 01:08:58.195225||event||progress-marker||training-end||2||0
+2015-12-02 01:08:58.339113||treatment||visit website||http://kpmg.com||3||0
+2015-12-02 01:08:58.339245||event||progress-marker||training-end||3||0
+2015-12-02 01:09:01.256521||treatment||visit website||http://kpmg.com||0||0
+2015-12-02 01:09:01.256666||event||progress-marker||training-end||0||0
+2015-12-02 01:09:01.895509||treatment||visit website||http://pwc.com||5||1
+2015-12-02 01:09:07.906494||treatment||visit website||http://ey.com||5||1
+2015-12-02 01:09:14.449735||treatment||visit website||http://kpmg.com||5||1
+2015-12-02 01:09:14.449840||event||progress-marker||training-end||5||1
+2015-12-02 01:09:16.366150||event||progress-marker||measurement-start||0||0
+2015-12-02 01:09:18.314423||event||progress-marker||measurement-start||2||0
+2015-12-02 01:09:18.474010||event||progress-marker||measurement-start||3||0
+2015-12-02 01:09:19.496021||event||progress-marker||measurement-start||5||1
+2015-12-02 01:09:29.286256||measurement||price||2015-12-02 01:09:23.834784@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:09:31.519823||measurement||price||2015-12-02 01:09:25.628285@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||0
+2015-12-02 01:09:32.169327||measurement||price||2015-12-02 01:09:26.385602@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||0
+2015-12-02 01:09:34.206675||measurement||price||2015-12-02 01:09:27.662924@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 01:09:41.638106||measurement||price||2015-12-02 01:09:23.834784@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:09:43.882038||measurement||price||2015-12-02 01:09:25.628285@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||0
+2015-12-02 01:09:44.521779||measurement||price||2015-12-02 01:09:26.385602@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||0
+2015-12-02 01:09:47.020097||measurement||price||2015-12-02 01:09:27.662924@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 01:09:48.744277||measurement||loadtime||0:00:27.375425||0||0
+2015-12-02 01:09:50.987160||measurement||loadtime||0:00:27.668030||2||0
+2015-12-02 01:09:51.628413||measurement||loadtime||0:00:28.149282||3||0
+2015-12-02 01:09:54.247186||measurement||loadtime||0:00:29.748057||5||1
+2015-12-02 01:10:02.731794||measurement||price||2015-12-02 01:09:56.417954@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:10:08.596959||measurement||price||2015-12-02 01:10:01.990921@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||1
+2015-12-02 01:10:13.333998||error||collecting ads||Error||2||0
+2015-12-02 01:10:14.270514||error||collecting ads||Error||3||0
+2015-12-02 01:10:15.086405||measurement||price||2015-12-02 01:09:56.417954@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:10:21.661216||measurement||price||2015-12-02 01:10:01.990921@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||1
+2015-12-02 01:10:22.175165||measurement||loadtime||0:00:28.426063||0||0
+2015-12-02 01:10:26.025852||measurement||price||2015-12-02 01:10:20.480647@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 01:10:26.937285||measurement||price||2015-12-02 01:10:21.539123@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 01:10:28.888978||measurement||loadtime||0:00:29.636623||5||1
+2015-12-02 01:10:34.682236||measurement||price||2015-12-02 01:10:29.323736@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 01:10:38.346288||measurement||price||2015-12-02 01:10:20.480647@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 01:10:39.257167||measurement||price||2015-12-02 01:10:21.539123@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 01:10:45.455143||measurement||loadtime||0:00:27.119215||2||0
+2015-12-02 01:10:46.361605||measurement||loadtime||0:00:27.085931||3||0
+2015-12-02 01:10:47.019977||measurement||price||2015-12-02 01:10:29.323736@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 01:10:52.861054||error||collecting ads||Error||5||1
+2015-12-02 01:10:54.131140||measurement||loadtime||0:00:26.950797||0||0
+2015-12-02 01:10:55.373454||event||progress-marker||training-start||4||1
+2015-12-02 01:10:59.503774||measurement||price||2015-12-02 01:10:54.155633@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:11:02.015502||treatment||visit website||http://irs.gov||4||1
+2015-12-02 01:11:06.591774||measurement||price||2015-12-02 01:11:00.248585@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 01:11:06.812496||measurement||price||2015-12-02 01:11:01.264808@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 01:11:07.712002||error||collecting ads||Error||2||0
+2015-12-02 01:11:08.564338||treatment||visit website||http://deloitte.com||4||1
+2015-12-02 01:11:10.112111||event||progress-marker||training-start||1||1
+2015-12-02 01:11:11.859523||measurement||price||2015-12-02 01:10:54.155633@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:11:16.552568||treatment||visit website||http://irs.gov||1||1
+2015-12-02 01:11:17.422170||treatment||visit website||http://pwc.com||4||1
+2015-12-02 01:11:18.968245||measurement||loadtime||0:00:27.605105||3||0
+2015-12-02 01:11:19.155362||measurement||price||2015-12-02 01:11:01.264808@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 01:11:19.468891||measurement||price||2015-12-02 01:11:00.248585@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 01:11:20.001945||measurement||price||2015-12-02 01:11:14.362835@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 01:11:22.903531||treatment||visit website||http://deloitte.com||1||1
+2015-12-02 01:11:23.331310||treatment||visit website||http://ey.com||4||1
+2015-12-02 01:11:26.271154||measurement||loadtime||0:00:27.134851||0||0
+2015-12-02 01:11:26.687130||measurement||loadtime||0:00:28.823419||5||1
+2015-12-02 01:11:31.451119||treatment||visit website||http://kpmg.com||4||1
+2015-12-02 01:11:31.451245||event||progress-marker||training-end||4||1
+2015-12-02 01:11:31.666148||measurement||price||2015-12-02 01:11:26.124459@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 01:11:31.691105||treatment||visit website||http://pwc.com||1||1
+2015-12-02 01:11:32.344006||measurement||price||2015-12-02 01:11:14.362835@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 01:11:37.839304||treatment||visit website||http://ey.com||1||1
+2015-12-02 01:11:38.890994||measurement||price||2015-12-02 01:11:33.497050@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:11:39.451704||measurement||loadtime||0:00:26.734469||2||0
+2015-12-02 01:11:40.788608||measurement||price||2015-12-02 01:11:34.085788@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 01:11:44.008595||measurement||price||2015-12-02 01:11:26.124459@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 01:11:44.203120||treatment||visit website||http://kpmg.com||1||1
+2015-12-02 01:11:44.203233||event||progress-marker||training-end||1||1
+2015-12-02 01:11:46.557397||event||progress-marker||measurement-start||4||1
+2015-12-02 01:11:49.251381||event||progress-marker||measurement-start||1||1
+2015-12-02 01:11:51.118306||measurement||loadtime||0:00:27.144831||3||0
+2015-12-02 01:11:51.228692||measurement||price||2015-12-02 01:11:33.497050@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:11:51.721335||measurement||price||2015-12-02 01:11:46.130786@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||2||0
+2015-12-02 01:11:53.596122||measurement||price||2015-12-02 01:11:34.085788@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 01:11:58.340564||measurement||loadtime||0:00:27.064199||0||0
+2015-12-02 01:12:00.802737||measurement||loadtime||0:00:29.111467||5||1
+2015-12-02 01:12:04.032524||measurement||price||2015-12-02 01:11:46.130786@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||2||0
+2015-12-02 01:12:04.395138||measurement||price||2015-12-02 01:11:58.229888@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:12:04.466798||measurement||price||2015-12-02 01:11:58.999261@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-02 01:12:10.996805||measurement||price||2015-12-02 01:12:05.521716@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:12:11.070748||error||collecting ads||Error||4||1
+2015-12-02 01:12:11.137851||measurement||loadtime||0:00:26.680939||2||0
+2015-12-02 01:12:15.003486||measurement||price||2015-12-02 01:12:08.575176@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 01:12:16.779625||measurement||price||2015-12-02 01:11:58.999261@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-02 01:12:17.351310||measurement||price||2015-12-02 01:11:58.229888@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:12:23.291104||measurement||price||2015-12-02 01:12:05.521716@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:12:23.400043||measurement||price||2015-12-02 01:12:17.768481@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-02 01:12:23.872452||measurement||loadtime||0:00:27.748955||3||0
+2015-12-02 01:12:24.542873||measurement||loadtime||0:00:30.287055||1||1
+2015-12-02 01:12:25.202650||measurement||price||2015-12-02 01:12:18.906942@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 01:12:28.007295||measurement||price||2015-12-02 01:12:08.575176@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 01:12:30.383135||measurement||loadtime||0:00:27.037336||0||0
+2015-12-02 01:12:35.210219||measurement||loadtime||0:00:29.403080||5||1
+2015-12-02 01:12:35.754721||measurement||price||2015-12-02 01:12:17.768481@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-02 01:12:36.438072||measurement||price||2015-12-02 01:12:30.968755@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 01:12:38.049879||measurement||price||2015-12-02 01:12:18.906942@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 01:12:38.581837||measurement||price||2015-12-02 01:12:32.197726@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 01:12:42.871152||measurement||loadtime||0:00:26.731541||2||0
+2015-12-02 01:12:45.268380||measurement||loadtime||0:00:29.194751||4||1
+2015-12-02 01:12:48.767556||measurement||price||2015-12-02 01:12:30.968755@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 01:12:49.125707||measurement||price||2015-12-02 01:12:42.452985@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 01:12:51.471710||measurement||price||2015-12-02 01:12:32.197726@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 01:12:52.909226||error||collecting ads||Error||0||0
+2015-12-02 01:12:55.504807||measurement||price||2015-12-02 01:12:49.920921@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-02 01:12:55.889032||measurement||loadtime||0:00:27.011389||3||0
+2015-12-02 01:12:58.689599||measurement||loadtime||0:00:29.141541||1||1
+2015-12-02 01:12:59.496174||measurement||price||2015-12-02 01:12:53.062378@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:13:01.965904||measurement||price||2015-12-02 01:12:42.452985@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 01:13:05.816847||measurement||price||2015-12-02 01:13:00.315909@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||0||0
+2015-12-02 01:13:07.851719||measurement||price||2015-12-02 01:12:49.920921@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-02 01:13:09.198822||measurement||loadtime||0:00:28.987662||5||1
+2015-12-02 01:13:12.372905||measurement||price||2015-12-02 01:12:53.062378@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:13:12.505200||measurement||price||2015-12-02 01:13:06.320214@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 01:13:14.964720||measurement||loadtime||0:00:27.088562||2||0
+2015-12-02 01:13:18.130219||measurement||price||2015-12-02 01:13:00.315909@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-02 01:13:18.558758||error||collecting ads||Error||3||0
+2015-12-02 01:13:19.571849||measurement||loadtime||0:00:29.298264||4||1
+2015-12-02 01:13:25.241891||measurement||loadtime||0:00:27.330814||0||0
+2015-12-02 01:13:25.379941||measurement||price||2015-12-02 01:13:06.320214@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 01:13:27.119484||measurement||price||2015-12-02 01:13:21.667596@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 01:13:31.769763||measurement||price||2015-12-02 01:13:26.279726@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:13:32.599212||measurement||loadtime||0:00:28.904441||1||1
+2015-12-02 01:13:33.636096||error||collecting ads||Error||5||1
+2015-12-02 01:13:33.771263||measurement||price||2015-12-02 01:13:27.686894@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 01:13:38.333275||measurement||price||2015-12-02 01:13:32.802332@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 01:13:39.470914||measurement||price||2015-12-02 01:13:21.667596@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 01:13:44.087396||measurement||price||2015-12-02 01:13:26.279726@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:13:46.570830||measurement||price||2015-12-02 01:13:40.337140@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 01:13:46.591120||measurement||loadtime||0:00:26.624004||2||0
+2015-12-02 01:13:46.691553||measurement||price||2015-12-02 01:13:27.686894@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 01:13:47.918257||measurement||price||2015-12-02 01:13:40.921857@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 01:13:50.661578||measurement||price||2015-12-02 01:13:32.802332@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 01:13:51.179504||measurement||loadtime||0:00:27.616344||3||0
+2015-12-02 01:13:53.905371||measurement||loadtime||0:00:29.330236||4||1
+2015-12-02 01:13:57.754829||measurement||loadtime||0:00:27.508112||0||0
+2015-12-02 01:13:58.804564||measurement||price||2015-12-02 01:13:53.242243@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-02 01:13:59.427840||measurement||price||2015-12-02 01:13:40.337140@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 01:14:00.945422||measurement||price||2015-12-02 01:13:40.921857@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 01:14:06.629208||measurement||loadtime||0:00:29.026073||1||1
+2015-12-02 01:14:07.655839||measurement||price||2015-12-02 01:14:01.616762@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 01:14:08.307199||measurement||loadtime||0:00:29.666133||5||1
+2015-12-02 01:14:10.108160||measurement||price||2015-12-02 01:14:04.756900@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 01:14:11.111763||measurement||price||2015-12-02 01:13:53.242243@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-02 01:14:13.544910||error||collecting ads||Error||3||0
+2015-12-02 01:14:18.222263||measurement||loadtime||0:00:26.625966||2||0
+2015-12-02 01:14:20.410619||measurement||price||2015-12-02 01:14:14.244651@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 01:14:20.656521||measurement||price||2015-12-02 01:14:01.616762@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 01:14:22.238008||measurement||price||2015-12-02 01:14:15.657259@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-02 01:14:22.398483||measurement||price||2015-12-02 01:14:04.756900@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 01:14:26.299886||measurement||price||2015-12-02 01:14:20.702848@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 01:14:27.867906||measurement||loadtime||0:00:28.960777||4||1
+2015-12-02 01:14:29.483103||measurement||loadtime||0:00:26.723074||0||0
+2015-12-02 01:14:30.855108||measurement||price||2015-12-02 01:14:25.038862@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 01:14:33.210486||measurement||price||2015-12-02 01:14:14.244651@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 01:14:35.171492||measurement||price||2015-12-02 01:14:15.657259@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-02 01:14:38.620791||measurement||price||2015-12-02 01:14:20.702848@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 01:14:40.427798||measurement||loadtime||0:00:28.796675||1||1
+2015-12-02 01:14:41.644117||measurement||price||2015-12-02 01:14:35.521668@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 01:14:42.411094||measurement||loadtime||0:00:29.099921||5||1
+2015-12-02 01:14:42.541020||measurement||price||2015-12-02 01:14:37.171014@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 01:14:43.191588||measurement||price||2015-12-02 01:14:25.038862@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 01:14:45.726330||measurement||loadtime||0:00:27.179210||3||0
+2015-12-02 01:14:50.301533||measurement||loadtime||0:00:27.079054||2||0
+2015-12-02 01:14:54.062624||measurement||price||2015-12-02 01:14:47.949149@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 01:14:54.532346||measurement||price||2015-12-02 01:14:35.521668@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 01:14:54.865030||measurement||price||2015-12-02 01:14:37.171014@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 01:14:57.033011||measurement||price||2015-12-02 01:14:50.819838@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||1
+2015-12-02 01:15:01.727166||measurement||loadtime||0:00:28.854070||4||1
+2015-12-02 01:15:01.977122||measurement||loadtime||0:00:27.489965||0||0
+2015-12-02 01:15:02.508162||measurement||price||2015-12-02 01:14:56.936337@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-02 01:15:06.932581||measurement||price||2015-12-02 01:14:47.949149@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 01:15:08.359983||error||collecting ads||Error||3||0
+2015-12-02 01:15:09.944228||measurement||price||2015-12-02 01:14:50.819838@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||1
+2015-12-02 01:15:14.166948||measurement||loadtime||0:00:28.735819||1||1
+2015-12-02 01:15:14.549154||measurement||price||2015-12-02 01:15:09.134196@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 01:15:14.842040||measurement||price||2015-12-02 01:14:56.936337@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-02 01:15:15.727570||measurement||price||2015-12-02 01:15:09.564156@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-02 01:15:17.180370||measurement||loadtime||0:00:29.764054||5||1
+2015-12-02 01:15:21.175317||measurement||price||2015-12-02 01:15:15.760185@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||3||0
+2015-12-02 01:15:21.959448||measurement||loadtime||0:00:26.652750||2||0
+2015-12-02 01:15:26.868477||measurement||price||2015-12-02 01:15:09.134196@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 01:15:28.026325||measurement||price||2015-12-02 01:15:21.879910@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:15:28.623951||measurement||price||2015-12-02 01:15:09.564156@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-02 01:15:31.510951||measurement||price||2015-12-02 01:15:24.607244@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-02 01:15:33.512702||measurement||price||2015-12-02 01:15:15.760185@|Electronic Arts@| $58.93   @|Star Wars: Battlefront - Standard Edition - Xbox One||3||0
+2015-12-02 01:15:33.975646||measurement||loadtime||0:00:26.996479||0||0
+2015-12-02 01:15:34.529741||measurement||price||2015-12-02 01:15:28.790625@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 01:15:35.819167||measurement||loadtime||0:00:29.086812||4||1
+2015-12-02 01:15:40.627155||measurement||loadtime||0:00:27.261966||3||0
+2015-12-02 01:15:40.850518||measurement||price||2015-12-02 01:15:21.879910@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:15:44.651239||measurement||price||2015-12-02 01:15:24.607244@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-02 01:15:46.823582||measurement||price||2015-12-02 01:15:28.790625@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 01:15:47.216943||measurement||price||2015-12-02 01:15:41.609090@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 01:15:48.045034||measurement||loadtime||0:00:28.872889||1||1
+2015-12-02 01:15:49.726810||measurement||price||2015-12-02 01:15:43.595506@|@|$118.00@|BLU Studio 7.0 II -Unlocked Smartphone - US GSM - Gold||4||1
+2015-12-02 01:15:51.891940||measurement||loadtime||0:00:29.707774||5||1
+2015-12-02 01:15:53.107501||measurement||price||2015-12-02 01:15:47.736875@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-02 01:15:53.907248||measurement||loadtime||0:00:26.944116||2||0
+2015-12-02 01:15:59.541890||measurement||price||2015-12-02 01:15:41.609090@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 01:16:01.856380||measurement||price||2015-12-02 01:15:55.733348@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:16:02.667355||measurement||price||2015-12-02 01:15:43.595506@|@|$199.00@|BLU Vivo Air LTE Smartphone - GSM Unlocked - Black||4||1
+2015-12-02 01:16:05.436553||measurement||price||2015-12-02 01:15:47.736875@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-02 01:16:05.968643||measurement||price||2015-12-02 01:15:59.322599@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||5||1
+2015-12-02 01:16:06.630019||measurement||loadtime||0:00:27.649645||0||0
+2015-12-02 01:16:06.840383||measurement||price||2015-12-02 01:16:01.036618@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 01:16:09.847175||measurement||loadtime||0:00:29.024028||4||1
+2015-12-02 01:16:12.543164||measurement||loadtime||0:00:26.915063||3||0
+2015-12-02 01:16:14.737583||measurement||price||2015-12-02 01:15:55.733348@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:16:18.820322||measurement||price||2015-12-02 01:15:59.322599@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||5||1
+2015-12-02 01:16:19.181420||measurement||price||2015-12-02 01:16:01.036618@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 01:16:21.935986||measurement||loadtime||0:00:28.885770||1||1
+2015-12-02 01:16:25.131719||measurement||price||2015-12-02 01:16:19.732850@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 01:16:26.038090||measurement||loadtime||0:00:29.142932||5||1
+2015-12-02 01:16:26.301293||measurement||loadtime||0:00:27.388855||2||0
+2015-12-02 01:16:29.028298||error||collecting ads||Error||0||0
+2015-12-02 01:16:33.784906||error||collecting ads||Error||4||1
+2015-12-02 01:16:35.862967||measurement||price||2015-12-02 01:16:29.650229@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-02 01:16:37.460575||measurement||price||2015-12-02 01:16:19.732850@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 01:16:38.623940||measurement||price||2015-12-02 01:16:33.082018@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||0
+2015-12-02 01:16:40.284761||measurement||price||2015-12-02 01:16:33.332169@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||1
+2015-12-02 01:16:41.595740||measurement||price||2015-12-02 01:16:36.258077@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:16:44.565496||measurement||loadtime||0:00:27.018357||3||0
+2015-12-02 01:16:47.521193||measurement||price||2015-12-02 01:16:41.386363@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:16:48.765992||measurement||price||2015-12-02 01:16:29.650229@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-02 01:16:50.939807||measurement||price||2015-12-02 01:16:33.082018@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||0
+2015-12-02 01:16:53.182567||measurement||price||2015-12-02 01:16:33.332169@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||1
+2015-12-02 01:16:53.933360||measurement||price||2015-12-02 01:16:36.258077@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:16:55.983763||measurement||loadtime||0:00:29.042589||1||1
+2015-12-02 01:16:57.097388||measurement||price||2015-12-02 01:16:51.664753@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 01:16:58.051139||measurement||loadtime||0:00:26.748003||2||0
+2015-12-02 01:17:00.391171||measurement||loadtime||0:00:29.348029||5||1
+2015-12-02 01:17:00.443388||measurement||price||2015-12-02 01:16:41.386363@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:17:01.033069||measurement||loadtime||0:00:26.999573||0||0
+2015-12-02 01:17:07.643152||measurement||loadtime||0:00:28.856009||4||1
+2015-12-02 01:17:09.430963||measurement||price||2015-12-02 01:16:51.664753@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 01:17:09.693930||measurement||price||2015-12-02 01:17:03.641498@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 01:17:10.418281||measurement||price||2015-12-02 01:17:04.647323@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||0
+2015-12-02 01:17:14.070586||measurement||price||2015-12-02 01:17:08.583687@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-02 01:17:14.553318||measurement||price||2015-12-02 01:17:07.737974@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||1
+2015-12-02 01:17:16.550503||measurement||loadtime||0:00:26.982194||3||0
+2015-12-02 01:17:22.618554||measurement||price||2015-12-02 01:17:03.641498@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 01:17:22.768260||measurement||price||2015-12-02 01:17:04.647323@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||0
+2015-12-02 01:17:26.394534||measurement||price||2015-12-02 01:17:08.583687@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-02 01:17:27.585614||measurement||price||2015-12-02 01:17:07.737974@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||1
+2015-12-02 01:17:29.108159||measurement||price||2015-12-02 01:17:23.689280@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||0
+2015-12-02 01:17:29.843793||measurement||loadtime||0:00:28.854995||1||1
+2015-12-02 01:17:29.894880||measurement||loadtime||0:00:26.838586||2||0
+2015-12-02 01:17:31.503845||error||collecting ads||Error||4||1
+2015-12-02 01:17:33.497784||measurement||loadtime||0:00:27.462655||0||0
+2015-12-02 01:17:34.778535||measurement||loadtime||0:00:29.382012||5||1
+2015-12-02 01:17:41.429675||measurement||price||2015-12-02 01:17:23.689280@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||0
+2015-12-02 01:17:42.247197||measurement||price||2015-12-02 01:17:36.521501@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-02 01:17:44.150667||measurement||price||2015-12-02 01:17:37.991867@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:17:45.561788||measurement||price||2015-12-02 01:17:39.487457@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 01:17:48.519628||measurement||loadtime||0:00:26.963887||3||0
+2015-12-02 01:17:48.796511||measurement||price||2015-12-02 01:17:42.252477@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||1
+2015-12-02 01:17:54.575496||measurement||price||2015-12-02 01:17:36.521501@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-02 01:17:56.631294||error||collecting ads||Error||0||0
+2015-12-02 01:17:57.176313||measurement||price||2015-12-02 01:17:37.991867@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:17:58.510760||measurement||price||2015-12-02 01:17:39.487457@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 01:18:01.688467||measurement||loadtime||0:00:26.788447||2||0
+2015-12-02 01:18:01.778872||measurement||price||2015-12-02 01:17:42.252477@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||1
+2015-12-02 01:18:01.984656||measurement||price||2015-12-02 01:17:56.068930@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 01:18:04.403124||measurement||loadtime||0:00:29.554143||1||1
+2015-12-02 01:18:05.717927||measurement||loadtime||0:00:29.212710||4||1
+2015-12-02 01:18:08.969462||measurement||loadtime||0:00:29.186318||5||1
+2015-12-02 01:18:09.276449||measurement||price||2015-12-02 01:18:03.833238@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:18:14.016993||measurement||price||2015-12-02 01:18:08.410414@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-02 01:18:14.292201||measurement||price||2015-12-02 01:17:56.068930@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 01:18:18.255795||measurement||price||2015-12-02 01:18:12.042154@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:18:21.379152||measurement||loadtime||0:00:27.854310||3||0
+2015-12-02 01:18:21.576395||measurement||price||2015-12-02 01:18:03.833238@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:18:26.316167||measurement||price||2015-12-02 01:18:08.410414@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-02 01:18:28.668937||measurement||loadtime||0:00:27.034846||0||0
+2015-12-02 01:18:29.341611||error||collecting ads||Error||4||1
+2015-12-02 01:18:31.256325||measurement||price||2015-12-02 01:18:12.042154@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:18:33.164845||error||collecting ads||Error||5||1
+2015-12-02 01:18:33.406091||measurement||loadtime||0:00:26.712433||2||0
+2015-12-02 01:18:38.451167||measurement||loadtime||0:00:29.047556||1||1
+2015-12-02 01:18:43.453584||measurement||price||2015-12-02 01:18:37.174315@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:18:43.910501||error||collecting ads||Error||3||0
+2015-12-02 01:18:47.318914||measurement||price||2015-12-02 01:18:40.555063@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 01:18:51.407019||error||collecting ads||Error||0||0
+2015-12-02 01:18:55.779912||error||collecting ads||Error||2||0
+2015-12-02 01:18:56.340641||measurement||price||2015-12-02 01:18:37.174315@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:18:56.378388||measurement||price||2015-12-02 01:18:51.036651@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:19:00.207875||measurement||price||2015-12-02 01:18:40.555063@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 01:19:02.306536||error||collecting ads||Error||1||1
+2015-12-02 01:19:03.567282||measurement||loadtime||0:00:29.224151||4||1
+2015-12-02 01:19:03.992673||measurement||price||2015-12-02 01:18:58.560170@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:19:07.407184||measurement||loadtime||0:00:29.237158||5||1
+2015-12-02 01:19:08.738523||measurement||price||2015-12-02 01:18:51.036651@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:19:15.855210||measurement||loadtime||0:00:26.940022||3||0
+2015-12-02 01:19:15.855302||event||progress-marker||measurement-end||3||0
+2015-12-02 01:19:16.205013||measurement||price||2015-12-02 01:19:10.055337@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:19:16.357191||measurement||price||2015-12-02 01:18:58.560170@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:19:17.562051||measurement||price||2015-12-02 01:19:11.289634@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:19:18.020635||error||collecting ads||Error||2||0
+2015-12-02 01:19:18.020743||event||progress-marker||measurement-end||2||0
+2015-12-02 01:19:21.558665||measurement||price||2015-12-02 01:19:14.805443@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 01:19:23.478327||measurement||loadtime||0:00:27.067191||0||0
+2015-12-02 01:19:23.478442||event||progress-marker||measurement-end||0||0
+2015-12-02 01:19:29.075944||measurement||price||2015-12-02 01:19:10.055337@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:19:30.381855||measurement||price||2015-12-02 01:19:11.289634@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:19:34.387041||measurement||price||2015-12-02 01:19:14.805443@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 01:19:36.270230||measurement||loadtime||0:00:28.958472||1||1
+2015-12-02 01:19:37.577956||measurement||loadtime||0:00:29.005497||4||1
+2015-12-02 01:19:41.584190||measurement||loadtime||0:00:29.173062||5||1
+2015-12-02 01:19:50.220103||measurement||price||2015-12-02 01:19:44.058044@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||1||1
+2015-12-02 01:19:52.313763||measurement||price||2015-12-02 01:19:45.982008@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:19:55.393325||measurement||price||2015-12-02 01:19:49.049257@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-02 01:20:05.309400||measurement||price||2015-12-02 01:19:45.982008@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:20:08.360381||measurement||price||2015-12-02 01:19:49.049257@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-02 01:20:12.667228||measurement||loadtime||0:00:30.084066||4||1
+2015-12-02 01:20:13.115881||error||collecting ads||Error||1||1
+2015-12-02 01:20:15.543064||measurement||loadtime||0:00:28.955884||5||1
+2015-12-02 01:20:15.543163||event||progress-marker||measurement-end||5||1
+2015-12-02 01:20:36.589444||error||collecting ads||Error||4||1
+2015-12-02 01:20:36.969330||error||collecting ads||Error||1||1
+2015-12-02 01:20:50.768549||measurement||price||2015-12-02 01:20:44.368930@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||1
+2015-12-02 01:20:51.218333||measurement||price||2015-12-02 01:20:45.235416@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||1
+2015-12-02 01:21:03.586633||measurement||price||2015-12-02 01:20:44.368930@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||1
+2015-12-02 01:21:04.095720||measurement||price||2015-12-02 01:20:45.235416@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||1
+2015-12-02 01:21:10.802543||measurement||loadtime||0:00:29.207897||4||1
+2015-12-02 01:21:11.325800||measurement||loadtime||0:00:29.351294||1||1
+2015-12-02 01:21:24.621304||measurement||price||2015-12-02 01:21:18.501602@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 01:21:35.622631||error||collecting ads||Error||1||1
+2015-12-02 01:21:37.534403||measurement||price||2015-12-02 01:21:18.501602@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 01:21:44.714134||measurement||loadtime||0:00:28.906383||4||1
+2015-12-02 01:21:58.977975||measurement||price||2015-12-02 01:21:53.121522@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 01:21:59.255192||error||collecting ads||Error||1||1
+2015-12-02 01:22:12.032039||measurement||price||2015-12-02 01:21:53.121522@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 01:22:12.996379||measurement||price||2015-12-02 01:22:06.807989@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 01:22:19.254402||measurement||loadtime||0:00:29.535068||4||1
+2015-12-02 01:22:19.254527||event||progress-marker||measurement-end||4||1
+2015-12-02 01:22:26.007698||measurement||price||2015-12-02 01:22:06.807989@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 01:22:33.186761||measurement||loadtime||0:00:28.930502||1||1
+2015-12-02 01:22:33.186914||event||progress-marker||measurement-end||1||1
+2015-12-02 01:22:33.715091||meta||block_id end||18
+2015-12-02 01:22:33.715328||meta||block_id start||19
+2015-12-02 01:22:33.715346||meta||assignment||3@|0@|5@|2@|4@|1
+2015-12-02 01:22:35.298101||event||progress-marker||training-start||0||0
+2015-12-02 01:22:35.353848||event||progress-marker||training-start||5||0
+2015-12-02 01:22:35.375166||event||progress-marker||training-start||3||0
+2015-12-02 01:22:42.191137||treatment||visit website||http://irs.gov||5||0
+2015-12-02 01:22:42.191247||treatment||visit website||http://irs.gov||3||0
+2015-12-02 01:22:42.203803||treatment||visit website||http://irs.gov||0||0
+2015-12-02 01:23:12.425983||treatment||visit website||http://deloitte.com||0||0
+2015-12-02 01:23:12.426537||treatment||visit website||http://deloitte.com||5||0
+2015-12-02 01:23:12.435105||treatment||visit website||http://deloitte.com||3||0
+2015-12-02 01:23:20.823577||treatment||visit website||http://pwc.com||5||0
+2015-12-02 01:23:20.955096||treatment||visit website||http://pwc.com||0||0
+2015-12-02 01:23:20.955547||treatment||visit website||http://pwc.com||3||0
+2015-12-02 01:23:38.338588||treatment||visit website||http://ey.com||0||0
+2015-12-02 01:23:38.351093||treatment||visit website||http://ey.com||3||0
+2015-12-02 01:23:39.292923||treatment||visit website||http://ey.com||5||0
+2015-12-02 01:23:45.275621||treatment||visit website||http://kpmg.com||0||0
+2015-12-02 01:23:45.275775||event||progress-marker||training-end||0||0
+2015-12-02 01:23:46.027121||treatment||visit website||http://kpmg.com||5||0
+2015-12-02 01:23:46.027256||event||progress-marker||training-end||5||0
+2015-12-02 01:23:46.236086||treatment||visit website||http://kpmg.com||3||0
+2015-12-02 01:23:46.236184||event||progress-marker||training-end||3||0
+2015-12-02 01:23:50.325264||event||progress-marker||measurement-start||0||0
+2015-12-02 01:23:51.082049||event||progress-marker||measurement-start||5||0
+2015-12-02 01:23:51.283173||event||progress-marker||measurement-start||3||0
+2015-12-02 01:24:02.225260||event||progress-marker||training-start||1||1
+2015-12-02 01:24:07.205057||event||progress-marker||training-start||4||1
+2015-12-02 01:24:09.371112||treatment||visit website||http://irs.gov||1||1
+2015-12-02 01:24:13.709453||treatment||visit website||http://irs.gov||4||1
+2015-12-02 01:24:13.821312||error||collecting ads||Error||0||0
+2015-12-02 01:24:14.575978||error||collecting ads||Error||3||0
+2015-12-02 01:24:14.822369||error||collecting ads||Error||5||0
+2015-12-02 01:24:16.451788||treatment||visit website||http://deloitte.com||1||1
+2015-12-02 01:24:20.755229||treatment||visit website||http://deloitte.com||4||1
+2015-12-02 01:24:25.189813||treatment||visit website||http://pwc.com||1||1
+2015-12-02 01:24:26.584967||measurement||price||2015-12-02 01:24:21.072897@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:24:27.716159||measurement||price||2015-12-02 01:24:22.184036@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:24:28.197474||measurement||price||2015-12-02 01:24:22.264521@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 01:24:29.615116||treatment||visit website||http://pwc.com||4||1
+2015-12-02 01:24:38.931126||measurement||price||2015-12-02 01:24:21.072897@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:24:40.057262||measurement||price||2015-12-02 01:24:22.184036@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:24:40.527792||measurement||price||2015-12-02 01:24:22.264521@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 01:24:46.039097||measurement||loadtime||0:00:27.215904||0||0
+2015-12-02 01:24:47.155691||measurement||loadtime||0:00:27.576542||3||0
+2015-12-02 01:24:47.637478||measurement||loadtime||0:00:27.810319||5||0
+2015-12-02 01:24:50.304324||treatment||visit website||http://ey.com||1||1
+2015-12-02 01:24:51.287120||treatment||visit website||http://ey.com||4||1
+2015-12-02 01:24:56.960132||event||progress-marker||training-start||2||1
+2015-12-02 01:25:02.472264||treatment||visit website||http://kpmg.com||4||1
+2015-12-02 01:25:02.472382||event||progress-marker||training-end||4||1
+2015-12-02 01:25:02.544042||measurement||price||2015-12-02 01:24:57.100164@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 01:25:02.713765||measurement||price||2015-12-02 01:24:57.098795@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:25:03.889558||treatment||visit website||http://kpmg.com||1||1
+2015-12-02 01:25:03.889714||event||progress-marker||training-end||1||1
+2015-12-02 01:25:03.902734||treatment||visit website||http://irs.gov||2||1
+2015-12-02 01:25:11.031249||treatment||visit website||http://deloitte.com||2||1
+2015-12-02 01:25:12.872724||error||collecting ads||Error||3||0
+2015-12-02 01:25:14.902942||measurement||price||2015-12-02 01:24:57.100164@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 01:25:15.091483||measurement||price||2015-12-02 01:24:57.098795@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:25:19.935129||treatment||visit website||http://pwc.com||2||1
+2015-12-02 01:25:22.015175||measurement||loadtime||0:00:29.376033||5||0
+2015-12-02 01:25:22.161386||measurement||loadtime||0:00:31.118234||0||0
+2015-12-02 01:25:25.625587||measurement||price||2015-12-02 01:25:20.164586@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:25:25.989213||treatment||visit website||http://ey.com||2||1
+2015-12-02 01:25:32.571474||treatment||visit website||http://kpmg.com||2||1
+2015-12-02 01:25:32.571579||event||progress-marker||training-end||2||1
+2015-12-02 01:25:32.660047||event||progress-marker||measurement-start||4||1
+2015-12-02 01:25:34.077314||event||progress-marker||measurement-start||1||1
+2015-12-02 01:25:35.127065||measurement||price||2015-12-02 01:25:29.567574@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 01:25:35.165057||measurement||price||2015-12-02 01:25:29.629931@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||0||0
+2015-12-02 01:25:37.617482||event||progress-marker||measurement-start||2||1
+2015-12-02 01:25:37.960543||measurement||price||2015-12-02 01:25:20.164586@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:25:45.067186||measurement||loadtime||0:00:27.189261||3||0
+2015-12-02 01:25:47.445767||measurement||price||2015-12-02 01:25:29.567574@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 01:25:49.353692||measurement||price||2015-12-02 01:25:43.215739@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:25:54.527171||measurement||loadtime||0:00:27.508004||5||0
+2015-12-02 01:25:57.487371||error||collecting ads||Error||0||0
+2015-12-02 01:25:57.787041||measurement||price||2015-12-02 01:25:52.374170@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:25:58.074270||error||collecting ads||Error||4||1
+2015-12-02 01:26:02.173120||error||collecting ads||Error||2||1
+2015-12-02 01:26:02.252734||measurement||price||2015-12-02 01:25:43.215739@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:26:07.442253||measurement||price||2015-12-02 01:26:01.824915@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 01:26:09.499173||measurement||loadtime||0:00:30.416668||1||1
+2015-12-02 01:26:10.035765||measurement||price||2015-12-02 01:26:04.619809@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 01:26:10.132539||measurement||price||2015-12-02 01:25:52.374170@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:26:12.542185||measurement||price||2015-12-02 01:26:06.436363@|Mr Beams@|$23.99@|Mr. Beams MB723 Battery-Powered Motion-Sensing LED Stick-Any...||4||1
+2015-12-02 01:26:16.153781||measurement||price||2015-12-02 01:26:09.879226@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 01:26:17.260955||measurement||loadtime||0:00:27.188531||3||0
+2015-12-02 01:26:19.783737||measurement||price||2015-12-02 01:26:01.824915@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 01:26:22.402655||measurement||price||2015-12-02 01:26:04.619809@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 01:26:23.693747||measurement||price||2015-12-02 01:26:17.644265@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:26:25.358325||measurement||price||2015-12-02 01:26:06.436363@|Mr. Beams@|$29.99@|Mr Beams MB390 300-Lumen Weatherproof Wireless Battery Power...||4||1
+2015-12-02 01:26:26.899166||measurement||loadtime||0:00:27.366782||5||0
+2015-12-02 01:26:29.111962||measurement||price||2015-12-02 01:26:09.879226@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 01:26:29.515271||measurement||loadtime||0:00:27.023395||0||0
+2015-12-02 01:26:30.017816||measurement||price||2015-12-02 01:26:24.611238@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:26:32.578578||measurement||loadtime||0:00:29.501671||4||1
+2015-12-02 01:26:36.294894||measurement||loadtime||0:00:29.116568||2||1
+2015-12-02 01:26:36.508209||measurement||price||2015-12-02 01:26:17.644265@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:26:42.024936||measurement||price||2015-12-02 01:26:36.605902@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:26:42.353686||measurement||price||2015-12-02 01:26:24.611238@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:26:43.777347||measurement||loadtime||0:00:29.274198||1||1
+2015-12-02 01:26:46.447365||measurement||price||2015-12-02 01:26:40.490247@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:26:49.482000||measurement||loadtime||0:00:27.215850||3||0
+2015-12-02 01:26:49.695401||error||collecting ads||Error||5||0
+2015-12-02 01:26:50.176544||measurement||price||2015-12-02 01:26:44.019687@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 01:26:54.363081||measurement||price||2015-12-02 01:26:36.605902@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:26:57.975346||measurement||price||2015-12-02 01:26:51.803907@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 01:26:59.313000||measurement||price||2015-12-02 01:26:40.490247@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:27:01.475230||measurement||loadtime||0:00:26.957153||0||0
+2015-12-02 01:27:02.199309||measurement||price||2015-12-02 01:26:56.544960@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-02 01:27:02.761371||measurement||price||2015-12-02 01:26:57.194442@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 01:27:03.076305||measurement||price||2015-12-02 01:26:44.019687@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 01:27:06.525600||measurement||loadtime||0:00:28.942470||4||1
+2015-12-02 01:27:10.292983||measurement||loadtime||0:00:28.993827||2||1
+2015-12-02 01:27:10.870264||measurement||price||2015-12-02 01:26:51.803907@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 01:27:14.504520||measurement||price||2015-12-02 01:27:08.995441@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:27:14.525953||measurement||price||2015-12-02 01:26:56.544960@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-02 01:27:15.064372||measurement||price||2015-12-02 01:26:57.194442@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 01:27:18.072285||measurement||loadtime||0:00:29.289723||1||1
+2015-12-02 01:27:20.820629||measurement||price||2015-12-02 01:27:14.656796@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:27:21.618943||measurement||loadtime||0:00:26.922357||5||0
+2015-12-02 01:27:22.146855||measurement||loadtime||0:00:27.662052||3||0
+2015-12-02 01:27:25.118051||measurement||price||2015-12-02 01:27:19.198672@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 01:27:26.854722||measurement||price||2015-12-02 01:27:08.995441@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:27:31.698530||measurement||price||2015-12-02 01:27:25.714293@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:27:33.725050||measurement||price||2015-12-02 01:27:14.656796@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:27:33.983129||measurement||loadtime||0:00:27.507502||0||0
+2015-12-02 01:27:34.011725||measurement||price||2015-12-02 01:27:28.324097@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-02 01:27:36.619337||measurement||price||2015-12-02 01:27:30.358720@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-02 01:27:38.020808||measurement||price||2015-12-02 01:27:19.198672@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 01:27:40.939136||measurement||loadtime||0:00:29.409142||4||1
+2015-12-02 01:27:44.720838||measurement||price||2015-12-02 01:27:25.714293@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:27:45.219571||measurement||loadtime||0:00:29.921881||2||1
+2015-12-02 01:27:46.343974||measurement||price||2015-12-02 01:27:28.324097@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-02 01:27:46.692984||measurement||price||2015-12-02 01:27:41.282026@|@|$37.46@|OtterBox DEFENDER iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:27:48.893428||measurement||price||2015-12-02 01:27:30.358720@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-02 01:27:51.955156||measurement||loadtime||0:00:28.879379||1||1
+2015-12-02 01:27:53.451172||measurement||loadtime||0:00:26.828039||5||0
+2015-12-02 01:27:55.973226||measurement||loadtime||0:00:28.821143||3||0
+2015-12-02 01:27:59.003238||measurement||price||2015-12-02 01:27:52.832906@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 01:27:59.023234||measurement||price||2015-12-02 01:27:41.282026@|@|$18.89@|OtterBox COMMUTER iPhone 6/6s Case - Frustration-Free Packag...||0||0
+2015-12-02 01:28:04.678023||error||collecting ads||Error||4||1
+2015-12-02 01:28:05.922815||measurement||price||2015-12-02 01:28:00.380618@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 01:28:06.140734||measurement||loadtime||0:00:27.153997||0||0
+2015-12-02 01:28:06.194653||measurement||price||2015-12-02 01:28:00.069379@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:28:08.949489||measurement||price||2015-12-02 01:28:03.540560@|Disney Software@|$12.59@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||3||0
+2015-12-02 01:28:11.948168||measurement||price||2015-12-02 01:27:52.832906@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 01:28:18.250320||measurement||price||2015-12-02 01:28:00.380618@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 01:28:18.454366||measurement||price||2015-12-02 01:28:12.299052@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-02 01:28:19.017927||measurement||price||2015-12-02 01:28:00.069379@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:28:19.133939||measurement||price||2015-12-02 01:28:13.627127@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-02 01:28:19.143118||measurement||loadtime||0:00:28.919548||2||1
+2015-12-02 01:28:21.285082||measurement||price||2015-12-02 01:28:03.540560@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||3||0
+2015-12-02 01:28:25.355143||measurement||loadtime||0:00:26.899958||5||0
+2015-12-02 01:28:26.255851||measurement||loadtime||0:00:29.295530||1||1
+2015-12-02 01:28:28.395106||measurement||loadtime||0:00:27.419930||3||0
+2015-12-02 01:28:31.349816||measurement||price||2015-12-02 01:28:12.299052@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-02 01:28:31.490797||measurement||price||2015-12-02 01:28:13.627127@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-02 01:28:32.990161||measurement||price||2015-12-02 01:28:26.827743@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 01:28:37.715355||measurement||price||2015-12-02 01:28:32.073300@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-02 01:28:38.573181||measurement||loadtime||0:00:28.889936||4||1
+2015-12-02 01:28:38.605771||measurement||loadtime||0:00:27.459858||0||0
+2015-12-02 01:28:41.056283||measurement||price||2015-12-02 01:28:35.636921@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 01:28:45.914789||measurement||price||2015-12-02 01:28:26.827743@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 01:28:50.046850||measurement||price||2015-12-02 01:28:32.073300@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-02 01:28:50.071099||error||collecting ads||Error||1||1
+2015-12-02 01:28:51.133927||measurement||price||2015-12-02 01:28:45.738177@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:28:52.555083||measurement||price||2015-12-02 01:28:46.413569@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:28:53.143108||measurement||loadtime||0:00:28.994763||2||1
+2015-12-02 01:28:53.376535||measurement||price||2015-12-02 01:28:35.636921@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 01:28:57.159153||measurement||loadtime||0:00:26.798773||5||0
+2015-12-02 01:29:00.483162||measurement||loadtime||0:00:27.084496||3||0
+2015-12-02 01:29:03.463581||measurement||price||2015-12-02 01:28:45.738177@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:29:05.415132||measurement||price||2015-12-02 01:28:46.413569@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:29:07.167444||measurement||price||2015-12-02 01:29:00.929051@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 01:29:09.430044||measurement||price||2015-12-02 01:29:03.796429@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 01:29:10.574987||measurement||loadtime||0:00:26.967857||0||0
+2015-12-02 01:29:12.618093||measurement||loadtime||0:00:29.039658||4||1
+2015-12-02 01:29:13.136362||measurement||price||2015-12-02 01:29:07.739316@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||0
+2015-12-02 01:29:13.784669||error||collecting ads||Error||1||1
+2015-12-02 01:29:20.224209||measurement||price||2015-12-02 01:29:00.929051@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 01:29:21.778544||measurement||price||2015-12-02 01:29:03.796429@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 01:29:23.222293||measurement||price||2015-12-02 01:29:17.887862@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-02 01:29:25.477695||measurement||price||2015-12-02 01:29:07.739316@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||0
+2015-12-02 01:29:27.111092||measurement||price||2015-12-02 01:29:21.072575@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:29:27.484502||measurement||loadtime||0:00:29.336201||2||1
+2015-12-02 01:29:27.490763||measurement||price||2015-12-02 01:29:21.496797@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:29:28.892266||measurement||loadtime||0:00:26.729391||5||0
+2015-12-02 01:29:32.591161||measurement||loadtime||0:00:27.102774||3||0
+2015-12-02 01:29:35.571972||measurement||price||2015-12-02 01:29:17.887862@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-02 01:29:40.188182||measurement||price||2015-12-02 01:29:21.072575@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:29:40.390538||measurement||price||2015-12-02 01:29:21.496797@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:29:41.445449||measurement||price||2015-12-02 01:29:35.196822@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 01:29:42.695199||measurement||loadtime||0:00:27.114999||0||0
+2015-12-02 01:29:45.224902||measurement||price||2015-12-02 01:29:39.744580@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 01:29:47.407157||measurement||loadtime||0:00:29.785119||4||1
+2015-12-02 01:29:47.610296||measurement||loadtime||0:00:28.820299||1||1
+2015-12-02 01:29:51.400092||error||collecting ads||Error||5||0
+2015-12-02 01:29:54.330989||measurement||price||2015-12-02 01:29:35.196822@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 01:29:55.281376||measurement||price||2015-12-02 01:29:49.833413@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 01:29:57.560053||measurement||price||2015-12-02 01:29:39.744580@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 01:30:01.547170||measurement||loadtime||0:00:29.060857||2||1
+2015-12-02 01:30:01.563565||measurement||price||2015-12-02 01:29:55.170123@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-02 01:30:04.017533||measurement||price||2015-12-02 01:29:58.426277@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-02 01:30:04.672808||measurement||loadtime||0:00:27.076450||3||0
+2015-12-02 01:30:07.630391||measurement||price||2015-12-02 01:29:49.833413@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 01:30:11.363471||error||collecting ads||Error||1||1
+2015-12-02 01:30:14.473475||measurement||price||2015-12-02 01:29:55.170123@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-02 01:30:14.743181||measurement||loadtime||0:00:27.042729||0||0
+2015-12-02 01:30:15.528594||measurement||price||2015-12-02 01:30:09.215369@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||1
+2015-12-02 01:30:16.314897||measurement||price||2015-12-02 01:29:58.426277@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-02 01:30:17.852317||measurement||price||2015-12-02 01:30:12.341577@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||0
+2015-12-02 01:30:21.703150||measurement||loadtime||0:00:29.292024||4||1
+2015-12-02 01:30:23.428681||measurement||loadtime||0:00:27.023368||5||0
+2015-12-02 01:30:25.722847||measurement||price||2015-12-02 01:30:19.377502@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:30:27.471168||measurement||price||2015-12-02 01:30:21.952476@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||0
+2015-12-02 01:30:28.357029||measurement||price||2015-12-02 01:30:09.215369@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||1
+2015-12-02 01:30:30.150480||measurement||price||2015-12-02 01:30:12.341577@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||0
+2015-12-02 01:30:35.589578||measurement||loadtime||0:00:29.037177||2||1
+2015-12-02 01:30:35.695816||measurement||price||2015-12-02 01:30:29.412784@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 01:30:36.248918||measurement||price||2015-12-02 01:30:30.687580@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-02 01:30:37.239509||measurement||loadtime||0:00:27.564374||3||0
+2015-12-02 01:30:38.650335||measurement||price||2015-12-02 01:30:19.377502@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:30:39.760148||measurement||price||2015-12-02 01:30:21.952476@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||0
+2015-12-02 01:30:45.892441||measurement||loadtime||0:00:29.525312||1||1
+2015-12-02 01:30:46.834556||measurement||loadtime||0:00:27.087428||0||0
+2015-12-02 01:30:48.599840||measurement||price||2015-12-02 01:30:30.687580@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-02 01:30:48.603176||measurement||price||2015-12-02 01:30:29.412784@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 01:30:49.929515||measurement||price||2015-12-02 01:30:44.569008@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:30:49.953865||measurement||price||2015-12-02 01:30:43.653273@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 01:30:55.715144||measurement||loadtime||0:00:27.284664||5||0
+2015-12-02 01:30:55.816661||measurement||loadtime||0:00:29.109530||4||1
+2015-12-02 01:30:59.298375||measurement||price||2015-12-02 01:30:53.902316@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 01:30:59.643864||measurement||price||2015-12-02 01:30:53.518969@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-02 01:31:02.194024||measurement||price||2015-12-02 01:30:44.569008@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:31:02.917771||measurement||price||2015-12-02 01:30:43.653273@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 01:31:08.353818||measurement||price||2015-12-02 01:31:02.734376@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||0
+2015-12-02 01:31:09.283505||measurement||loadtime||0:00:27.038958||3||0
+2015-12-02 01:31:09.674413||measurement||price||2015-12-02 01:31:03.540132@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-02 01:31:10.159882||measurement||loadtime||0:00:29.565081||2||1
+2015-12-02 01:31:11.571859||measurement||price||2015-12-02 01:30:53.902316@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 01:31:12.533772||measurement||price||2015-12-02 01:30:53.518969@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-02 01:31:18.655141||measurement||loadtime||0:00:26.819505||0||0
+2015-12-02 01:31:19.754546||measurement||loadtime||0:00:28.859315||1||1
+2015-12-02 01:31:20.691962||measurement||price||2015-12-02 01:31:02.734376@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||0
+2015-12-02 01:31:21.954157||measurement||price||2015-12-02 01:31:16.544572@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||0
+2015-12-02 01:31:22.467831||measurement||price||2015-12-02 01:31:03.540132@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-02 01:31:27.798787||measurement||loadtime||0:00:27.078465||5||0
+2015-12-02 01:31:29.667160||measurement||loadtime||0:00:28.848017||4||1
+2015-12-02 01:31:31.633086||measurement||price||2015-12-02 01:31:25.899911@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-02 01:31:33.782315||measurement||price||2015-12-02 01:31:27.757807@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 01:31:33.974526||error||collecting ads||Error||2||1
+2015-12-02 01:31:34.289426||measurement||price||2015-12-02 01:31:16.544572@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||0
+2015-12-02 01:31:40.191113||measurement||price||2015-12-02 01:31:34.532428@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||5||0
+2015-12-02 01:31:41.411465||measurement||loadtime||0:00:27.124340||3||0
+2015-12-02 01:31:43.978625||measurement||price||2015-12-02 01:31:25.899911@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-02 01:31:44.285549||measurement||price||2015-12-02 01:31:38.238469@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 01:31:46.623701||measurement||price||2015-12-02 01:31:27.757807@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 01:31:47.922906||measurement||price||2015-12-02 01:31:41.696678@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-02 01:31:51.075154||measurement||loadtime||0:00:27.414829||0||0
+2015-12-02 01:31:52.494449||measurement||price||2015-12-02 01:31:34.532428@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||5||0
+2015-12-02 01:31:53.847237||measurement||loadtime||0:00:29.088096||1||1
+2015-12-02 01:31:53.981868||measurement||price||2015-12-02 01:31:48.613710@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 01:31:57.304312||measurement||price||2015-12-02 01:31:38.238469@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 01:31:59.579166||measurement||loadtime||0:00:26.779781||5||0
+2015-12-02 01:32:00.720529||measurement||price||2015-12-02 01:31:41.696678@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-02 01:32:03.505501||measurement||price||2015-12-02 01:31:58.130805@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-02 01:32:04.519795||measurement||loadtime||0:00:29.847255||4||1
+2015-12-02 01:32:06.326520||measurement||price||2015-12-02 01:31:48.613710@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 01:32:07.480949||measurement||price||2015-12-02 01:32:01.421213@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 01:32:07.934918||measurement||loadtime||0:00:28.955786||2||1
+2015-12-02 01:32:12.354028||measurement||price||2015-12-02 01:32:06.740495@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-02 01:32:13.443146||measurement||loadtime||0:00:27.030670||3||0
+2015-12-02 01:32:15.820275||measurement||price||2015-12-02 01:31:58.130805@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-02 01:32:20.285426||measurement||price||2015-12-02 01:32:01.421213@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 01:32:22.933247||measurement||loadtime||0:00:26.854105||0||0
+2015-12-02 01:32:24.698866||measurement||price||2015-12-02 01:32:06.740495@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-02 01:32:27.502617||measurement||loadtime||0:00:28.654790||1||1
+2015-12-02 01:32:31.817393||measurement||loadtime||0:00:27.234249||5||0
+2015-12-02 01:32:44.155421||measurement||price||2015-12-02 01:32:38.508002@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-02 01:32:44.254355||measurement||price||2015-12-02 01:32:38.095545@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-02 01:32:50.398802||measurement||price||2015-12-02 01:32:45.034020@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||0||0
+2015-12-02 01:32:53.010259||measurement||price||2015-12-02 01:32:46.775717@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 01:32:55.618823||measurement||price||2015-12-02 01:32:49.677546@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-02 01:32:56.512619||measurement||price||2015-12-02 01:32:38.508002@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-02 01:32:57.130343||measurement||price||2015-12-02 01:32:38.095545@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-02 01:32:57.765294||measurement||price||2015-12-02 01:32:52.181189@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||3||0
+2015-12-02 01:33:02.710196||measurement||price||2015-12-02 01:32:45.034020@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||0||0
+2015-12-02 01:33:03.619261||measurement||loadtime||0:00:26.800355||5||0
+2015-12-02 01:33:04.329077||measurement||loadtime||0:00:31.821904||1||1
+2015-12-02 01:33:06.068459||measurement||price||2015-12-02 01:32:46.775717@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 01:33:08.486314||measurement||price||2015-12-02 01:32:49.677546@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-02 01:33:09.794066||measurement||loadtime||0:00:41.858909||0||0
+2015-12-02 01:33:10.070783||measurement||price||2015-12-02 01:32:52.181189@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||3||0
+2015-12-02 01:33:13.352002||measurement||loadtime||0:01:00.412926||2||1
+2015-12-02 01:33:15.685042||measurement||loadtime||0:01:06.164744||4||1
+2015-12-02 01:33:16.482101||measurement||price||2015-12-02 01:33:10.758138@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||5||0
+2015-12-02 01:33:17.155146||measurement||loadtime||0:00:58.708031||3||0
+2015-12-02 01:33:18.068513||measurement||price||2015-12-02 01:33:12.019172@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||1
+2015-12-02 01:33:22.113922||measurement||price||2015-12-02 01:33:16.754502@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-02 01:33:27.052846||measurement||price||2015-12-02 01:33:20.853711@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-02 01:33:28.823282||measurement||price||2015-12-02 01:33:10.758138@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||5||0
+2015-12-02 01:33:29.502323||measurement||price||2015-12-02 01:33:23.398675@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 01:33:30.331320||measurement||price||2015-12-02 01:33:24.975302@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-02 01:33:30.883150||measurement||price||2015-12-02 01:33:12.019172@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||1
+2015-12-02 01:33:34.389170||measurement||price||2015-12-02 01:33:16.754502@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-02 01:33:35.937715||measurement||loadtime||0:00:27.313241||5||0
+2015-12-02 01:33:38.099080||measurement||loadtime||0:00:28.765571||1||1
+2015-12-02 01:33:39.920464||measurement||price||2015-12-02 01:33:20.853711@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-02 01:33:41.467963||measurement||loadtime||0:00:26.668678||0||0
+2015-12-02 01:33:42.277196||measurement||price||2015-12-02 01:33:23.398675@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 01:33:42.608077||measurement||price||2015-12-02 01:33:24.975302@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-02 01:33:47.109517||measurement||loadtime||0:00:28.754384||2||1
+2015-12-02 01:33:48.219144||measurement||price||2015-12-02 01:33:42.586607@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-02 01:33:49.463138||measurement||loadtime||0:00:28.772923||4||1
+2015-12-02 01:33:49.683071||measurement||loadtime||0:00:27.523914||3||0
+2015-12-02 01:33:51.781407||measurement||price||2015-12-02 01:33:45.820599@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:33:53.881793||measurement||price||2015-12-02 01:33:48.552021@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||0||0
+2015-12-02 01:34:00.544843||measurement||price||2015-12-02 01:33:42.586607@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-02 01:34:01.102717||measurement||price||2015-12-02 01:33:54.854681@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||2||1
+2015-12-02 01:34:03.088157||measurement||price||2015-12-02 01:33:57.697214@|3M Littmann@|$85.00 - $234.56@|3M Littmann Classic III Stethoscope (Multiple Colors)||3||0
+2015-12-02 01:34:03.552792||measurement||price||2015-12-02 01:33:57.272397@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||1
+2015-12-02 01:34:04.577191||measurement||price||2015-12-02 01:33:45.820599@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:34:06.204426||measurement||price||2015-12-02 01:33:48.552021@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||0||0
+2015-12-02 01:34:07.655144||measurement||loadtime||0:00:26.712202||5||0
+2015-12-02 01:34:07.655233||event||progress-marker||measurement-end||5||0
+2015-12-02 01:34:11.789569||measurement||loadtime||0:00:28.686431||1||1
+2015-12-02 01:34:13.321669||measurement||loadtime||0:00:26.848501||0||0
+2015-12-02 01:34:14.030957||measurement||price||2015-12-02 01:33:54.854681@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||2||1
+2015-12-02 01:34:15.412487||measurement||price||2015-12-02 01:33:57.697214@|3M Littmann@|$62.96 - $319.00@|3M Littmann Classic II S.E. Stethoscope (Multiple Colors)||3||0
+2015-12-02 01:34:16.410511||measurement||price||2015-12-02 01:33:57.272397@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||1
+2015-12-02 01:34:21.229905||measurement||loadtime||0:00:29.118425||2||1
+2015-12-02 01:34:22.520742||measurement||loadtime||0:00:27.832509||3||0
+2015-12-02 01:34:23.627959||measurement||loadtime||0:00:29.160812||4||1
+2015-12-02 01:34:25.834504||measurement||price||2015-12-02 01:34:20.408859@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||0||0
+2015-12-02 01:34:25.836535||measurement||price||2015-12-02 01:34:19.927296@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-02 01:34:35.248102||measurement||price||2015-12-02 01:34:29.878679@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-02 01:34:35.517633||measurement||price||2015-12-02 01:34:29.380679@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||1
+2015-12-02 01:34:37.578333||measurement||price||2015-12-02 01:34:31.430408@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||4||1
+2015-12-02 01:34:38.171625||measurement||price||2015-12-02 01:34:20.408859@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||0||0
+2015-12-02 01:34:38.678978||measurement||price||2015-12-02 01:34:19.927296@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-02 01:34:45.283755||measurement||loadtime||0:00:26.956874||0||0
+2015-12-02 01:34:45.283895||event||progress-marker||measurement-end||0||0
+2015-12-02 01:34:45.920006||measurement||loadtime||0:00:29.128839||1||1
+2015-12-02 01:34:47.576663||measurement||price||2015-12-02 01:34:29.878679@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-02 01:34:48.414313||measurement||price||2015-12-02 01:34:29.380679@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||1
+2015-12-02 01:34:50.419187||measurement||price||2015-12-02 01:34:31.430408@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||4||1
+2015-12-02 01:34:54.687231||measurement||loadtime||0:00:27.161319||3||0
+2015-12-02 01:34:54.687347||event||progress-marker||measurement-end||3||0
+2015-12-02 01:34:55.646638||measurement||loadtime||0:00:29.411477||2||1
+2015-12-02 01:34:57.618794||measurement||loadtime||0:00:28.985616||4||1
+2015-12-02 01:34:59.370921||measurement||price||2015-12-02 01:34:53.451887@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:35:09.699115||measurement||price||2015-12-02 01:35:03.551722@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-02 01:35:11.710676||measurement||price||2015-12-02 01:35:05.696332@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||4||1
+2015-12-02 01:35:12.353404||measurement||price||2015-12-02 01:34:53.451887@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:35:19.550318||measurement||loadtime||0:00:28.627158||1||1
+2015-12-02 01:35:22.724398||measurement||price||2015-12-02 01:35:03.551722@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-02 01:35:24.549894||measurement||price||2015-12-02 01:35:05.696332@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||4||1
+2015-12-02 01:35:29.904827||measurement||loadtime||0:00:29.253691||2||1
+2015-12-02 01:35:31.744909||measurement||loadtime||0:00:29.120864||4||1
+2015-12-02 01:35:33.307718||measurement||price||2015-12-02 01:35:27.142240@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-02 01:35:43.606663||measurement||price||2015-12-02 01:35:37.474238@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||2||1
+2015-12-02 01:35:45.531015||measurement||price||2015-12-02 01:35:39.401274@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-02 01:35:46.212732||measurement||price||2015-12-02 01:35:27.142240@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-02 01:35:53.415182||measurement||loadtime||0:00:28.859856||1||1
+2015-12-02 01:35:56.574991||measurement||price||2015-12-02 01:35:37.474238@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||2||1
+2015-12-02 01:35:58.400023||measurement||price||2015-12-02 01:35:39.401274@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-02 01:36:03.761658||measurement||loadtime||0:00:28.854361||2||1
+2015-12-02 01:36:05.598299||measurement||loadtime||0:00:28.848178||4||1
+2015-12-02 01:36:07.024043||measurement||price||2015-12-02 01:36:00.998790@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-02 01:36:17.356543||measurement||price||2015-12-02 01:36:11.239721@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-02 01:36:19.883807||measurement||price||2015-12-02 01:36:00.998790@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-02 01:36:27.097663||measurement||loadtime||0:00:28.678533||1||1
+2015-12-02 01:36:27.097773||event||progress-marker||measurement-end||1||1
+2015-12-02 01:36:29.341531||error||collecting ads||Error||4||1
+2015-12-02 01:36:30.194422||measurement||price||2015-12-02 01:36:11.239721@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-02 01:36:37.391724||measurement||loadtime||0:00:28.624857||2||1
+2015-12-02 01:36:43.082315||measurement||price||2015-12-02 01:36:36.975132@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||1
+2015-12-02 01:36:51.134805||measurement||price||2015-12-02 01:36:44.980314@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||1
+2015-12-02 01:36:55.897174||measurement||price||2015-12-02 01:36:36.975132@|@|$70.79@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||1
+2015-12-02 01:37:03.103716||measurement||loadtime||0:00:28.756980||4||1
+2015-12-02 01:37:03.103813||event||progress-marker||measurement-end||4||1
+2015-12-02 01:37:04.005430||measurement||price||2015-12-02 01:36:44.980314@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||1
+2015-12-02 01:37:11.199505||measurement||loadtime||0:00:28.802559||2||1
+2015-12-02 01:37:11.199661||event||progress-marker||measurement-end||2||1
+2015-12-02 01:37:11.740475||meta||block_id end||19
+2015-12-02 01:37:11.740758||meta||block_id start||20
+2015-12-02 01:37:11.740785||meta||assignment||1@|2@|5@|0@|4@|3
+2015-12-02 01:37:13.363787||event||progress-marker||training-start||1||0
+2015-12-02 01:37:13.381598||event||progress-marker||training-start||2||0
+2015-12-02 01:37:20.072956||treatment||visit website||http://irs.gov||1||0
+2015-12-02 01:37:20.217589||treatment||visit website||http://irs.gov||2||0
+2015-12-02 01:37:20.220026||error||website timeout||http://deloitte.com||2||0
+2015-12-02 01:37:20.221848||error||website timeout||http://pwc.com||2||0
+2015-12-02 01:37:20.223721||error||website timeout||http://ey.com||2||0
+2015-12-02 01:37:20.225598||error||website timeout||http://kpmg.com||2||0
+2015-12-02 01:37:20.225665||event||progress-marker||training-end||2||0
+2015-12-02 01:37:27.563126||treatment||visit website||http://deloitte.com||1||0
+2015-12-02 01:37:35.482576||treatment||visit website||http://pwc.com||1||0
+2015-12-02 01:37:41.274293||treatment||visit website||http://ey.com||1||0
+2015-12-02 01:37:45.432170||error||website timeout||http://kpmg.com||1||0
+2015-12-02 01:37:45.432319||event||progress-marker||training-end||1||0

--- a/AdFisher/examples/log.group.baseline.amazon.txt
+++ b/AdFisher/examples/log.group.baseline.amazon.txt
@@ -1,0 +1,7999 @@
+2015-12-01 14:06:00.075859||meta||agents||6
+2015-12-01 14:06:00.075905||meta||treatnames||control (chrome)@|experimental (firefox)
+2015-12-01 14:06:00.076097||meta||block_id start||0
+2015-12-01 14:06:00.076123||meta||assignment||1@|2@|5@|0@|3@|4
+2015-12-01 14:06:01.678696||event||progress-marker||training-start||1||0
+2015-12-01 14:06:01.678787||event||progress-marker||training-end||1||0
+2015-12-01 14:06:01.697187||event||progress-marker||training-start||2||0
+2015-12-01 14:06:01.697283||event||progress-marker||training-end||2||0
+2015-12-01 14:06:01.700177||event||progress-marker||training-start||5||0
+2015-12-01 14:06:01.700266||event||progress-marker||training-end||5||0
+2015-12-01 14:06:06.684213||event||progress-marker||measurement-start||1||0
+2015-12-01 14:06:06.702818||event||progress-marker||measurement-start||2||0
+2015-12-01 14:06:06.705799||event||progress-marker||measurement-start||5||0
+2015-12-01 14:06:21.351760||measurement||price||2015-12-01 14:06:15.943305@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||0
+2015-12-01 14:06:21.998599||measurement||price||2015-12-01 14:06:16.037164@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||0
+2015-12-01 14:06:31.778649||error||collecting ads||Error||2||0
+2015-12-01 14:06:33.709291||measurement||price||2015-12-01 14:06:15.943305@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||0
+2015-12-01 14:06:34.359035||measurement||price||2015-12-01 14:06:16.037164@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||0
+2015-12-01 14:06:40.815337||measurement||loadtime||0:00:29.108187||5||0
+2015-12-01 14:06:41.475162||measurement||loadtime||0:00:29.785655||1||0
+2015-12-01 14:06:44.621983||measurement||price||2015-12-01 14:06:39.179885@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:06:52.560338||event||progress-marker||training-start||0||1
+2015-12-01 14:06:52.560440||event||progress-marker||training-end||0||1
+2015-12-01 14:06:53.578886||measurement||price||2015-12-01 14:06:48.052737@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 14:06:54.884740||measurement||price||2015-12-01 14:06:48.886059@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||0
+2015-12-01 14:06:56.956260||measurement||price||2015-12-01 14:06:39.179885@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:06:57.566123||event||progress-marker||measurement-start||0||1
+2015-12-01 14:07:04.064360||measurement||loadtime||0:00:27.280474||2||0
+2015-12-01 14:07:05.916394||measurement||price||2015-12-01 14:06:48.052737@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 14:07:07.188011||measurement||price||2015-12-01 14:06:48.886059@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||0
+2015-12-01 14:07:13.029925||measurement||loadtime||0:00:27.209415||5||0
+2015-12-01 14:07:13.744252||measurement||price||2015-12-01 14:07:07.438811@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:07:14.271963||measurement||loadtime||0:00:27.794772||1||0
+2015-12-01 14:07:16.854051||measurement||price||2015-12-01 14:07:11.185194@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:07:25.681222||measurement||price||2015-12-01 14:07:19.919609@|At-A-Glance@|$23.97@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-01 14:07:26.628933||measurement||price||2015-12-01 14:07:07.438811@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:07:27.417551||measurement||price||2015-12-01 14:07:21.539833@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||0
+2015-12-01 14:07:29.179762||measurement||price||2015-12-01 14:07:11.185194@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:07:33.841904||measurement||loadtime||0:00:31.270556||0||1
+2015-12-01 14:07:36.292268||measurement||loadtime||0:00:27.225102||2||0
+2015-12-01 14:07:38.031007||measurement||price||2015-12-01 14:07:19.919609@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-01 14:07:39.774163||measurement||price||2015-12-01 14:07:21.539833@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||0
+2015-12-01 14:07:45.147761||measurement||loadtime||0:00:27.112628||5||0
+2015-12-01 14:07:46.936551||measurement||loadtime||0:00:27.661388||1||0
+2015-12-01 14:07:48.337802||measurement||price||2015-12-01 14:07:41.886257@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:07:49.032451||measurement||price||2015-12-01 14:07:43.320248@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 14:07:57.831296||measurement||price||2015-12-01 14:07:52.179278@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:07:59.980235||measurement||price||2015-12-01 14:07:54.213514@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||0
+2015-12-01 14:08:01.320820||measurement||price||2015-12-01 14:07:41.886257@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:08:01.363414||measurement||price||2015-12-01 14:07:43.320248@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 14:08:08.474667||measurement||loadtime||0:00:27.179385||2||0
+2015-12-01 14:08:08.535171||measurement||loadtime||0:00:29.691011||0||1
+2015-12-01 14:08:10.180730||measurement||price||2015-12-01 14:07:52.179278@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:08:12.332950||measurement||price||2015-12-01 14:07:54.213514@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||0
+2015-12-01 14:08:17.291144||measurement||loadtime||0:00:27.138192||5||0
+2015-12-01 14:08:19.429664||measurement||loadtime||0:00:27.490517||1||0
+2015-12-01 14:08:21.479830||measurement||price||2015-12-01 14:08:15.767992@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||2||0
+2015-12-01 14:08:23.065340||measurement||price||2015-12-01 14:08:16.843124@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:08:32.465719||measurement||price||2015-12-01 14:08:26.717977@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:08:33.819753||measurement||price||2015-12-01 14:08:15.767992@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||2||0
+2015-12-01 14:08:35.989492||measurement||price||2015-12-01 14:08:16.843124@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:08:36.747446||event||progress-marker||training-start||4||1
+2015-12-01 14:08:36.747544||event||progress-marker||training-end||4||1
+2015-12-01 14:08:36.748709||event||progress-marker||training-start||3||1
+2015-12-01 14:08:36.748786||event||progress-marker||training-end||3||1
+2015-12-01 14:08:40.184801||error||collecting ads||Error||5||0
+2015-12-01 14:08:40.931131||measurement||loadtime||0:00:27.451208||2||0
+2015-12-01 14:08:41.753617||event||progress-marker||measurement-start||4||1
+2015-12-01 14:08:41.754797||event||progress-marker||measurement-start||3||1
+2015-12-01 14:08:43.224297||measurement||loadtime||0:00:29.683928||0||1
+2015-12-01 14:08:44.831139||measurement||price||2015-12-01 14:08:26.717977@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:08:51.923160||measurement||loadtime||0:00:27.488292||1||0
+2015-12-01 14:08:53.035754||measurement||price||2015-12-01 14:08:47.403478@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:08:57.481400||measurement||price||2015-12-01 14:08:51.281626@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||3||1
+2015-12-01 14:08:57.644673||measurement||price||2015-12-01 14:08:51.308280@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||1
+2015-12-01 14:08:58.391576||measurement||price||2015-12-01 14:08:52.137729@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||0||1
+2015-12-01 14:09:04.006715||error||collecting ads||Error||2||0
+2015-12-01 14:09:05.047017||measurement||price||2015-12-01 14:08:59.250446@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||0
+2015-12-01 14:09:05.378989||measurement||price||2015-12-01 14:08:47.403478@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:09:10.434509||measurement||price||2015-12-01 14:08:51.281626@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||3||1
+2015-12-01 14:09:10.578628||measurement||price||2015-12-01 14:08:51.308280@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||1
+2015-12-01 14:09:11.280579||measurement||price||2015-12-01 14:08:52.137729@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||0||1
+2015-12-01 14:09:12.505019||measurement||loadtime||0:00:27.314988||5||0
+2015-12-01 14:09:17.418448||measurement||price||2015-12-01 14:08:59.250446@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||0
+2015-12-01 14:09:17.655160||measurement||loadtime||0:00:30.895810||3||1
+2015-12-01 14:09:17.785030||measurement||loadtime||0:00:31.026132||4||1
+2015-12-01 14:09:18.488558||measurement||loadtime||0:00:30.261406||0||1
+2015-12-01 14:09:24.567150||measurement||loadtime||0:00:27.641155||1||0
+2015-12-01 14:09:26.863170||error||collecting ads||Error||2||0
+2015-12-01 14:09:32.039579||measurement||price||2015-12-01 14:09:25.451074@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:09:32.938231||measurement||price||2015-12-01 14:09:26.530609@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||1
+2015-12-01 14:09:32.960731||measurement||price||2015-12-01 14:09:26.526145@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:09:35.295374||error||collecting ads||Error||5||0
+2015-12-01 14:09:37.781685||measurement||price||2015-12-01 14:09:32.182860@|At-A-Glance@|$23.97@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||1||0
+2015-12-01 14:09:39.561507||measurement||price||2015-12-01 14:09:34.120837@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:09:44.874210||measurement||price||2015-12-01 14:09:25.451074@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:09:45.862055||measurement||price||2015-12-01 14:09:26.530609@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||1
+2015-12-01 14:09:45.893360||measurement||price||2015-12-01 14:09:26.526145@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:09:48.131858||measurement||price||2015-12-01 14:09:42.484264@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-01 14:09:50.121721||measurement||price||2015-12-01 14:09:32.182860@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||1||0
+2015-12-01 14:09:51.912589||measurement||price||2015-12-01 14:09:34.120837@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:09:52.080122||measurement||loadtime||0:00:29.292960||4||1
+2015-12-01 14:09:53.076612||measurement||loadtime||0:00:30.416246||3||1
+2015-12-01 14:09:53.104544||measurement||loadtime||0:00:29.610774||0||1
+2015-12-01 14:09:57.227163||measurement||loadtime||0:00:27.656279||1||0
+2015-12-01 14:09:59.009235||measurement||loadtime||0:00:27.143191||2||0
+2015-12-01 14:10:00.502534||measurement||price||2015-12-01 14:09:42.484264@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-01 14:10:06.543701||measurement||price||2015-12-01 14:10:00.046503@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:10:07.597312||measurement||price||2015-12-01 14:10:01.250867@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:10:07.622768||measurement||loadtime||0:00:27.323654||5||0
+2015-12-01 14:10:09.994548||measurement||price||2015-12-01 14:10:04.410557@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:10:17.456748||error||collecting ads||Error||0||1
+2015-12-01 14:10:19.477061||measurement||price||2015-12-01 14:10:00.046503@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:10:20.463433||measurement||price||2015-12-01 14:10:14.610804@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:10:20.561378||measurement||price||2015-12-01 14:10:01.250867@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:10:21.875819||error||collecting ads||Error||2||0
+2015-12-01 14:10:22.313046||measurement||price||2015-12-01 14:10:04.410557@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:10:26.739157||measurement||loadtime||0:00:29.653827||4||1
+2015-12-01 14:10:27.791174||measurement||loadtime||0:00:29.709326||3||1
+2015-12-01 14:10:29.425510||measurement||loadtime||0:00:27.194366||1||0
+2015-12-01 14:10:32.008348||measurement||price||2015-12-01 14:10:25.128369@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:10:32.804178||measurement||price||2015-12-01 14:10:14.610804@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:10:39.919430||measurement||loadtime||0:00:27.291488||5||0
+2015-12-01 14:10:40.933905||measurement||price||2015-12-01 14:10:34.550010@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:10:42.202118||measurement||price||2015-12-01 14:10:35.150280@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:10:42.356487||measurement||price||2015-12-01 14:10:36.662612@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:10:44.739495||error||collecting ads||Error||2||0
+2015-12-01 14:10:44.950757||measurement||price||2015-12-01 14:10:25.128369@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:10:52.163148||measurement||loadtime||0:00:29.701136||0||1
+2015-12-01 14:10:53.107570||measurement||price||2015-12-01 14:10:47.464918@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||5||0
+2015-12-01 14:10:53.910397||measurement||price||2015-12-01 14:10:34.550010@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:10:54.654139||measurement||price||2015-12-01 14:10:36.662612@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:10:55.168650||measurement||price||2015-12-01 14:10:35.150280@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:10:57.581988||measurement||price||2015-12-01 14:10:51.907699@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:11:01.127154||measurement||loadtime||0:00:29.382797||4||1
+2015-12-01 14:11:01.731174||measurement||loadtime||0:00:27.300480||1||0
+2015-12-01 14:11:02.375288||measurement||loadtime||0:00:29.580132||3||1
+2015-12-01 14:11:05.458563||measurement||price||2015-12-01 14:10:47.464918@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||5||0
+2015-12-01 14:11:06.414038||measurement||price||2015-12-01 14:11:00.181563@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:11:09.942740||measurement||price||2015-12-01 14:10:51.907699@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:11:12.574921||measurement||loadtime||0:00:27.651771||5||0
+2015-12-01 14:11:15.563757||measurement||price||2015-12-01 14:11:09.441122@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:11:17.059973||measurement||loadtime||0:00:27.316837||2||0
+2015-12-01 14:11:17.067927||measurement||price||2015-12-01 14:11:10.320734@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:11:19.232400||measurement||price||2015-12-01 14:11:00.181563@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:11:24.652703||error||collecting ads||Error||1||0
+2015-12-01 14:11:25.718615||measurement||price||2015-12-01 14:11:20.070574@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||5||0
+2015-12-01 14:11:26.436247||measurement||loadtime||0:00:29.267914||0||1
+2015-12-01 14:11:28.553720||measurement||price||2015-12-01 14:11:09.441122@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:11:30.028721||measurement||price||2015-12-01 14:11:10.320734@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:11:30.066624||measurement||price||2015-12-01 14:11:24.412607@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:11:35.778939||measurement||loadtime||0:00:29.648371||4||1
+2015-12-01 14:11:37.225991||measurement||loadtime||0:00:29.847131||3||1
+2015-12-01 14:11:37.597681||measurement||price||2015-12-01 14:11:31.915675@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:11:38.075144||measurement||price||2015-12-01 14:11:20.070574@|Electronic Arts@|    @|Star Wars: Battlefront - Standard Edition - Xbox One||5||0
+2015-12-01 14:11:42.363215||measurement||price||2015-12-01 14:11:24.412607@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:11:45.185599||measurement||loadtime||0:00:27.606402||5||0
+2015-12-01 14:11:49.444241||measurement||loadtime||0:00:27.379062||2||0
+2015-12-01 14:11:49.924745||measurement||price||2015-12-01 14:11:43.947496@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:11:49.945224||measurement||price||2015-12-01 14:11:31.915675@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:11:50.873413||error||collecting ads||Error||0||1
+2015-12-01 14:11:51.682197||measurement||price||2015-12-01 14:11:45.105559@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:11:57.043169||measurement||loadtime||0:00:27.388010||1||0
+2015-12-01 14:12:02.831711||measurement||price||2015-12-01 14:11:43.947496@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:12:04.900810||measurement||price||2015-12-01 14:11:45.105559@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:12:08.514227||error||collecting ads||Error||5||0
+2015-12-01 14:12:09.327965||measurement||price||2015-12-01 14:12:03.751364@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:12:10.080428||measurement||loadtime||0:00:29.297155||4||1
+2015-12-01 14:12:12.133223||measurement||loadtime||0:00:29.902057||3||1
+2015-12-01 14:12:12.498017||error||collecting ads||Error||2||0
+2015-12-01 14:12:15.326160||error||collecting ads||Error||0||1
+2015-12-01 14:12:21.663544||measurement||price||2015-12-01 14:12:03.751364@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:12:24.329724||measurement||price||2015-12-01 14:12:18.281178@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:12:26.801463||measurement||price||2015-12-01 14:12:20.029483@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:12:28.756501||measurement||loadtime||0:00:26.708120||1||0
+2015-12-01 14:12:29.807455||measurement||price||2015-12-01 14:12:23.458757@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:12:31.503284||error||collecting ads||Error||5||0
+2015-12-01 14:12:35.644014||error||collecting ads||Error||2||0
+2015-12-01 14:12:37.433853||measurement||price||2015-12-01 14:12:18.281178@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:12:39.875782||measurement||price||2015-12-01 14:12:20.029483@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:12:42.756423||measurement||price||2015-12-01 14:12:23.458757@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:12:44.388792||measurement||price||2015-12-01 14:12:38.718727@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:12:44.695952||measurement||loadtime||0:00:29.612809||4||1
+2015-12-01 14:12:47.070134||measurement||loadtime||0:00:29.934965||3||1
+2015-12-01 14:12:48.501946||measurement||price||2015-12-01 14:12:42.775705@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:12:50.027787||measurement||loadtime||0:00:29.696614||0||1
+2015-12-01 14:12:51.488069||error||collecting ads||Error||1||0
+2015-12-01 14:12:56.759506||measurement||price||2015-12-01 14:12:38.718727@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:12:58.948014||measurement||price||2015-12-01 14:12:52.584177@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:13:00.835500||measurement||price||2015-12-01 14:12:42.775705@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:13:03.850277||measurement||loadtime||0:00:27.341784||5||0
+2015-12-01 14:13:04.177242||measurement||price||2015-12-01 14:12:57.405784@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:13:07.931453||measurement||loadtime||0:00:27.282206||2||0
+2015-12-01 14:13:11.659266||error||collecting ads||Error||3||1
+2015-12-01 14:13:12.025439||measurement||price||2015-12-01 14:12:52.584177@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:13:14.254516||error||collecting ads||Error||1||0
+2015-12-01 14:13:16.665338||measurement||price||2015-12-01 14:13:10.954345@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:13:17.094651||measurement||price||2015-12-01 14:12:57.405784@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:13:19.255158||measurement||loadtime||0:00:29.555553||4||1
+2015-12-01 14:13:20.255098||measurement||price||2015-12-01 14:13:14.692656@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:13:24.323180||measurement||loadtime||0:00:29.290171||0||1
+2015-12-01 14:13:26.041787||measurement||price||2015-12-01 14:13:19.308383@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:13:26.590839||measurement||price||2015-12-01 14:13:20.973087@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:13:28.988569||measurement||price||2015-12-01 14:13:10.954345@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:13:32.581398||measurement||price||2015-12-01 14:13:14.692656@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:13:33.645644||measurement||price||2015-12-01 14:13:27.229365@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:13:36.103194||measurement||loadtime||0:00:27.247686||5||0
+2015-12-01 14:13:38.684456||measurement||price||2015-12-01 14:13:31.886385@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:13:38.914104||measurement||price||2015-12-01 14:13:20.973087@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:13:39.008886||measurement||price||2015-12-01 14:13:19.308383@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:13:39.729607||measurement||loadtime||0:00:26.792942||2||0
+2015-12-01 14:13:46.010812||measurement||loadtime||0:00:26.751670||1||0
+2015-12-01 14:13:46.263156||measurement||loadtime||0:00:29.600027||3||1
+2015-12-01 14:13:46.611534||measurement||price||2015-12-01 14:13:27.229365@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:13:49.280080||measurement||price||2015-12-01 14:13:43.625331@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:13:51.710128||measurement||price||2015-12-01 14:13:31.886385@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:13:52.075240||measurement||price||2015-12-01 14:13:46.462068@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:13:53.858157||measurement||loadtime||0:00:29.597799||4||1
+2015-12-01 14:13:58.718561||measurement||price||2015-12-01 14:13:53.073716@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:13:58.911805||measurement||loadtime||0:00:29.584640||0||1
+2015-12-01 14:14:00.628914||measurement||price||2015-12-01 14:13:53.641879@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:14:01.599789||measurement||price||2015-12-01 14:13:43.625331@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:14:04.424633||measurement||price||2015-12-01 14:13:46.462068@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:14:08.720362||measurement||loadtime||0:00:27.611958||5||0
+2015-12-01 14:14:11.052574||measurement||price||2015-12-01 14:13:53.073716@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:14:11.534347||measurement||loadtime||0:00:26.799526||2||0
+2015-12-01 14:14:13.516531||measurement||price||2015-12-01 14:13:53.641879@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:14:18.175155||measurement||loadtime||0:00:27.159113||1||0
+2015-12-01 14:14:18.196485||error||collecting ads||Error||4||1
+2015-12-01 14:14:20.733188||measurement||loadtime||0:00:29.466042||3||1
+2015-12-01 14:14:21.090426||measurement||price||2015-12-01 14:14:15.426816@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:14:23.012860||error||collecting ads||Error||0||1
+2015-12-01 14:14:23.825532||measurement||price||2015-12-01 14:14:18.231913@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:14:30.556189||measurement||price||2015-12-01 14:14:24.953470@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:14:32.906379||measurement||price||2015-12-01 14:14:26.318717@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:14:33.438773||measurement||price||2015-12-01 14:14:15.426816@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:14:34.913488||measurement||price||2015-12-01 14:14:28.070536@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:14:36.168027||measurement||price||2015-12-01 14:14:18.231913@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:14:40.547158||measurement||loadtime||0:00:26.821611||5||0
+2015-12-01 14:14:42.857539||measurement||price||2015-12-01 14:14:24.953470@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:14:43.292415||measurement||loadtime||0:00:26.753247||2||0
+2015-12-01 14:14:45.878368||measurement||price||2015-12-01 14:14:26.318717@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:14:47.001085||error||collecting ads||Error||0||1
+2015-12-01 14:14:47.766781||measurement||price||2015-12-01 14:14:28.070536@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:14:49.947180||measurement||loadtime||0:00:26.766835||1||0
+2015-12-01 14:14:53.078498||measurement||loadtime||0:00:29.879359||4||1
+2015-12-01 14:14:53.270500||measurement||price||2015-12-01 14:14:47.619239@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:14:54.978467||measurement||loadtime||0:00:29.243321||3||1
+2015-12-01 14:14:55.584130||measurement||price||2015-12-01 14:14:49.962403@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:15:02.690637||measurement||price||2015-12-01 14:14:57.114324@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:15:05.592194||measurement||price||2015-12-01 14:14:47.619239@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:15:06.973917||measurement||price||2015-12-01 14:15:00.559677@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:15:07.931008||measurement||price||2015-12-01 14:14:49.962403@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:15:09.101820||measurement||price||2015-12-01 14:15:02.282618@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:15:11.580943||error||collecting ads||Error||0||1
+2015-12-01 14:15:12.699561||measurement||loadtime||0:00:27.147186||5||0
+2015-12-01 14:15:15.033381||measurement||price||2015-12-01 14:14:57.114324@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:15:15.043780||measurement||loadtime||0:00:26.748622||2||0
+2015-12-01 14:15:19.803903||measurement||price||2015-12-01 14:15:00.559677@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:15:22.147157||measurement||loadtime||0:00:27.194786||1||0
+2015-12-01 14:15:22.155481||measurement||price||2015-12-01 14:15:02.282618@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:15:25.551742||measurement||price||2015-12-01 14:15:19.909104@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:15:25.717313||measurement||price||2015-12-01 14:15:18.963928@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:15:27.019203||measurement||loadtime||0:00:28.936026||4||1
+2015-12-01 14:15:27.474162||measurement||price||2015-12-01 14:15:21.870591@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:15:29.383174||measurement||loadtime||0:00:29.403586||3||1
+2015-12-01 14:15:34.476944||measurement||price||2015-12-01 14:15:28.856957@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:15:37.901078||measurement||price||2015-12-01 14:15:19.909104@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:15:38.646557||measurement||price||2015-12-01 14:15:18.963928@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:15:39.833072||measurement||price||2015-12-01 14:15:21.870591@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:15:43.705831||measurement||price||2015-12-01 14:15:37.306999@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:15:45.007704||measurement||loadtime||0:00:27.307338||5||0
+2015-12-01 14:15:45.852605||measurement||loadtime||0:00:29.266439||0||1
+2015-12-01 14:15:46.822044||measurement||price||2015-12-01 14:15:28.856957@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:15:46.942607||measurement||loadtime||0:00:26.893629||2||0
+2015-12-01 14:15:46.942717||event||progress-marker||measurement-end||2||0
+2015-12-01 14:15:50.978874||error||collecting ads||Error||4||1
+2015-12-01 14:15:53.931173||measurement||loadtime||0:00:26.782403||1||0
+2015-12-01 14:15:56.775845||measurement||price||2015-12-01 14:15:37.306999@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:15:59.970427||measurement||price||2015-12-01 14:15:53.338574@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:16:04.035127||measurement||loadtime||0:00:29.647933||3||1
+2015-12-01 14:16:04.891971||measurement||price||2015-12-01 14:15:58.330119@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:16:06.339977||measurement||price||2015-12-01 14:16:00.632692@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:16:08.073028||error||collecting ads||Error||5||0
+2015-12-01 14:16:08.073153||event||progress-marker||measurement-end||5||0
+2015-12-01 14:16:13.011503||measurement||price||2015-12-01 14:15:53.338574@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:16:17.813529||measurement||price||2015-12-01 14:15:58.330119@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:16:17.993973||measurement||price||2015-12-01 14:16:11.424848@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:16:18.680454||measurement||price||2015-12-01 14:16:00.632692@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:16:20.231259||measurement||loadtime||0:00:29.376089||0||1
+2015-12-01 14:16:24.995866||measurement||loadtime||0:00:29.011758||4||1
+2015-12-01 14:16:25.803259||measurement||loadtime||0:00:26.868091||1||0
+2015-12-01 14:16:25.803412||event||progress-marker||measurement-end||1||0
+2015-12-01 14:16:30.900504||measurement||price||2015-12-01 14:16:11.424848@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:16:34.211614||measurement||price||2015-12-01 14:16:27.889388@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:16:38.105814||measurement||loadtime||0:00:29.069396||3||1
+2015-12-01 14:16:38.636471||measurement||price||2015-12-01 14:16:32.504963@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:16:47.043255||measurement||price||2015-12-01 14:16:27.889388@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:16:51.648136||measurement||price||2015-12-01 14:16:32.504963@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:16:54.226834||measurement||loadtime||0:00:28.990329||0||1
+2015-12-01 14:16:58.843445||measurement||loadtime||0:00:28.842330||4||1
+2015-12-01 14:17:01.859872||error||collecting ads||Error||3||1
+2015-12-01 14:17:08.112584||measurement||price||2015-12-01 14:17:01.499402@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:17:12.362432||measurement||price||2015-12-01 14:17:06.418072@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:17:15.910804||measurement||price||2015-12-01 14:17:09.456748@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:17:21.117481||measurement||price||2015-12-01 14:17:01.499402@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:17:25.207628||measurement||price||2015-12-01 14:17:06.418072@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:17:28.317005||measurement||loadtime||0:00:29.084930||0||1
+2015-12-01 14:17:28.317146||event||progress-marker||measurement-end||0||1
+2015-12-01 14:17:28.843729||measurement||price||2015-12-01 14:17:09.456748@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:17:32.402955||measurement||loadtime||0:00:28.554276||4||1
+2015-12-01 14:17:36.041205||measurement||loadtime||0:00:29.176101||3||1
+2015-12-01 14:17:46.341986||measurement||price||2015-12-01 14:17:39.845158@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:17:50.138789||measurement||price||2015-12-01 14:17:43.712981@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:17:59.230951||measurement||price||2015-12-01 14:17:39.845158@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:18:02.962625||measurement||price||2015-12-01 14:17:43.712981@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:18:06.409384||measurement||loadtime||0:00:29.001138||4||1
+2015-12-01 14:18:10.163549||measurement||loadtime||0:00:29.118885||3||1
+2015-12-01 14:18:20.425485||measurement||price||2015-12-01 14:18:14.364444@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:18:24.745567||measurement||price||2015-12-01 14:18:18.247076@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:18:33.526715||measurement||price||2015-12-01 14:18:14.364444@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:18:37.819200||measurement||price||2015-12-01 14:18:18.247076@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:18:40.741812||measurement||loadtime||0:00:29.327179||4||1
+2015-12-01 14:18:45.038760||measurement||loadtime||0:00:29.869973||3||1
+2015-12-01 14:18:55.104022||measurement||price||2015-12-01 14:18:48.769468@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:18:58.902541||measurement||price||2015-12-01 14:18:52.608792@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:19:08.114090||measurement||price||2015-12-01 14:18:48.769468@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:19:11.752238||measurement||price||2015-12-01 14:18:52.608792@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:19:15.440408||measurement||loadtime||0:00:29.693332||4||1
+2015-12-01 14:19:18.943457||measurement||loadtime||0:00:28.899424||3||1
+2015-12-01 14:19:29.354918||measurement||price||2015-12-01 14:19:23.012979@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:19:32.828943||measurement||price||2015-12-01 14:19:26.621627@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:19:42.335336||measurement||price||2015-12-01 14:19:23.012979@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:19:45.716807||measurement||price||2015-12-01 14:19:26.621627@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:19:49.533932||measurement||loadtime||0:00:29.088315||4||1
+2015-12-01 14:19:49.534069||event||progress-marker||measurement-end||4||1
+2015-12-01 14:19:52.930297||measurement||loadtime||0:00:28.981567||3||1
+2015-12-01 14:19:52.930435||event||progress-marker||measurement-end||3||1
+2015-12-01 14:19:53.371360||meta||block_id end||0
+2015-12-01 14:19:53.371659||meta||block_id start||1
+2015-12-01 14:19:53.371690||meta||assignment||1@|4@|3@|5@|0@|2
+2015-12-01 14:19:54.986295||event||progress-marker||training-start||3||0
+2015-12-01 14:19:54.986406||event||progress-marker||training-end||3||0
+2015-12-01 14:19:55.024320||event||progress-marker||training-start||1||0
+2015-12-01 14:19:55.024409||event||progress-marker||training-end||1||0
+2015-12-01 14:19:55.029018||event||progress-marker||training-start||4||0
+2015-12-01 14:19:55.029111||event||progress-marker||training-end||4||0
+2015-12-01 14:19:59.995079||event||progress-marker||measurement-start||3||0
+2015-12-01 14:20:00.033098||event||progress-marker||measurement-start||1||0
+2015-12-01 14:20:00.036448||event||progress-marker||measurement-start||4||0
+2015-12-01 14:20:13.665708||measurement||price||2015-12-01 14:20:08.250115@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 14:20:13.699568||measurement||price||2015-12-01 14:20:07.713987@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:20:13.794284||measurement||price||2015-12-01 14:20:08.342166@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 14:20:26.032687||measurement||price||2015-12-01 14:20:08.250115@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 14:20:26.054633||measurement||price||2015-12-01 14:20:07.713987@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:20:26.151433||measurement||price||2015-12-01 14:20:08.342166@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 14:20:33.145416||measurement||loadtime||0:00:28.146361||3||0
+2015-12-01 14:20:33.172180||measurement||loadtime||0:00:28.137041||1||0
+2015-12-01 14:20:33.251493||measurement||loadtime||0:00:28.212352||4||0
+2015-12-01 14:20:45.606958||measurement||price||2015-12-01 14:20:40.021639@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:20:46.127882||measurement||price||2015-12-01 14:20:40.309966@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 14:20:46.335349||measurement||price||2015-12-01 14:20:40.532021@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:20:57.942800||measurement||price||2015-12-01 14:20:40.021639@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:20:58.468479||measurement||price||2015-12-01 14:20:40.309966@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 14:20:58.641799||measurement||price||2015-12-01 14:20:40.532021@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:21:05.059636||measurement||loadtime||0:00:26.884469||1||0
+2015-12-01 14:21:05.589216||measurement||loadtime||0:00:27.438576||3||0
+2015-12-01 14:21:05.717882||measurement||loadtime||0:00:27.462741||4||0
+2015-12-01 14:21:18.480615||measurement||price||2015-12-01 14:21:12.851939@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 14:21:18.628054||measurement||price||2015-12-01 14:21:12.999292@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 14:21:28.081192||error||collecting ads||Error||1||0
+2015-12-01 14:21:29.977477||event||progress-marker||training-start||2||1
+2015-12-01 14:21:29.977580||event||progress-marker||training-end||2||1
+2015-12-01 14:21:30.799285||measurement||price||2015-12-01 14:21:12.851939@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 14:21:30.988430||measurement||price||2015-12-01 14:21:12.999292@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 14:21:31.222628||event||progress-marker||training-start||5||1
+2015-12-01 14:21:31.222742||event||progress-marker||training-end||5||1
+2015-12-01 14:21:34.037311||event||progress-marker||training-start||0||1
+2015-12-01 14:21:34.037452||event||progress-marker||training-end||0||1
+2015-12-01 14:21:34.986392||event||progress-marker||measurement-start||2||1
+2015-12-01 14:21:36.231758||event||progress-marker||measurement-start||5||1
+2015-12-01 14:21:37.880585||measurement||loadtime||0:00:27.286144||3||0
+2015-12-01 14:21:38.103706||measurement||loadtime||0:00:27.384540||4||0
+2015-12-01 14:21:39.046445||event||progress-marker||measurement-start||0||1
+2015-12-01 14:21:40.441859||measurement||price||2015-12-01 14:21:34.872176@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:21:50.949898||measurement||price||2015-12-01 14:21:44.690671@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||2||1
+2015-12-01 14:21:51.337513||measurement||price||2015-12-01 14:21:45.802240@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:21:51.911186||measurement||price||2015-12-01 14:21:45.231965@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 14:21:52.765856||measurement||price||2015-12-01 14:21:34.872176@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:21:59.874701||measurement||loadtime||0:00:26.788314||1||0
+2015-12-01 14:22:00.926907||error||collecting ads||Error||3||0
+2015-12-01 14:22:03.674101||measurement||price||2015-12-01 14:21:45.802240@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:22:03.840377||measurement||price||2015-12-01 14:21:44.690671@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||2||1
+2015-12-01 14:22:04.171733||error||collecting ads||Error||0||1
+2015-12-01 14:22:04.854860||measurement||price||2015-12-01 14:21:45.231965@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 14:22:10.788128||measurement||loadtime||0:00:27.679214||4||0
+2015-12-01 14:22:11.059182||measurement||loadtime||0:00:31.067550||2||1
+2015-12-01 14:22:12.089421||measurement||loadtime||0:00:30.852463||5||1
+2015-12-01 14:22:13.457134||measurement||price||2015-12-01 14:22:07.746030@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:22:18.691595||measurement||price||2015-12-01 14:22:12.131792@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:22:22.686304||error||collecting ads||Error||1||0
+2015-12-01 14:22:23.742019||measurement||price||2015-12-01 14:22:18.118894@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:22:25.779826||measurement||price||2015-12-01 14:22:07.746030@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:22:26.489504||measurement||price||2015-12-01 14:22:19.674062@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:22:31.671502||measurement||price||2015-12-01 14:22:12.131792@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:22:32.885539||measurement||loadtime||0:00:26.953407||3||0
+2015-12-01 14:22:35.085014||measurement||price||2015-12-01 14:22:29.516199@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:22:36.030317||measurement||price||2015-12-01 14:22:18.118894@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:22:36.712805||error||collecting ads||Error||5||1
+2015-12-01 14:22:38.887168||measurement||loadtime||0:00:29.710203||0||1
+2015-12-01 14:22:39.503800||measurement||price||2015-12-01 14:22:19.674062@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:22:43.112470||measurement||loadtime||0:00:27.319118||4||0
+2015-12-01 14:22:45.513568||measurement||price||2015-12-01 14:22:39.897904@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 14:22:46.711190||measurement||loadtime||0:00:30.648029||2||1
+2015-12-01 14:22:47.418211||measurement||price||2015-12-01 14:22:29.516199@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:22:51.138796||measurement||price||2015-12-01 14:22:44.595603@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 14:22:54.527174||measurement||loadtime||0:00:26.840282||1||0
+2015-12-01 14:22:54.769123||measurement||price||2015-12-01 14:22:46.957656@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:22:57.819332||measurement||price||2015-12-01 14:22:39.897904@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 14:23:01.941371||measurement||price||2015-12-01 14:22:55.554979@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 14:23:04.050490||measurement||price||2015-12-01 14:22:44.595603@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 14:23:04.928534||measurement||loadtime||0:00:27.037787||3||0
+2015-12-01 14:23:07.403982||measurement||price||2015-12-01 14:23:01.769081@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:23:07.899594||measurement||price||2015-12-01 14:22:46.957656@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:23:08.630492||error||collecting ads||Error||4||0
+2015-12-01 14:23:11.282709||measurement||loadtime||0:00:29.564653||5||1
+2015-12-01 14:23:14.932873||measurement||price||2015-12-01 14:22:55.554979@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 14:23:15.111167||measurement||loadtime||0:00:31.219997||0||1
+2015-12-01 14:23:19.685516||measurement||price||2015-12-01 14:23:01.769081@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:23:21.380345||measurement||price||2015-12-01 14:23:15.757679@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 14:23:22.176958||measurement||loadtime||0:00:30.460532||2||1
+2015-12-01 14:23:25.537568||measurement||price||2015-12-01 14:23:19.233622@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 14:23:26.767160||measurement||loadtime||0:00:27.234775||1||0
+2015-12-01 14:23:27.675833||error||collecting ads||Error||3||0
+2015-12-01 14:23:29.663601||measurement||price||2015-12-01 14:23:23.597766@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:23:33.705966||measurement||price||2015-12-01 14:23:15.757679@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 14:23:36.276890||measurement||price||2015-12-01 14:23:30.286828@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:23:38.425648||measurement||price||2015-12-01 14:23:19.233622@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 14:23:40.799176||measurement||loadtime||0:00:27.164028||4||0
+2015-12-01 14:23:40.920460||measurement||price||2015-12-01 14:23:35.298764@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||0
+2015-12-01 14:23:42.860104||measurement||price||2015-12-01 14:23:23.597766@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:23:45.639364||measurement||loadtime||0:00:29.351432||5||1
+2015-12-01 14:23:49.180240||measurement||price||2015-12-01 14:23:30.286828@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:23:49.521504||error||collecting ads||Error||1||0
+2015-12-01 14:23:50.158444||measurement||loadtime||0:00:30.042073||0||1
+2015-12-01 14:23:53.090460||measurement||price||2015-12-01 14:23:47.566657@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 14:23:53.359402||measurement||price||2015-12-01 14:23:35.298764@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||0
+2015-12-01 14:23:56.431085||measurement||loadtime||0:00:29.248887||2||1
+2015-12-01 14:23:59.683374||measurement||price||2015-12-01 14:23:52.890203@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:24:00.462449||measurement||loadtime||0:00:27.785996||3||0
+2015-12-01 14:24:02.314338||measurement||price||2015-12-01 14:23:56.717766@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:24:04.383761||measurement||price||2015-12-01 14:23:57.834414@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:24:05.419771||measurement||price||2015-12-01 14:23:47.566657@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 14:24:10.853750||measurement||price||2015-12-01 14:24:04.656193@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:24:12.533987||measurement||loadtime||0:00:26.729573||4||0
+2015-12-01 14:24:12.825205||measurement||price||2015-12-01 14:23:52.890203@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:24:13.465302||measurement||price||2015-12-01 14:24:07.879073@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 14:24:14.631765||measurement||price||2015-12-01 14:23:56.717766@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:24:17.206825||measurement||price||2015-12-01 14:23:57.834414@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:24:20.055675||measurement||loadtime||0:00:29.413761||5||1
+2015-12-01 14:24:21.748979||measurement||loadtime||0:00:27.225814||1||0
+2015-12-01 14:24:23.999747||measurement||price||2015-12-01 14:24:04.656193@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:24:24.425088||measurement||loadtime||0:00:29.261441||0||1
+2015-12-01 14:24:25.805396||measurement||price||2015-12-01 14:24:07.879073@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 14:24:31.207335||measurement||loadtime||0:00:29.771027||2||1
+2015-12-01 14:24:32.918279||measurement||loadtime||0:00:27.450624||3||0
+2015-12-01 14:24:34.069954||measurement||price||2015-12-01 14:24:28.465199@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:24:34.742398||measurement||price||2015-12-01 14:24:27.877080@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 14:24:34.858404||error||collecting ads||Error||4||0
+2015-12-01 14:24:38.817299||measurement||price||2015-12-01 14:24:32.406606@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:24:45.370052||measurement||price||2015-12-01 14:24:39.828529@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 14:24:46.390892||measurement||price||2015-12-01 14:24:28.465199@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:24:47.184643||measurement||price||2015-12-01 14:24:41.613072@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:24:47.861156||measurement||price||2015-12-01 14:24:27.877080@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 14:24:51.758650||measurement||price||2015-12-01 14:24:32.406606@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:24:53.510556||measurement||loadtime||0:00:26.756349||1||0
+2015-12-01 14:24:55.163547||measurement||loadtime||0:00:30.102657||5||1
+2015-12-01 14:24:55.674801||error||collecting ads||Error||2||1
+2015-12-01 14:24:57.675294||measurement||price||2015-12-01 14:24:39.828529@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 14:24:58.968148||measurement||loadtime||0:00:29.537839||0||1
+2015-12-01 14:24:59.528218||measurement||price||2015-12-01 14:24:41.613072@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:25:04.758694||measurement||loadtime||0:00:26.835204||3||0
+2015-12-01 14:25:06.638259||measurement||loadtime||0:00:26.775083||4||0
+2015-12-01 14:25:15.827957||error||collecting ads||Error||1||0
+2015-12-01 14:25:17.060490||measurement||price||2015-12-01 14:25:11.547390@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 14:25:18.990294||measurement||price||2015-12-01 14:25:13.397554@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 14:25:19.600142||error||collecting ads||Error||5||1
+2015-12-01 14:25:19.743145||error||collecting ads||Error||2||1
+2015-12-01 14:25:22.891006||error||collecting ads||Error||0||1
+2015-12-01 14:25:28.571816||measurement||price||2015-12-01 14:25:22.911219@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:25:29.402916||measurement||price||2015-12-01 14:25:11.547390@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 14:25:31.293045||measurement||price||2015-12-01 14:25:13.397554@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 14:25:33.898437||measurement||price||2015-12-01 14:25:27.591141@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:25:34.372183||measurement||price||2015-12-01 14:25:28.160490@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:25:36.513946||measurement||loadtime||0:00:26.750044||3||0
+2015-12-01 14:25:37.230480||measurement||price||2015-12-01 14:25:30.667885@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:25:38.368917||measurement||loadtime||0:00:26.725764||4||0
+2015-12-01 14:25:40.890506||measurement||price||2015-12-01 14:25:22.911219@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:25:47.139590||measurement||price||2015-12-01 14:25:27.591141@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:25:47.467305||measurement||price||2015-12-01 14:25:28.160490@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:25:47.985791||measurement||loadtime||0:00:27.154631||1||0
+2015-12-01 14:25:48.779061||measurement||price||2015-12-01 14:25:43.267972@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:25:50.210721||measurement||price||2015-12-01 14:25:30.667885@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:25:50.629781||measurement||price||2015-12-01 14:25:45.019660@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:25:54.351170||measurement||loadtime||0:00:29.748390||5||1
+2015-12-01 14:25:54.707154||measurement||loadtime||0:00:29.958804||2||1
+2015-12-01 14:25:57.429706||measurement||loadtime||0:00:29.534544||0||1
+2015-12-01 14:26:00.733030||measurement||price||2015-12-01 14:25:55.080732@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:26:01.110146||measurement||price||2015-12-01 14:25:43.267972@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:26:02.958899||measurement||price||2015-12-01 14:25:45.019660@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:26:08.085954||measurement||price||2015-12-01 14:26:01.593647@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:26:08.235554||measurement||loadtime||0:00:26.716334||3||0
+2015-12-01 14:26:08.866605||measurement||price||2015-12-01 14:26:02.851980@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 14:26:10.077543||measurement||loadtime||0:00:26.706388||4||0
+2015-12-01 14:26:11.776626||measurement||price||2015-12-01 14:26:05.223950@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:26:13.074496||measurement||price||2015-12-01 14:25:55.080732@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:26:20.192037||measurement||loadtime||0:00:27.201025||1||0
+2015-12-01 14:26:20.616864||measurement||price||2015-12-01 14:26:14.932562@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 14:26:21.090584||measurement||price||2015-12-01 14:26:01.593647@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:26:21.763737||measurement||price||2015-12-01 14:26:02.851980@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 14:26:23.127115||measurement||price||2015-12-01 14:26:17.748600@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 14:26:24.962977||measurement||price||2015-12-01 14:26:05.223950@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:26:28.309140||measurement||loadtime||0:00:28.952754||5||1
+2015-12-01 14:26:28.984250||measurement||loadtime||0:00:29.275283||2||1
+2015-12-01 14:26:32.219181||measurement||loadtime||0:00:29.784188||0||1
+2015-12-01 14:26:32.947449||measurement||price||2015-12-01 14:26:14.932562@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 14:26:33.025774||measurement||price||2015-12-01 14:26:27.226284@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:26:35.450005||measurement||price||2015-12-01 14:26:17.748600@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 14:26:40.049736||measurement||loadtime||0:00:26.808993||3||0
+2015-12-01 14:26:42.576161||measurement||loadtime||0:00:27.497022||4||0
+2015-12-01 14:26:45.336941||measurement||price||2015-12-01 14:26:27.226284@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:26:46.957084||measurement||price||2015-12-01 14:26:40.556415@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:26:52.344258||measurement||price||2015-12-01 14:26:46.708312@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:26:52.443169||measurement||loadtime||0:00:27.245928||1||0
+2015-12-01 14:26:52.469179||error||collecting ads||Error||5||1
+2015-12-01 14:26:52.848204||error||collecting ads||Error||2||1
+2015-12-01 14:26:54.869389||measurement||price||2015-12-01 14:26:49.281012@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 14:27:00.046515||measurement||price||2015-12-01 14:26:40.556415@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:27:04.699549||measurement||price||2015-12-01 14:26:46.708312@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:27:04.892875||measurement||price||2015-12-01 14:26:59.231983@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:27:07.170271||measurement||price||2015-12-01 14:27:00.627869@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:27:07.204136||measurement||price||2015-12-01 14:26:49.281012@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 14:27:07.295142||measurement||loadtime||0:00:30.072017||0||1
+2015-12-01 14:27:11.809871||measurement||loadtime||0:00:26.754922||3||0
+2015-12-01 14:27:14.278594||measurement||loadtime||0:00:26.699440||4||0
+2015-12-01 14:27:16.941335||error||collecting ads||Error||2||1
+2015-12-01 14:27:17.211762||measurement||price||2015-12-01 14:26:59.231983@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:27:20.361521||measurement||price||2015-12-01 14:27:00.627869@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:27:21.300027||measurement||price||2015-12-01 14:27:14.811581@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:27:24.314520||measurement||loadtime||0:00:26.866146||1||0
+2015-12-01 14:27:26.990841||measurement||price||2015-12-01 14:27:21.345281@|Amy Poehler@| $19.96   @|Inside Out (Blu-ray/DVD Combo Pack + Digital Copy)||4||0
+2015-12-01 14:27:27.611944||measurement||loadtime||0:00:30.140771||5||1
+2015-12-01 14:27:30.853199||measurement||price||2015-12-01 14:27:24.664609@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 14:27:34.062720||error||collecting ads||Error||3||0
+2015-12-01 14:27:34.143342||measurement||price||2015-12-01 14:27:14.811581@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:27:36.592394||measurement||price||2015-12-01 14:27:31.001320@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:27:39.335366||measurement||price||2015-12-01 14:27:21.345281@|Sandra Bullock@| $18.99   @|Minions (Blu-ray + DVD + DIGITAL HD)||4||0
+2015-12-01 14:27:41.355175||measurement||loadtime||0:00:29.054833||0||1
+2015-12-01 14:27:42.074125||measurement||price||2015-12-01 14:27:35.503644@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 14:27:43.908588||measurement||price||2015-12-01 14:27:24.664609@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 14:27:46.325964||measurement||price||2015-12-01 14:27:40.700897@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 14:27:46.453387||measurement||loadtime||0:00:27.169578||4||0
+2015-12-01 14:27:48.920956||measurement||price||2015-12-01 14:27:31.001320@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:27:51.112124||measurement||loadtime||0:00:29.166128||2||1
+2015-12-01 14:27:55.012415||measurement||price||2015-12-01 14:27:35.503644@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 14:27:55.968850||measurement||price||2015-12-01 14:27:49.814292@|Amy Poehler@| $19.96   @|Inside Out (Blu-ray/DVD Combo Pack + Digital Copy)||0||1
+2015-12-01 14:27:56.039361||measurement||loadtime||0:00:26.719658||1||0
+2015-12-01 14:27:58.667540||measurement||price||2015-12-01 14:27:40.700897@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 14:27:58.734072||measurement||price||2015-12-01 14:27:53.155156@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 14:28:02.225647||measurement||loadtime||0:00:29.610506||5||1
+2015-12-01 14:28:04.854392||measurement||price||2015-12-01 14:27:58.719148@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 14:28:05.796345||measurement||loadtime||0:00:26.732555||3||0
+2015-12-01 14:28:08.642910||measurement||price||2015-12-01 14:28:03.034059@|@|$249.00@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||1||0
+2015-12-01 14:28:08.874901||measurement||price||2015-12-01 14:27:49.814292@|Sandra Bullock@| $18.99   @|Minions (Blu-ray + DVD + DIGITAL HD)||0||1
+2015-12-01 14:28:11.075133||measurement||price||2015-12-01 14:27:53.155156@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 14:28:16.029485||measurement||price||2015-12-01 14:28:09.637600@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 14:28:16.093189||measurement||loadtime||0:00:29.736584||0||1
+2015-12-01 14:28:17.798605||measurement||price||2015-12-01 14:27:58.719148@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 14:28:18.188827||measurement||loadtime||0:00:26.730248||4||0
+2015-12-01 14:28:20.998391||measurement||price||2015-12-01 14:28:03.034059@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||1||0
+2015-12-01 14:28:24.999184||measurement||loadtime||0:00:28.884076||2||1
+2015-12-01 14:28:28.099805||error||collecting ads||Error||3||0
+2015-12-01 14:28:28.109675||measurement||loadtime||0:00:27.065140||1||0
+2015-12-01 14:28:28.874739||measurement||price||2015-12-01 14:28:09.637600@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 14:28:30.623232||measurement||price||2015-12-01 14:28:24.991052@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:28:36.091170||measurement||loadtime||0:00:28.861599||5||1
+2015-12-01 14:28:39.026840||measurement||price||2015-12-01 14:28:32.796287@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:28:40.607133||measurement||price||2015-12-01 14:28:35.062951@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:28:40.704125||error||collecting ads||Error||0||1
+2015-12-01 14:28:42.949089||measurement||price||2015-12-01 14:28:24.991052@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:28:50.060813||measurement||loadtime||0:00:26.866774||4||0
+2015-12-01 14:28:50.168579||measurement||price||2015-12-01 14:28:43.470513@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:28:50.497435||error||collecting ads||Error||3||0
+2015-12-01 14:28:52.004060||measurement||price||2015-12-01 14:28:32.796287@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:28:52.954297||measurement||price||2015-12-01 14:28:35.062951@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:28:54.840427||measurement||price||2015-12-01 14:28:47.993795@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:28:59.220681||measurement||loadtime||0:00:29.216237||2||1
+2015-12-01 14:29:00.060885||measurement||loadtime||0:00:26.949704||1||0
+2015-12-01 14:29:02.439363||measurement||price||2015-12-01 14:28:56.810233@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:29:02.804071||measurement||price||2015-12-01 14:28:57.207853@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:29:02.980062||measurement||price||2015-12-01 14:28:43.470513@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:29:07.824231||measurement||price||2015-12-01 14:28:47.993795@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:29:10.175186||measurement||loadtime||0:00:29.083382||5||1
+2015-12-01 14:29:12.428180||measurement||price||2015-12-01 14:29:06.860258@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:29:13.366972||measurement||price||2015-12-01 14:29:07.385384@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 14:29:14.783533||measurement||price||2015-12-01 14:28:56.810233@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:29:15.021109||measurement||loadtime||0:00:29.313964||0||1
+2015-12-01 14:29:15.173249||measurement||price||2015-12-01 14:28:57.207853@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:29:21.898927||measurement||loadtime||0:00:26.832914||4||0
+2015-12-01 14:29:22.279154||measurement||loadtime||0:00:26.780010||3||0
+2015-12-01 14:29:24.095212||measurement||price||2015-12-01 14:29:17.706812@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:29:24.733695||measurement||price||2015-12-01 14:29:06.860258@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:29:26.400910||measurement||price||2015-12-01 14:29:07.385384@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 14:29:31.823341||measurement||loadtime||0:00:26.757241||1||0
+2015-12-01 14:29:33.611185||measurement||loadtime||0:00:29.385239||2||1
+2015-12-01 14:29:34.271165||measurement||price||2015-12-01 14:29:28.627384@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 14:29:37.119018||measurement||price||2015-12-01 14:29:17.706812@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:29:39.033220||error||collecting ads||Error||0||1
+2015-12-01 14:29:44.059081||measurement||price||2015-12-01 14:29:38.505056@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:29:44.319221||measurement||loadtime||0:00:29.138834||5||1
+2015-12-01 14:29:44.444958||error||collecting ads||Error||3||0
+2015-12-01 14:29:44.445051||event||progress-marker||measurement-end||3||0
+2015-12-01 14:29:46.600970||measurement||price||2015-12-01 14:29:28.627384@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 14:29:47.546633||measurement||price||2015-12-01 14:29:41.282005@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 14:29:52.950890||measurement||price||2015-12-01 14:29:46.345048@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:29:53.717425||measurement||loadtime||0:00:26.814293||4||0
+2015-12-01 14:29:56.342780||measurement||price||2015-12-01 14:29:38.505056@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:29:59.519389||measurement||price||2015-12-01 14:29:53.350675@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:30:00.594289||measurement||price||2015-12-01 14:29:41.282005@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 14:30:03.432677||measurement||loadtime||0:00:26.604095||1||0
+2015-12-01 14:30:03.432803||event||progress-marker||measurement-end||1||0
+2015-12-01 14:30:05.838404||measurement||price||2015-12-01 14:29:46.345048@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:30:06.447800||measurement||price||2015-12-01 14:30:00.861880@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||4||0
+2015-12-01 14:30:07.832314||measurement||loadtime||0:00:29.217155||2||1
+2015-12-01 14:30:12.568847||measurement||price||2015-12-01 14:29:53.350675@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:30:13.053935||measurement||loadtime||0:00:29.018191||0||1
+2015-12-01 14:30:19.960059||measurement||loadtime||0:00:30.635616||5||1
+2015-12-01 14:30:23.009689||measurement||price||2015-12-01 14:30:16.907979@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||2||1
+2015-12-01 14:30:27.363755||measurement||price||2015-12-01 14:30:20.960421@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:30:28.820255||error||collecting ads||Error||4||0
+2015-12-01 14:30:28.820362||event||progress-marker||measurement-end||4||0
+2015-12-01 14:30:33.839975||measurement||price||2015-12-01 14:30:27.428606@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 14:30:36.030174||measurement||price||2015-12-01 14:30:16.907979@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||2||1
+2015-12-01 14:30:40.330139||measurement||price||2015-12-01 14:30:20.960421@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:30:43.262485||measurement||loadtime||0:00:30.424937||2||1
+2015-12-01 14:30:46.658794||measurement||price||2015-12-01 14:30:27.428606@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 14:30:47.599931||measurement||loadtime||0:00:29.540794||0||1
+2015-12-01 14:30:53.859168||measurement||loadtime||0:00:28.895977||5||1
+2015-12-01 14:30:57.129507||measurement||price||2015-12-01 14:30:51.095246@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 14:31:01.612392||measurement||price||2015-12-01 14:30:54.825202@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:31:07.978748||measurement||price||2015-12-01 14:31:01.175972@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:31:09.980190||measurement||price||2015-12-01 14:30:51.095246@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 14:31:14.483976||measurement||price||2015-12-01 14:30:54.825202@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:31:17.165752||measurement||loadtime||0:00:28.898025||2||1
+2015-12-01 14:31:20.904226||measurement||price||2015-12-01 14:31:01.175972@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 14:31:21.678771||measurement||loadtime||0:00:29.073612||0||1
+2015-12-01 14:31:28.103721||measurement||loadtime||0:00:29.239831||5||1
+2015-12-01 14:31:35.555530||measurement||price||2015-12-01 14:31:29.219472@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:31:41.196509||error||collecting ads||Error||2||1
+2015-12-01 14:31:42.265148||measurement||price||2015-12-01 14:31:35.965346@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||5||1
+2015-12-01 14:31:48.589624||measurement||price||2015-12-01 14:31:29.219472@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:31:55.283413||measurement||price||2015-12-01 14:31:49.077739@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 14:31:55.805239||measurement||loadtime||0:00:29.121250||0||1
+2015-12-01 14:32:05.163831||error||collecting ads||Error||5||1
+2015-12-01 14:32:08.211102||measurement||price||2015-12-01 14:31:49.077739@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 14:32:09.859140||measurement||price||2015-12-01 14:32:03.766099@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||1
+2015-12-01 14:32:15.440839||measurement||loadtime||0:00:29.239077||2||1
+2015-12-01 14:32:15.440982||event||progress-marker||measurement-end||2||1
+2015-12-01 14:32:22.902763||measurement||price||2015-12-01 14:32:03.766099@|Warner Bros@|$49.95@|Jurassic World Team Pack - LEGO Dimensions||0||1
+2015-12-01 14:32:29.577368||error||collecting ads||Error||5||1
+2015-12-01 14:32:29.577472||event||progress-marker||measurement-end||5||1
+2015-12-01 14:32:30.119554||measurement||loadtime||0:00:29.309038||0||1
+2015-12-01 14:32:30.119673||event||progress-marker||measurement-end||0||1
+2015-12-01 14:32:30.494323||meta||block_id end||1
+2015-12-01 14:32:30.494651||meta||block_id start||2
+2015-12-01 14:32:30.494684||meta||assignment||5@|1@|2@|3@|0@|4
+2015-12-01 14:32:32.066390||event||progress-marker||training-start||1||0
+2015-12-01 14:32:32.066486||event||progress-marker||training-end||1||0
+2015-12-01 14:32:32.067538||event||progress-marker||training-start||2||0
+2015-12-01 14:32:32.068687||event||progress-marker||training-end||2||0
+2015-12-01 14:32:32.074870||event||progress-marker||training-start||5||0
+2015-12-01 14:32:32.075056||event||progress-marker||training-end||5||0
+2015-12-01 14:32:33.861128||event||progress-marker||training-start||3||1
+2015-12-01 14:32:33.861225||event||progress-marker||training-end||3||1
+2015-12-01 14:32:37.078936||event||progress-marker||measurement-start||1||0
+2015-12-01 14:32:37.081105||event||progress-marker||measurement-start||2||0
+2015-12-01 14:32:37.086583||event||progress-marker||measurement-start||5||0
+2015-12-01 14:32:38.872901||event||progress-marker||measurement-start||3||1
+2015-12-01 14:32:51.208469||measurement||price||2015-12-01 14:32:45.209973@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:32:55.101414||measurement||price||2015-12-01 14:32:48.907349@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:33:00.533580||error||collecting ads||Error||5||0
+2015-12-01 14:33:01.485000||error||collecting ads||Error||1||0
+2015-12-01 14:33:03.558748||measurement||price||2015-12-01 14:32:45.209973@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:33:08.000528||measurement||price||2015-12-01 14:32:48.907349@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:33:10.671870||measurement||loadtime||0:00:28.585546||2||0
+2015-12-01 14:33:14.435980||measurement||price||2015-12-01 14:33:08.875312@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:33:15.235750||measurement||loadtime||0:00:31.360602||3||1
+2015-12-01 14:33:23.206011||error||collecting ads||Error||5||0
+2015-12-01 14:33:26.758992||measurement||price||2015-12-01 14:33:08.875312@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:33:29.144686||measurement||price||2015-12-01 14:33:22.815593@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:33:32.974105||error||collecting ads||Error||2||0
+2015-12-01 14:33:33.854029||measurement||loadtime||0:00:27.363801||1||0
+2015-12-01 14:33:41.611010||event||progress-marker||training-start||0||1
+2015-12-01 14:33:41.611129||event||progress-marker||training-end||0||1
+2015-12-01 14:33:42.011100||measurement||price||2015-12-01 14:33:22.815593@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:33:45.808948||measurement||price||2015-12-01 14:33:40.161050@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:33:46.043264||error||collecting ads||Error||5||0
+2015-12-01 14:33:46.616010||measurement||price||2015-12-01 14:33:41.079299@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:33:46.623408||event||progress-marker||measurement-start||0||1
+2015-12-01 14:33:49.242801||measurement||loadtime||0:00:29.001841||3||1
+2015-12-01 14:33:58.136866||measurement||price||2015-12-01 14:33:40.161050@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:33:58.926881||measurement||price||2015-12-01 14:33:41.079299@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:34:01.284125||measurement||price||2015-12-01 14:33:54.577444@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:34:03.567481||measurement||price||2015-12-01 14:33:57.058800@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:34:05.226494||measurement||loadtime||0:00:27.251311||2||0
+2015-12-01 14:34:06.027305||measurement||loadtime||0:00:27.168140||1||0
+2015-12-01 14:34:08.328686||error||collecting ads||Error||5||0
+2015-12-01 14:34:14.137397||measurement||price||2015-12-01 14:33:54.577444@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:34:16.741163||measurement||price||2015-12-01 14:33:57.058800@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:34:18.929717||measurement||price||2015-12-01 14:34:13.267476@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:34:21.007609||measurement||price||2015-12-01 14:34:15.491400@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:34:21.514752||measurement||loadtime||0:00:29.886124||0||1
+2015-12-01 14:34:23.964545||measurement||loadtime||0:00:29.717402||3||1
+2015-12-01 14:34:27.560641||error||collecting ads||Error||2||0
+2015-12-01 14:34:31.286382||measurement||price||2015-12-01 14:34:13.267476@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:34:33.306801||measurement||price||2015-12-01 14:34:15.491400@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:34:35.751109||measurement||price||2015-12-01 14:34:29.685504@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:34:38.383607||measurement||loadtime||0:00:27.352475||1||0
+2015-12-01 14:34:39.898183||measurement||price||2015-12-01 14:34:34.274727@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:34:40.404480||measurement||loadtime||0:00:27.072876||5||0
+2015-12-01 14:34:48.303879||error||collecting ads||Error||3||1
+2015-12-01 14:34:48.666727||measurement||price||2015-12-01 14:34:29.685504@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:34:52.246296||measurement||price||2015-12-01 14:34:34.274727@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:34:53.138576||measurement||price||2015-12-01 14:34:47.504563@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:34:55.923195||measurement||loadtime||0:00:29.404022||0||1
+2015-12-01 14:34:59.353380||measurement||loadtime||0:00:26.789204||2||0
+2015-12-01 14:35:01.745093||error||collecting ads||Error||1||0
+2015-12-01 14:35:05.425521||measurement||price||2015-12-01 14:34:47.504563@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:35:10.454638||measurement||price||2015-12-01 14:35:04.120901@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:35:12.038090||error||collecting ads||Error||3||1
+2015-12-01 14:35:12.524570||measurement||loadtime||0:00:27.114902||5||0
+2015-12-01 14:35:14.109980||measurement||price||2015-12-01 14:35:08.537575@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:35:22.220981||error||collecting ads||Error||2||0
+2015-12-01 14:35:23.476129||measurement||price||2015-12-01 14:35:04.120901@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:35:24.885223||measurement||price||2015-12-01 14:35:19.272402@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:35:26.439613||measurement||price||2015-12-01 14:35:08.537575@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:35:30.706980||measurement||loadtime||0:00:29.778540||0||1
+2015-12-01 14:35:33.549035||measurement||loadtime||0:00:26.798753||1||0
+2015-12-01 14:35:36.623085||error||collecting ads||Error||3||1
+2015-12-01 14:35:37.232364||measurement||price||2015-12-01 14:35:19.272402@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:35:44.347156||measurement||loadtime||0:00:26.817400||5||0
+2015-12-01 14:35:44.855823||error||collecting ads||Error||2||0
+2015-12-01 14:35:50.885110||measurement||price||2015-12-01 14:35:44.322881@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:35:54.992747||error||collecting ads||Error||0||1
+2015-12-01 14:35:56.375673||error||collecting ads||Error||1||0
+2015-12-01 14:35:58.323484||measurement||price||2015-12-01 14:35:52.643724@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:36:04.102085||measurement||price||2015-12-01 14:35:44.322881@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:36:07.601742||error||collecting ads||Error||5||0
+2015-12-01 14:36:09.402775||measurement||price||2015-12-01 14:36:02.964489@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:36:10.666051||measurement||price||2015-12-01 14:35:52.643724@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:36:11.315187||measurement||loadtime||0:00:29.687077||3||1
+2015-12-01 14:36:17.763238||measurement||loadtime||0:00:27.904063||2||0
+2015-12-01 14:36:19.230580||error||collecting ads||Error||1||0
+2015-12-01 14:36:20.325329||measurement||price||2015-12-01 14:36:14.749062@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:36:22.237027||measurement||price||2015-12-01 14:36:02.964489@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:36:25.695999||measurement||price||2015-12-01 14:36:19.244901@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:36:29.494728||measurement||loadtime||0:00:29.496706||0||1
+2015-12-01 14:36:32.668650||measurement||price||2015-12-01 14:36:14.749062@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:36:38.786383||measurement||price||2015-12-01 14:36:19.244901@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:36:39.767203||measurement||loadtime||0:00:27.164033||5||0
+2015-12-01 14:36:40.509167||error||collecting ads||Error||2||0
+2015-12-01 14:36:41.941416||error||collecting ads||Error||1||0
+2015-12-01 14:36:46.132266||measurement||loadtime||0:00:29.811876||3||1
+2015-12-01 14:36:52.420954||measurement||price||2015-12-01 14:36:46.840320@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:36:52.845869||measurement||price||2015-12-01 14:36:47.179773@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:36:53.822890||error||collecting ads||Error||0||1
+2015-12-01 14:37:00.695286||measurement||price||2015-12-01 14:36:53.938953@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:37:04.288716||error||collecting ads||Error||1||0
+2015-12-01 14:37:04.757512||measurement||price||2015-12-01 14:36:46.840320@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:37:05.185681||measurement||price||2015-12-01 14:36:47.179773@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:37:07.902572||measurement||price||2015-12-01 14:37:01.114295@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:37:11.871168||measurement||loadtime||0:00:27.100716||5||0
+2015-12-01 14:37:12.296764||measurement||loadtime||0:00:26.785604||2||0
+2015-12-01 14:37:13.595576||measurement||price||2015-12-01 14:36:53.938953@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:37:20.793011||measurement||price||2015-12-01 14:37:01.114295@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:37:20.803997||measurement||loadtime||0:00:29.668846||3||1
+2015-12-01 14:37:24.811170||measurement||price||2015-12-01 14:37:18.997064@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:37:26.594580||error||collecting ads||Error||1||0
+2015-12-01 14:37:28.008996||measurement||loadtime||0:00:29.180894||0||1
+2015-12-01 14:37:34.635138||error||collecting ads||Error||2||0
+2015-12-01 14:37:34.729888||measurement||price||2015-12-01 14:37:28.047351@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:37:37.166591||measurement||price||2015-12-01 14:37:18.997064@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:37:41.930893||measurement||price||2015-12-01 14:37:35.447882@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:37:44.282583||measurement||loadtime||0:00:27.406226||5||0
+2015-12-01 14:37:46.961399||measurement||price||2015-12-01 14:37:41.349891@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:37:47.636587||measurement||price||2015-12-01 14:37:28.047351@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:37:48.989584||error||collecting ads||Error||1||0
+2015-12-01 14:37:54.810003||measurement||price||2015-12-01 14:37:35.447882@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:37:54.855152||measurement||loadtime||0:00:29.045952||3||1
+2015-12-01 14:37:56.525045||measurement||price||2015-12-01 14:37:50.931156@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:37:59.301182||measurement||price||2015-12-01 14:37:41.349891@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:38:02.037554||measurement||loadtime||0:00:29.023365||0||1
+2015-12-01 14:38:02.156605||measurement||price||2015-12-01 14:37:56.438095@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:38:06.405633||measurement||loadtime||0:00:26.765264||2||0
+2015-12-01 14:38:08.860143||measurement||price||2015-12-01 14:37:50.931156@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:38:08.943398||measurement||price||2015-12-01 14:38:02.115858@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:38:14.561748||measurement||price||2015-12-01 14:37:56.438095@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:38:15.975188||measurement||loadtime||0:00:26.687369||5||0
+2015-12-01 14:38:16.300236||measurement||price||2015-12-01 14:38:09.706793@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:38:21.686855||measurement||loadtime||0:00:27.695847||1||0
+2015-12-01 14:38:21.852421||measurement||price||2015-12-01 14:38:02.115858@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:38:28.466281||measurement||price||2015-12-01 14:38:22.880321@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:38:29.056280||measurement||loadtime||0:00:29.200416||3||1
+2015-12-01 14:38:29.141758||error||collecting ads||Error||2||0
+2015-12-01 14:38:29.410896||measurement||price||2015-12-01 14:38:09.706793@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:38:34.063318||measurement||price||2015-12-01 14:38:28.397738@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:38:36.651182||measurement||loadtime||0:00:29.608417||0||1
+2015-12-01 14:38:40.811104||measurement||price||2015-12-01 14:38:22.880321@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:38:46.406055||measurement||price||2015-12-01 14:38:28.397738@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:38:47.928069||measurement||loadtime||0:00:26.947626||5||0
+2015-12-01 14:38:52.016418||error||collecting ads||Error||2||0
+2015-12-01 14:38:53.167360||error||collecting ads||Error||3||1
+2015-12-01 14:38:53.523178||measurement||loadtime||0:00:26.831103||1||0
+2015-12-01 14:39:00.233118||measurement||price||2015-12-01 14:38:54.672473@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:39:00.725452||error||collecting ads||Error||0||1
+2015-12-01 14:39:04.733867||measurement||price||2015-12-01 14:38:59.028568@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:39:06.417404||measurement||price||2015-12-01 14:39:01.064859@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:39:12.596527||measurement||price||2015-12-01 14:38:54.672473@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:39:14.963847||measurement||price||2015-12-01 14:39:08.430898@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:39:17.065063||measurement||price||2015-12-01 14:38:59.028568@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:39:17.232262||error||collecting ads||Error||3||1
+2015-12-01 14:39:18.764124||measurement||price||2015-12-01 14:39:01.064859@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:39:19.749725||measurement||loadtime||0:00:26.816438||5||0
+2015-12-01 14:39:24.174875||measurement||loadtime||0:00:27.153211||2||0
+2015-12-01 14:39:25.881858||measurement||loadtime||0:00:27.354725||1||0
+2015-12-01 14:39:27.823265||measurement||price||2015-12-01 14:39:08.430898@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:39:31.021451||measurement||price||2015-12-01 14:39:24.600666@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:39:35.047820||measurement||loadtime||0:00:29.317095||0||1
+2015-12-01 14:39:38.516238||measurement||price||2015-12-01 14:39:32.929205@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||0
+2015-12-01 14:39:42.012410||error||collecting ads||Error||5||0
+2015-12-01 14:39:44.068781||measurement||price||2015-12-01 14:39:24.600666@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:39:46.527521||error||collecting ads||Error||2||0
+2015-12-01 14:39:49.132811||measurement||price||2015-12-01 14:39:42.775322@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:39:50.867574||measurement||price||2015-12-01 14:39:32.929205@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||0
+2015-12-01 14:39:51.251185||measurement||loadtime||0:00:29.013728||3||1
+2015-12-01 14:39:54.307426||measurement||price||2015-12-01 14:39:48.676535@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:39:57.976765||measurement||loadtime||0:00:27.091419||1||0
+2015-12-01 14:39:58.835882||measurement||price||2015-12-01 14:39:53.291979@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:40:02.019941||measurement||price||2015-12-01 14:39:42.775322@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:40:06.644780||measurement||price||2015-12-01 14:39:48.676535@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:40:09.250230||measurement||loadtime||0:00:29.199086||0||1
+2015-12-01 14:40:11.187323||measurement||price||2015-12-01 14:39:53.291979@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:40:13.771155||measurement||loadtime||0:00:26.753536||5||0
+2015-12-01 14:40:15.329597||error||collecting ads||Error||3||1
+2015-12-01 14:40:18.300143||measurement||loadtime||0:00:26.767355||2||0
+2015-12-01 14:40:20.351680||error||collecting ads||Error||1||0
+2015-12-01 14:40:22.921948||measurement||price||2015-12-01 14:40:16.638704@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:40:29.402819||measurement||price||2015-12-01 14:40:22.781213@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:40:32.595885||measurement||price||2015-12-01 14:40:27.032663@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:40:35.823628||measurement||price||2015-12-01 14:40:16.638704@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:40:36.166048||error||collecting ads||Error||5||0
+2015-12-01 14:40:40.610368||error||collecting ads||Error||2||0
+2015-12-01 14:40:42.257129||measurement||price||2015-12-01 14:40:22.781213@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:40:43.055161||measurement||loadtime||0:00:28.799714||0||1
+2015-12-01 14:40:44.929621||measurement||price||2015-12-01 14:40:27.032663@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:40:48.421022||measurement||price||2015-12-01 14:40:42.894125@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:40:49.475182||measurement||loadtime||0:00:29.144036||3||1
+2015-12-01 14:40:52.040271||measurement||loadtime||0:00:26.684859||1||0
+2015-12-01 14:40:52.981381||measurement||price||2015-12-01 14:40:47.429616@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:41:00.752169||measurement||price||2015-12-01 14:40:42.894125@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:41:03.564476||measurement||price||2015-12-01 14:40:56.937373@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:41:04.405359||measurement||price||2015-12-01 14:40:58.853433@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:41:05.311602||measurement||price||2015-12-01 14:40:47.429616@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:41:06.994448||error||collecting ads||Error||0||1
+2015-12-01 14:41:07.861448||measurement||loadtime||0:00:26.690152||5||0
+2015-12-01 14:41:12.415468||measurement||loadtime||0:00:26.799877||2||0
+2015-12-01 14:41:16.442019||measurement||price||2015-12-01 14:40:56.937373@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:41:16.734880||measurement||price||2015-12-01 14:40:58.853433@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:41:20.245309||measurement||price||2015-12-01 14:41:14.722829@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:41:23.661014||measurement||loadtime||0:00:29.180599||3||1
+2015-12-01 14:41:23.857674||measurement||loadtime||0:00:26.814545||1||0
+2015-12-01 14:41:24.702374||measurement||price||2015-12-01 14:41:19.200291@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:41:31.237008||error||collecting ads||Error||0||1
+2015-12-01 14:41:32.557982||measurement||price||2015-12-01 14:41:14.722829@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:41:37.028301||measurement||price||2015-12-01 14:41:19.200291@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:41:37.877314||measurement||price||2015-12-01 14:41:31.036545@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:41:39.674628||measurement||loadtime||0:00:26.807938||5||0
+2015-12-01 14:41:44.137129||measurement||loadtime||0:00:26.716471||2||0
+2015-12-01 14:41:44.137221||event||progress-marker||measurement-end||2||0
+2015-12-01 14:41:46.307395||error||collecting ads||Error||1||0
+2015-12-01 14:41:46.307489||event||progress-marker||measurement-end||1||0
+2015-12-01 14:41:50.761556||measurement||price||2015-12-01 14:41:31.036545@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:41:52.062342||measurement||price||2015-12-01 14:41:46.490970@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:41:55.867948||error||collecting ads||Error||0||1
+2015-12-01 14:41:57.978447||measurement||loadtime||0:00:29.314080||3||1
+2015-12-01 14:42:04.391900||measurement||price||2015-12-01 14:41:46.490970@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:42:09.899253||measurement||price||2015-12-01 14:42:03.176428@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:42:11.498534||measurement||loadtime||0:00:26.818686||5||0
+2015-12-01 14:42:11.498648||event||progress-marker||measurement-end||5||0
+2015-12-01 14:42:12.138556||measurement||price||2015-12-01 14:42:05.282790@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:42:22.790685||measurement||price||2015-12-01 14:42:03.176428@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:42:25.147337||measurement||price||2015-12-01 14:42:05.282790@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:42:29.981697||measurement||loadtime||0:00:29.108499||0||1
+2015-12-01 14:42:32.364587||measurement||loadtime||0:00:29.380858||3||1
+2015-12-01 14:42:44.075890||measurement||price||2015-12-01 14:42:37.706465@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||1
+2015-12-01 14:42:56.103881||error||collecting ads||Error||3||1
+2015-12-01 14:42:56.104014||event||progress-marker||measurement-end||3||1
+2015-12-01 14:42:56.915465||measurement||price||2015-12-01 14:42:37.706465@|Warner Bros@|$49.95@|Jurassic World Team Pack - LEGO Dimensions||0||1
+2015-12-01 14:43:04.117804||measurement||loadtime||0:00:29.130862||0||1
+2015-12-01 14:43:17.818911||measurement||price||2015-12-01 14:43:11.502017@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:43:30.663187||measurement||price||2015-12-01 14:43:11.502017@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:43:37.864934||measurement||loadtime||0:00:28.741857||0||1
+2015-12-01 14:43:52.198488||measurement||price||2015-12-01 14:43:46.184347@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:44:05.325512||measurement||price||2015-12-01 14:43:46.184347@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:44:12.528050||measurement||loadtime||0:00:29.657862||0||1
+2015-12-01 14:44:12.528358||event||progress-marker||measurement-end||0||1
+2015-12-01 14:44:13.007385||meta||block_id end||2
+2015-12-01 14:44:13.007665||meta||block_id start||3
+2015-12-01 14:44:13.007697||meta||assignment||2@|5@|1@|3@|4@|0
+2015-12-01 14:44:14.588433||event||progress-marker||training-start||5||0
+2015-12-01 14:44:14.588541||event||progress-marker||training-end||5||0
+2015-12-01 14:44:14.622565||event||progress-marker||training-start||1||0
+2015-12-01 14:44:14.622653||event||progress-marker||training-end||1||0
+2015-12-01 14:44:14.639642||event||progress-marker||training-start||2||0
+2015-12-01 14:44:14.639736||event||progress-marker||training-end||2||0
+2015-12-01 14:44:19.598944||event||progress-marker||measurement-start||5||0
+2015-12-01 14:44:19.636379||event||progress-marker||measurement-start||1||0
+2015-12-01 14:44:19.653407||event||progress-marker||measurement-start||2||0
+2015-12-01 14:44:33.130272||measurement||price||2015-12-01 14:44:26.846601@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:44:36.085053||measurement||price||2015-12-01 14:44:27.682481@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:44:43.126155||error||collecting ads||Error||1||0
+2015-12-01 14:44:45.476847||measurement||price||2015-12-01 14:44:26.846601@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:44:48.439238||measurement||price||2015-12-01 14:44:27.682481@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:44:52.583196||measurement||loadtime||0:00:27.978979||5||0
+2015-12-01 14:44:55.543187||measurement||loadtime||0:00:30.888036||2||0
+2015-12-01 14:44:55.838213||measurement||price||2015-12-01 14:44:50.308443@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:45:08.182714||measurement||price||2015-12-01 14:44:50.308443@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:45:08.327826||measurement||price||2015-12-01 14:45:02.593884@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:45:15.295200||measurement||loadtime||0:00:27.163810||1||0
+2015-12-01 14:45:15.353910||error||collecting ads||Error||5||0
+2015-12-01 14:45:20.635973||measurement||price||2015-12-01 14:45:02.593884@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:45:27.639074||measurement||price||2015-12-01 14:45:22.010732@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:45:27.727182||measurement||loadtime||0:00:27.178775||2||0
+2015-12-01 14:45:35.346170||event||progress-marker||training-start||4||1
+2015-12-01 14:45:35.346331||event||progress-marker||training-end||4||1
+2015-12-01 14:45:38.102073||error||collecting ads||Error||1||0
+2015-12-01 14:45:39.976411||measurement||price||2015-12-01 14:45:34.366625@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:45:39.983676||measurement||price||2015-12-01 14:45:22.010732@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:45:40.360697||event||progress-marker||measurement-start||4||1
+2015-12-01 14:45:47.101491||measurement||loadtime||0:00:26.746339||5||0
+2015-12-01 14:45:49.519594||event||progress-marker||training-start||3||1
+2015-12-01 14:45:49.519728||event||progress-marker||training-end||3||1
+2015-12-01 14:45:50.413946||measurement||price||2015-12-01 14:45:44.828672@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:45:52.300172||measurement||price||2015-12-01 14:45:34.366625@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:45:54.533598||event||progress-marker||measurement-start||3||1
+2015-12-01 14:45:55.446851||measurement||price||2015-12-01 14:45:49.432170@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:45:59.409037||measurement||loadtime||0:00:26.681263||2||0
+2015-12-01 14:46:02.743619||measurement||price||2015-12-01 14:45:44.828672@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:46:08.458246||measurement||price||2015-12-01 14:45:49.432170@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:46:09.155070||measurement||price||2015-12-01 14:46:02.474134@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:46:09.444326||error||collecting ads||Error||5||0
+2015-12-01 14:46:09.839208||measurement||loadtime||0:00:26.731879||1||0
+2015-12-01 14:46:11.593711||measurement||price||2015-12-01 14:46:06.064339@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:46:15.651803||measurement||loadtime||0:00:30.288678||4||1
+2015-12-01 14:46:21.790407||measurement||price||2015-12-01 14:46:16.218021@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:46:22.152030||measurement||price||2015-12-01 14:46:02.474134@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:46:22.188400||measurement||price||2015-12-01 14:46:16.580275@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:46:22.477637||event||progress-marker||training-start||0||1
+2015-12-01 14:46:22.477765||event||progress-marker||training-end||0||1
+2015-12-01 14:46:23.928298||measurement||price||2015-12-01 14:46:06.064339@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:46:27.491046||event||progress-marker||measurement-start||0||1
+2015-12-01 14:46:29.386309||measurement||loadtime||0:00:29.851160||3||1
+2015-12-01 14:46:31.037673||measurement||loadtime||0:00:26.623395||2||0
+2015-12-01 14:46:34.135994||measurement||price||2015-12-01 14:46:16.218021@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:46:34.548911||measurement||price||2015-12-01 14:46:16.580275@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:46:39.675619||error||collecting ads||Error||4||1
+2015-12-01 14:46:41.249760||measurement||loadtime||0:00:26.801380||5||0
+2015-12-01 14:46:41.658015||measurement||loadtime||0:00:26.816954||1||0
+2015-12-01 14:46:41.922698||measurement||price||2015-12-01 14:46:35.419670@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:46:43.415064||measurement||price||2015-12-01 14:46:36.963902@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:46:53.947161||error||collecting ads||Error||2||0
+2015-12-01 14:46:54.421264||measurement||price||2015-12-01 14:46:48.073087@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:46:54.508786||measurement||price||2015-12-01 14:46:48.760367@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:46:54.773226||measurement||price||2015-12-01 14:46:49.233956@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:46:54.852150||measurement||price||2015-12-01 14:46:35.419670@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:46:56.273486||measurement||price||2015-12-01 14:46:36.963902@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:47:02.067211||measurement||loadtime||0:00:29.570921||0||1
+2015-12-01 14:47:03.455522||measurement||loadtime||0:00:29.064024||3||1
+2015-12-01 14:47:06.260233||measurement||price||2015-12-01 14:47:00.648817@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:47:06.810719||measurement||price||2015-12-01 14:46:48.760367@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:47:07.085074||measurement||price||2015-12-01 14:46:49.233956@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:47:07.511491||measurement||price||2015-12-01 14:46:48.073087@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:47:13.893568||measurement||loadtime||0:00:27.638588||5||0
+2015-12-01 14:47:14.176854||measurement||loadtime||0:00:27.513606||1||0
+2015-12-01 14:47:14.750914||measurement||loadtime||0:00:30.070075||4||1
+2015-12-01 14:47:16.573431||measurement||price||2015-12-01 14:47:10.421069@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:47:18.571395||measurement||price||2015-12-01 14:47:00.648817@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:47:25.682355||measurement||loadtime||0:00:26.729950||2||0
+2015-12-01 14:47:26.194537||measurement||price||2015-12-01 14:47:20.599966@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:47:27.026855||measurement||price||2015-12-01 14:47:21.419881@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:47:27.701567||error||collecting ads||Error||3||1
+2015-12-01 14:47:29.286350||measurement||price||2015-12-01 14:47:22.688873@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:47:29.566831||measurement||price||2015-12-01 14:47:10.421069@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:47:36.825124||measurement||loadtime||0:00:29.753979||0||1
+2015-12-01 14:47:38.008159||measurement||price||2015-12-01 14:47:32.396553@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:47:38.458908||measurement||price||2015-12-01 14:47:20.599966@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:47:39.331569||measurement||price||2015-12-01 14:47:21.419881@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:47:42.220952||measurement||price||2015-12-01 14:47:22.688873@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:47:43.011449||measurement||price||2015-12-01 14:47:36.860213@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:47:45.547164||measurement||loadtime||0:00:26.650911||5||0
+2015-12-01 14:47:46.419909||measurement||loadtime||0:00:27.240771||1||0
+2015-12-01 14:47:49.634533||measurement||loadtime||0:00:29.879367||4||1
+2015-12-01 14:47:50.315093||measurement||price||2015-12-01 14:47:32.396553@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:47:56.155266||measurement||price||2015-12-01 14:47:36.860213@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:47:57.398644||measurement||loadtime||0:00:26.713686||2||0
+2015-12-01 14:47:58.841667||measurement||price||2015-12-01 14:47:53.510664@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:47:59.140520||measurement||price||2015-12-01 14:47:53.594627@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:48:01.214735||error||collecting ads||Error||0||1
+2015-12-01 14:48:03.368120||measurement||loadtime||0:00:30.664981||3||1
+2015-12-01 14:48:04.035660||measurement||price||2015-12-01 14:47:57.578945@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:48:10.087557||measurement||price||2015-12-01 14:48:04.539563@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:48:11.248623||measurement||price||2015-12-01 14:47:53.510664@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:48:11.472898||measurement||price||2015-12-01 14:47:53.594627@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:48:15.306238||measurement||price||2015-12-01 14:48:09.165672@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||0||1
+2015-12-01 14:48:16.996327||measurement||price||2015-12-01 14:47:57.578945@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:48:17.529467||measurement||price||2015-12-01 14:48:10.640894@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:48:18.358839||measurement||loadtime||0:00:27.807687||5||0
+2015-12-01 14:48:18.588533||measurement||loadtime||0:00:27.165357||1||0
+2015-12-01 14:48:22.375677||measurement||price||2015-12-01 14:48:04.539563@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:48:24.267190||measurement||loadtime||0:00:29.628426||4||1
+2015-12-01 14:48:28.146494||measurement||price||2015-12-01 14:48:09.165672@|Electronic Arts@| $59.80   @|Star Wars: Battlefront - Standard Edition - Xbox One||0||1
+2015-12-01 14:48:29.467982||measurement||loadtime||0:00:27.064119||2||0
+2015-12-01 14:48:30.468941||measurement||price||2015-12-01 14:48:10.640894@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:48:31.138352||measurement||price||2015-12-01 14:48:25.491711@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:48:31.363553||measurement||price||2015-12-01 14:48:25.711382@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:48:35.359647||measurement||loadtime||0:00:29.140516||0||1
+2015-12-01 14:48:37.684611||measurement||loadtime||0:00:29.313444||3||1
+2015-12-01 14:48:38.793907||measurement||price||2015-12-01 14:48:32.275842@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:48:41.706158||measurement||price||2015-12-01 14:48:36.140266@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:48:43.434008||measurement||price||2015-12-01 14:48:25.491711@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:48:43.626173||measurement||price||2015-12-01 14:48:25.711382@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:48:50.515709||measurement||loadtime||0:00:27.152004||5||0
+2015-12-01 14:48:50.720202||measurement||loadtime||0:00:27.126460||1||0
+2015-12-01 14:48:51.770209||measurement||price||2015-12-01 14:48:32.275842@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:48:51.896574||measurement||price||2015-12-01 14:48:45.008467@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:48:54.031411||measurement||price||2015-12-01 14:48:36.140266@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:48:58.991171||measurement||loadtime||0:00:29.718722||4||1
+2015-12-01 14:48:59.553619||error||collecting ads||Error||0||1
+2015-12-01 14:49:01.145935||measurement||loadtime||0:00:26.677155||2||0
+2015-12-01 14:49:02.924314||measurement||price||2015-12-01 14:48:57.236414@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:49:03.047837||measurement||price||2015-12-01 14:48:57.389632@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:49:04.767533||measurement||price||2015-12-01 14:48:45.008467@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:49:11.989824||measurement||loadtime||0:00:29.302691||3||1
+2015-12-01 14:49:13.277366||measurement||price||2015-12-01 14:49:06.357038@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:49:14.162581||measurement||price||2015-12-01 14:49:08.409227@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:49:15.269680||measurement||price||2015-12-01 14:48:57.236414@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:49:15.401169||measurement||price||2015-12-01 14:48:57.389632@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:49:22.387299||measurement||loadtime||0:00:26.866344||5||0
+2015-12-01 14:49:22.516476||measurement||loadtime||0:00:26.791063||1||0
+2015-12-01 14:49:23.734171||error||collecting ads||Error||0||1
+2015-12-01 14:49:26.417099||measurement||price||2015-12-01 14:49:06.357038@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:49:26.502864||measurement||price||2015-12-01 14:49:08.409227@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:49:33.616105||measurement||loadtime||0:00:27.464861||2||0
+2015-12-01 14:49:33.671976||measurement||loadtime||0:00:29.675613||4||1
+2015-12-01 14:49:34.804853||measurement||price||2015-12-01 14:49:29.204215@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:49:35.424857||measurement||price||2015-12-01 14:49:29.837630@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:49:36.069695||error||collecting ads||Error||3||1
+2015-12-01 14:49:45.919331||measurement||price||2015-12-01 14:49:40.200359@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:49:47.138497||measurement||price||2015-12-01 14:49:29.204215@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:49:47.742158||measurement||price||2015-12-01 14:49:29.837630@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:49:48.042174||error||collecting ads||Error||0||1
+2015-12-01 14:49:48.371385||measurement||price||2015-12-01 14:49:41.464516@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:49:50.159714||measurement||price||2015-12-01 14:49:43.332491@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:49:54.247160||measurement||loadtime||0:00:26.854647||5||0
+2015-12-01 14:49:54.827145||measurement||loadtime||0:00:27.305466||1||0
+2015-12-01 14:49:58.256198||measurement||price||2015-12-01 14:49:40.200359@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:50:01.331421||measurement||price||2015-12-01 14:49:41.464516@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:50:01.743363||measurement||price||2015-12-01 14:49:55.584799@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:50:03.009604||measurement||price||2015-12-01 14:49:43.332491@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:50:05.378680||measurement||loadtime||0:00:26.757376||2||0
+2015-12-01 14:50:06.606271||measurement||price||2015-12-01 14:50:00.990852@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:50:08.036661||measurement||price||2015-12-01 14:50:02.376612@|Coast@|$9.54@|Coast HP1 Focusing 220 Lumen LED Flashlight||1||0
+2015-12-01 14:50:08.563183||measurement||loadtime||0:00:29.885975||4||1
+2015-12-01 14:50:10.231739||measurement||loadtime||0:00:29.160580||3||1
+2015-12-01 14:50:14.617978||measurement||price||2015-12-01 14:49:55.584799@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:50:18.110570||measurement||price||2015-12-01 14:50:12.479901@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:50:18.945824||measurement||price||2015-12-01 14:50:00.990852@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:50:20.361174||measurement||price||2015-12-01 14:50:02.376612@|Coast@|$31.41@|Coast HL7 Focusing 285 Lumen LED Headlamp||1||0
+2015-12-01 14:50:21.835717||measurement||loadtime||0:00:28.788337||0||1
+2015-12-01 14:50:22.881650||measurement||price||2015-12-01 14:50:16.488008@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||1
+2015-12-01 14:50:24.564517||measurement||price||2015-12-01 14:50:18.085895@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:50:26.052432||measurement||loadtime||0:00:26.800064||5||0
+2015-12-01 14:50:27.470300||measurement||loadtime||0:00:27.637935||1||0
+2015-12-01 14:50:30.479272||measurement||price||2015-12-01 14:50:12.479901@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:50:35.760239||measurement||price||2015-12-01 14:50:16.488008@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||1
+2015-12-01 14:50:36.345831||measurement||price||2015-12-01 14:50:29.964472@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:50:37.529811||measurement||price||2015-12-01 14:50:18.085895@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:50:37.597971||measurement||loadtime||0:00:27.214069||2||0
+2015-12-01 14:50:38.454104||measurement||price||2015-12-01 14:50:32.818746@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:50:42.971168||measurement||loadtime||0:00:29.402766||4||1
+2015-12-01 14:50:44.785024||measurement||loadtime||0:00:29.548052||3||1
+2015-12-01 14:50:49.230043||measurement||price||2015-12-01 14:50:29.964472@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:50:49.715753||error||collecting ads||Error||1||0
+2015-12-01 14:50:50.793246||measurement||price||2015-12-01 14:50:32.818746@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:50:56.459211||measurement||loadtime||0:00:29.618299||0||1
+2015-12-01 14:50:56.971303||measurement||price||2015-12-01 14:50:50.431396@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:50:57.898355||measurement||loadtime||0:00:26.840692||5||0
+2015-12-01 14:50:59.348047||measurement||price||2015-12-01 14:50:53.198267@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:50:59.959249||error||collecting ads||Error||2||0
+2015-12-01 14:51:02.339328||measurement||price||2015-12-01 14:50:56.814572@|@|$249.00@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||1||0
+2015-12-01 14:51:09.959260||measurement||price||2015-12-01 14:50:50.431396@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:51:10.726617||measurement||price||2015-12-01 14:51:05.117406@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:51:12.246500||measurement||price||2015-12-01 14:50:53.198267@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:51:12.277982||measurement||price||2015-12-01 14:51:06.586895@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 14:51:14.679430||measurement||price||2015-12-01 14:50:56.814572@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||1||0
+2015-12-01 14:51:17.164196||measurement||loadtime||0:00:29.187833||4||1
+2015-12-01 14:51:19.480088||measurement||loadtime||0:00:29.689886||3||1
+2015-12-01 14:51:20.909832||error||collecting ads||Error||0||1
+2015-12-01 14:51:21.802811||measurement||loadtime||0:00:27.081831||1||0
+2015-12-01 14:51:23.049483||measurement||price||2015-12-01 14:51:05.117406@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:51:24.624882||measurement||price||2015-12-01 14:51:06.586895@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 14:51:30.131155||measurement||loadtime||0:00:27.227593||5||0
+2015-12-01 14:51:31.326826||measurement||price||2015-12-01 14:51:25.172535@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:51:31.739194||measurement||loadtime||0:00:26.776054||2||0
+2015-12-01 14:51:33.964227||measurement||price||2015-12-01 14:51:27.289301@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:51:34.376914||measurement||price||2015-12-01 14:51:28.648736@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:51:35.512690||measurement||price||2015-12-01 14:51:29.011123@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:51:42.955242||measurement||price||2015-12-01 14:51:37.314145@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:51:44.515876||measurement||price||2015-12-01 14:51:25.172535@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:51:46.662267||measurement||price||2015-12-01 14:51:28.648736@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:51:47.113699||measurement||price||2015-12-01 14:51:27.289301@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:51:48.498113||measurement||price||2015-12-01 14:51:29.011123@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:51:51.745367||measurement||loadtime||0:00:29.575954||4||1
+2015-12-01 14:51:53.742078||measurement||loadtime||0:00:26.934917||1||0
+2015-12-01 14:51:54.316104||measurement||loadtime||0:00:29.830792||3||1
+2015-12-01 14:51:54.532268||error||collecting ads||Error||2||0
+2015-12-01 14:51:55.304408||measurement||price||2015-12-01 14:51:37.314145@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:51:55.706329||measurement||loadtime||0:00:29.795154||0||1
+2015-12-01 14:52:02.390633||measurement||loadtime||0:00:27.257503||5||0
+2015-12-01 14:52:06.347340||measurement||price||2015-12-01 14:51:59.572012@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:52:06.984765||measurement||price||2015-12-01 14:52:01.296110@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 14:52:09.184192||measurement||price||2015-12-01 14:52:02.308183@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:52:10.342354||measurement||price||2015-12-01 14:52:03.833002@|Mitchell@|$73.90@|Mitchell 300 Pro Spinning Rod and Reel Combo, 7-Feet/Medium||0||1
+2015-12-01 14:52:15.091310||measurement||price||2015-12-01 14:52:09.493072@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:52:16.156565||error||collecting ads||Error||1||0
+2015-12-01 14:52:19.336016||measurement||price||2015-12-01 14:52:01.296110@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 14:52:19.405742||measurement||price||2015-12-01 14:51:59.572012@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:52:22.154810||measurement||price||2015-12-01 14:52:02.308183@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:52:23.409291||measurement||price||2015-12-01 14:52:03.833002@|Penn@|$89.65@|Penn Battle II Spinning Reel, 4000||0||1
+2015-12-01 14:52:26.429136||measurement||loadtime||0:00:26.891470||2||0
+2015-12-01 14:52:26.627503||measurement||loadtime||0:00:29.876901||4||1
+2015-12-01 14:52:27.446064||measurement||price||2015-12-01 14:52:09.493072@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:52:28.480770||measurement||price||2015-12-01 14:52:22.945211@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:52:29.376067||measurement||loadtime||0:00:30.058738||3||1
+2015-12-01 14:52:30.695434||measurement||loadtime||0:00:29.984273||0||1
+2015-12-01 14:52:34.556625||measurement||loadtime||0:00:27.160750||5||0
+2015-12-01 14:52:40.817725||measurement||price||2015-12-01 14:52:22.945211@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:52:41.248230||measurement||price||2015-12-01 14:52:34.483253@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:52:44.766446||measurement||price||2015-12-01 14:52:37.897680@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 14:52:47.200619||measurement||price||2015-12-01 14:52:41.675927@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:52:47.935173||measurement||loadtime||0:00:26.776023||1||0
+2015-12-01 14:52:48.798061||error||collecting ads||Error||2||0
+2015-12-01 14:52:53.411826||error||collecting ads||Error||3||1
+2015-12-01 14:52:54.236289||measurement||price||2015-12-01 14:52:34.483253@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:52:57.614418||measurement||price||2015-12-01 14:52:37.897680@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 14:52:59.526402||measurement||price||2015-12-01 14:52:41.675927@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:53:00.360141||measurement||price||2015-12-01 14:52:54.768608@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:53:01.443162||measurement||loadtime||0:00:29.812022||4||1
+2015-12-01 14:53:04.817582||measurement||loadtime||0:00:29.116921||0||1
+2015-12-01 14:53:06.636607||measurement||loadtime||0:00:27.077826||5||0
+2015-12-01 14:53:07.687169||measurement||price||2015-12-01 14:53:01.071797@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 14:53:11.360119||error||collecting ads||Error||2||0
+2015-12-01 14:53:12.699784||measurement||price||2015-12-01 14:52:54.768608@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:53:18.988317||measurement||price||2015-12-01 14:53:13.375167@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 14:53:19.832103||measurement||loadtime||0:00:26.892922||1||0
+2015-12-01 14:53:19.999361||measurement||price||2015-12-01 14:53:12.148417@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:53:20.642151||measurement||price||2015-12-01 14:53:01.071797@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 14:53:23.762975||measurement||price||2015-12-01 14:53:18.182099@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:53:25.430877||error||collecting ads||Error||4||1
+2015-12-01 14:53:27.859163||measurement||loadtime||0:00:29.442120||3||1
+2015-12-01 14:53:31.321547||measurement||price||2015-12-01 14:53:13.375167@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 14:53:32.966443||measurement||price||2015-12-01 14:53:27.276865@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 14:53:32.992625||measurement||price||2015-12-01 14:53:12.148417@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:53:36.091406||measurement||price||2015-12-01 14:53:18.182099@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:53:38.429216||measurement||loadtime||0:00:26.790068||5||0
+2015-12-01 14:53:39.984678||measurement||price||2015-12-01 14:53:33.970657@|Coast@|$9.54@|Coast HP1 Focusing 220 Lumen LED Flashlight||4||1
+2015-12-01 14:53:40.208547||measurement||loadtime||0:00:30.388719||0||1
+2015-12-01 14:53:43.206776||measurement||loadtime||0:00:26.842342||2||0
+2015-12-01 14:53:45.265267||measurement||price||2015-12-01 14:53:27.276865@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 14:53:50.799043||measurement||price||2015-12-01 14:53:45.195931@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 14:53:51.925701||error||collecting ads||Error||3||1
+2015-12-01 14:53:52.349005||measurement||loadtime||0:00:27.513458||1||0
+2015-12-01 14:53:52.848118||measurement||price||2015-12-01 14:53:33.970657@|Coast@|$31.41@|Coast HL7 Focusing 285 Lumen LED Headlamp||4||1
+2015-12-01 14:53:54.281851||measurement||price||2015-12-01 14:53:47.541998@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:53:55.539601||measurement||price||2015-12-01 14:53:50.025401@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 14:54:00.051161||measurement||loadtime||0:00:29.615036||4||1
+2015-12-01 14:54:03.178327||measurement||price||2015-12-01 14:53:45.195931@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 14:54:07.137678||measurement||price||2015-12-01 14:53:47.541998@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:54:07.869512||measurement||price||2015-12-01 14:53:50.025401@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 14:54:10.291360||measurement||loadtime||0:00:26.858782||5||0
+2015-12-01 14:54:13.938842||measurement||price||2015-12-01 14:54:07.392911@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:54:14.361133||measurement||loadtime||0:00:29.147387||0||1
+2015-12-01 14:54:14.789793||error||collecting ads||Error||1||0
+2015-12-01 14:54:14.789891||event||progress-marker||measurement-end||1||0
+2015-12-01 14:54:14.995184||measurement||loadtime||0:00:26.783160||2||0
+2015-12-01 14:54:14.995303||event||progress-marker||measurement-end||2||0
+2015-12-01 14:54:15.961149||error||collecting ads||Error||3||1
+2015-12-01 14:54:22.617904||measurement||price||2015-12-01 14:54:16.965356@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 14:54:26.794236||measurement||price||2015-12-01 14:54:07.392911@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:54:28.379318||measurement||price||2015-12-01 14:54:21.864578@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 14:54:34.046691||measurement||loadtime||0:00:28.991536||4||1
+2015-12-01 14:54:34.964157||measurement||price||2015-12-01 14:54:16.965356@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 14:54:39.996211||error||collecting ads||Error||3||1
+2015-12-01 14:54:41.262177||measurement||price||2015-12-01 14:54:21.864578@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 14:54:42.075960||measurement||loadtime||0:00:26.779394||5||0
+2015-12-01 14:54:42.076070||event||progress-marker||measurement-end||5||0
+2015-12-01 14:54:48.154271||measurement||price||2015-12-01 14:54:41.679376@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 14:54:48.459158||measurement||loadtime||0:00:29.092797||0||1
+2015-12-01 14:54:53.895248||measurement||price||2015-12-01 14:54:47.657522@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:55:01.184042||measurement||price||2015-12-01 14:54:41.679376@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 14:55:06.911461||measurement||price||2015-12-01 14:54:47.657522@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:55:08.368092||measurement||loadtime||0:00:29.316148||4||1
+2015-12-01 14:55:12.569576||error||collecting ads||Error||0||1
+2015-12-01 14:55:14.111958||measurement||loadtime||0:00:29.110514||3||1
+2015-12-01 14:55:22.519802||measurement||price||2015-12-01 14:55:15.740118@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:55:26.479851||measurement||price||2015-12-01 14:55:20.007508@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:55:28.199098||measurement||price||2015-12-01 14:55:21.485431@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 14:55:35.565951||measurement||price||2015-12-01 14:55:15.740118@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:55:39.356137||measurement||price||2015-12-01 14:55:20.007508@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:55:41.220441||measurement||price||2015-12-01 14:55:21.485431@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 14:55:42.786168||measurement||loadtime||0:00:29.412884||4||1
+2015-12-01 14:55:46.535183||measurement||loadtime||0:00:28.964015||0||1
+2015-12-01 14:55:48.435464||measurement||loadtime||0:00:29.318286||3||1
+2015-12-01 14:55:56.433515||measurement||price||2015-12-01 14:55:50.245966@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:56:00.421312||measurement||price||2015-12-01 14:55:54.101678@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:56:02.933417||measurement||price||2015-12-01 14:55:56.749323@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 14:56:09.458101||measurement||price||2015-12-01 14:55:50.245966@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:56:13.240694||measurement||price||2015-12-01 14:55:54.101678@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:56:16.102565||measurement||price||2015-12-01 14:55:56.749323@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 14:56:16.652130||measurement||loadtime||0:00:28.860720||4||1
+2015-12-01 14:56:20.440530||measurement||loadtime||0:00:28.901387||0||1
+2015-12-01 14:56:23.308704||measurement||loadtime||0:00:29.867945||3||1
+2015-12-01 14:56:23.308810||event||progress-marker||measurement-end||3||1
+2015-12-01 14:56:34.532549||measurement||price||2015-12-01 14:56:27.751382@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 14:56:40.461708||error||collecting ads||Error||4||1
+2015-12-01 14:56:40.461845||event||progress-marker||measurement-end||4||1
+2015-12-01 14:56:47.422921||measurement||price||2015-12-01 14:56:27.751382@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 14:56:54.641725||measurement||loadtime||0:00:29.195918||0||1
+2015-12-01 14:56:54.641862||event||progress-marker||measurement-end||0||1
+2015-12-01 14:56:55.029976||meta||block_id end||3
+2015-12-01 14:56:55.030217||meta||block_id start||4
+2015-12-01 14:56:55.030237||meta||assignment||1@|3@|0@|4@|5@|2
+2015-12-01 14:56:56.605159||event||progress-marker||training-start||1||0
+2015-12-01 14:56:56.605258||event||progress-marker||training-end||1||0
+2015-12-01 14:56:56.657915||event||progress-marker||training-start||3||0
+2015-12-01 14:56:56.658015||event||progress-marker||training-end||3||0
+2015-12-01 14:56:56.665200||event||progress-marker||training-start||0||0
+2015-12-01 14:56:56.665307||event||progress-marker||training-end||0||0
+2015-12-01 14:57:01.622784||event||progress-marker||measurement-start||1||0
+2015-12-01 14:57:01.674912||event||progress-marker||measurement-start||3||0
+2015-12-01 14:57:01.686187||event||progress-marker||measurement-start||0||0
+2015-12-01 14:57:10.131278||event||progress-marker||training-start||4||1
+2015-12-01 14:57:10.131409||event||progress-marker||training-end||4||1
+2015-12-01 14:57:15.056246||measurement||price||2015-12-01 14:57:09.060899@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:57:15.064856||measurement||price||2015-12-01 14:57:09.080179@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 14:57:15.143365||event||progress-marker||measurement-start||4||1
+2015-12-01 14:57:25.034404||error||collecting ads||Error||0||0
+2015-12-01 14:57:27.410544||measurement||price||2015-12-01 14:57:09.080179@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 14:57:27.412022||measurement||price||2015-12-01 14:57:09.060899@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:57:29.941912||measurement||price||2015-12-01 14:57:23.416362@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:57:34.522195||measurement||loadtime||0:00:27.843015||3||0
+2015-12-01 14:57:34.527566||measurement||loadtime||0:00:27.899555||1||0
+2015-12-01 14:57:42.813730||measurement||price||2015-12-01 14:57:23.416362@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:57:46.964845||measurement||price||2015-12-01 14:57:41.189982@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:57:47.220964||error||collecting ads||Error||0||0
+2015-12-01 14:57:50.024606||measurement||loadtime||0:00:29.876011||4||1
+2015-12-01 14:57:57.012947||error||collecting ads||Error||3||0
+2015-12-01 14:57:59.296514||measurement||price||2015-12-01 14:57:41.189982@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:57:59.561537||measurement||price||2015-12-01 14:57:53.890617@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 14:58:01.996782||event||progress-marker||training-start||2||1
+2015-12-01 14:58:01.996932||event||progress-marker||training-end||2||1
+2015-12-01 14:58:04.008943||measurement||price||2015-12-01 14:57:57.500631@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 14:58:06.415360||measurement||loadtime||0:00:26.882575||1||0
+2015-12-01 14:58:07.012372||event||progress-marker||measurement-start||2||1
+2015-12-01 14:58:09.699682||measurement||price||2015-12-01 14:58:04.084305@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||3||0
+2015-12-01 14:58:11.910440||measurement||price||2015-12-01 14:57:53.890617@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 14:58:16.924396||measurement||price||2015-12-01 14:57:57.500631@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 14:58:18.767750||measurement||price||2015-12-01 14:58:13.156650@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:58:19.015176||measurement||loadtime||0:00:26.789498||0||0
+2015-12-01 14:58:21.582519||measurement||price||2015-12-01 14:58:14.891637@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:58:22.042805||measurement||price||2015-12-01 14:58:04.084305@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||3||0
+2015-12-01 14:58:24.139171||measurement||loadtime||0:00:29.109373||4||1
+2015-12-01 14:58:29.150554||measurement||loadtime||0:00:27.135413||3||0
+2015-12-01 14:58:31.108384||measurement||price||2015-12-01 14:58:13.156650@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:58:31.201709||measurement||price||2015-12-01 14:58:25.732443@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 14:58:34.430344||measurement||price||2015-12-01 14:58:14.891637@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:58:38.227164||measurement||loadtime||0:00:26.806619||1||0
+2015-12-01 14:58:38.369082||measurement||price||2015-12-01 14:58:31.532087@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 14:58:41.417619||measurement||price||2015-12-01 14:58:35.900435@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:58:41.633263||measurement||loadtime||0:00:29.618107||2||1
+2015-12-01 14:58:43.529619||measurement||price||2015-12-01 14:58:25.732443@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 14:58:50.639268||measurement||loadtime||0:00:26.618888||0||0
+2015-12-01 14:58:51.201438||measurement||price||2015-12-01 14:58:45.494407@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 14:58:51.276052||measurement||price||2015-12-01 14:58:31.532087@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 14:58:53.756082||measurement||price||2015-12-01 14:58:35.900435@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:58:55.619163||measurement||price||2015-12-01 14:58:49.302272@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 14:58:58.479181||measurement||loadtime||0:00:29.336026||4||1
+2015-12-01 14:59:00.860255||measurement||loadtime||0:00:26.705100||3||0
+2015-12-01 14:59:03.504390||measurement||price||2015-12-01 14:58:45.494407@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 14:59:03.538850||measurement||price||2015-12-01 14:58:57.903564@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 14:59:08.504892||measurement||price||2015-12-01 14:58:49.302272@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 14:59:10.594718||measurement||loadtime||0:00:27.362335||1||0
+2015-12-01 14:59:13.201033||measurement||price||2015-12-01 14:59:07.633023@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:59:15.731183||measurement||loadtime||0:00:29.092686||2||1
+2015-12-01 14:59:15.890820||measurement||price||2015-12-01 14:58:57.903564@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 14:59:22.545036||error||collecting ads||Error||4||1
+2015-12-01 14:59:23.003159||measurement||loadtime||0:00:27.360043||0||0
+2015-12-01 14:59:25.532164||measurement||price||2015-12-01 14:59:07.633023@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 14:59:29.929893||measurement||price||2015-12-01 14:59:23.178458@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 14:59:32.450861||event||progress-marker||training-start||5||1
+2015-12-01 14:59:32.450961||event||progress-marker||training-end||5||1
+2015-12-01 14:59:32.640198||measurement||loadtime||0:00:26.777127||3||0
+2015-12-01 14:59:32.829226||error||collecting ads||Error||1||0
+2015-12-01 14:59:35.216170||measurement||price||2015-12-01 14:59:29.591834@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 14:59:36.838048||measurement||price||2015-12-01 14:59:30.635276@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||4||1
+2015-12-01 14:59:37.465177||event||progress-marker||measurement-start||5||1
+2015-12-01 14:59:42.932375||measurement||price||2015-12-01 14:59:23.178458@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 14:59:45.030905||measurement||price||2015-12-01 14:59:39.465498@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 14:59:47.535787||measurement||price||2015-12-01 14:59:29.591834@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 14:59:49.743162||measurement||price||2015-12-01 14:59:30.635276@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||4||1
+2015-12-01 14:59:50.143206||measurement||loadtime||0:00:29.407758||2||1
+2015-12-01 14:59:51.774497||measurement||price||2015-12-01 14:59:45.299917@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 14:59:54.646137||measurement||loadtime||0:00:26.637761||0||0
+2015-12-01 14:59:55.152242||error||collecting ads||Error||1||0
+2015-12-01 14:59:56.950498||measurement||loadtime||0:00:29.400238||4||1
+2015-12-01 14:59:57.385064||measurement||price||2015-12-01 14:59:39.465498@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:00:04.494171||measurement||loadtime||0:00:26.848751||3||0
+2015-12-01 15:00:04.664340||measurement||price||2015-12-01 14:59:45.299917@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:00:07.009475||measurement||price||2015-12-01 15:00:01.359483@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:00:07.885129||measurement||price||2015-12-01 15:00:02.240404@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 15:00:11.111624||measurement||price||2015-12-01 15:00:04.834699@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 15:00:11.850044||measurement||loadtime||0:00:29.379608||5||1
+2015-12-01 15:00:14.086590||error||collecting ads||Error||2||1
+2015-12-01 15:00:16.786275||measurement||price||2015-12-01 15:00:11.121189@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:00:19.364083||measurement||price||2015-12-01 15:00:01.359483@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:00:20.221201||measurement||price||2015-12-01 15:00:02.240404@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 15:00:23.925024||measurement||price||2015-12-01 15:00:04.834699@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 15:00:25.861753||measurement||price||2015-12-01 15:00:19.362267@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:00:26.482366||measurement||loadtime||0:00:26.831756||0||0
+2015-12-01 15:00:27.321000||measurement||loadtime||0:00:27.163482||1||0
+2015-12-01 15:00:29.113245||measurement||price||2015-12-01 15:00:11.121189@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:00:31.125329||measurement||loadtime||0:00:29.170188||4||1
+2015-12-01 15:00:36.223166||measurement||loadtime||0:00:26.728313||3||0
+2015-12-01 15:00:38.077503||error||collecting ads||Error||2||1
+2015-12-01 15:00:38.783063||measurement||price||2015-12-01 15:00:33.131828@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:00:38.961261||measurement||price||2015-12-01 15:00:19.362267@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:00:39.758256||measurement||price||2015-12-01 15:00:34.122283@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 15:00:44.890380||measurement||price||2015-12-01 15:00:38.588276@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:00:46.170705||measurement||loadtime||0:00:29.315435||5||1
+2015-12-01 15:00:48.478028||measurement||price||2015-12-01 15:00:42.922714@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 15:00:51.123674||measurement||price||2015-12-01 15:00:33.131828@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:00:52.051119||measurement||price||2015-12-01 15:00:34.122283@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 15:00:52.061068||measurement||price||2015-12-01 15:00:45.507112@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:00:57.859341||measurement||price||2015-12-01 15:00:38.588276@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:00:58.242029||measurement||loadtime||0:00:26.754425||0||0
+2015-12-01 15:00:59.134508||measurement||loadtime||0:00:26.811318||1||0
+2015-12-01 15:01:00.300529||measurement||price||2015-12-01 15:00:53.684181@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:01:00.807614||measurement||price||2015-12-01 15:00:42.922714@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 15:01:05.067163||measurement||loadtime||0:00:28.940680||4||1
+2015-12-01 15:01:05.887218||measurement||price||2015-12-01 15:00:45.507112@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:01:07.916577||measurement||loadtime||0:00:26.691497||3||0
+2015-12-01 15:01:10.627663||measurement||price||2015-12-01 15:01:04.980258@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:01:11.535460||measurement||price||2015-12-01 15:01:05.892790@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 15:01:13.101333||measurement||loadtime||0:00:30.018641||2||1
+2015-12-01 15:01:13.363138||measurement||price||2015-12-01 15:00:53.684181@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:01:19.153906||measurement||price||2015-12-01 15:01:12.323393@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:01:20.579170||measurement||loadtime||0:00:29.403197||5||1
+2015-12-01 15:01:22.983906||measurement||price||2015-12-01 15:01:04.980258@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:01:23.876501||measurement||price||2015-12-01 15:01:05.892790@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 15:01:27.251792||measurement||price||2015-12-01 15:01:20.436183@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:01:30.095188||measurement||loadtime||0:00:26.847931||0||0
+2015-12-01 15:01:30.148682||error||collecting ads||Error||3||0
+2015-12-01 15:01:30.992606||measurement||loadtime||0:00:26.852888||1||0
+2015-12-01 15:01:32.270903||measurement||price||2015-12-01 15:01:12.323393@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:01:34.442546||measurement||price||2015-12-01 15:01:27.888566@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:01:39.493036||measurement||loadtime||0:00:29.420669||4||1
+2015-12-01 15:01:40.076362||measurement||price||2015-12-01 15:01:20.436183@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:01:42.495867||measurement||price||2015-12-01 15:01:36.813014@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:01:42.514585||measurement||price||2015-12-01 15:01:36.914848@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 15:01:43.422300||measurement||price||2015-12-01 15:01:37.863271@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 15:01:47.257981||measurement||loadtime||0:00:29.152026||2||1
+2015-12-01 15:01:47.382229||measurement||price||2015-12-01 15:01:27.888566@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:01:53.402393||measurement||price||2015-12-01 15:01:46.938331@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:01:54.571152||measurement||loadtime||0:00:28.986776||5||1
+2015-12-01 15:01:54.838440||measurement||price||2015-12-01 15:01:36.813014@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:01:54.851991||measurement||price||2015-12-01 15:01:36.914848@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 15:01:55.712122||measurement||price||2015-12-01 15:01:37.863271@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 15:02:01.436527||measurement||price||2015-12-01 15:01:54.533799@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:02:01.951151||measurement||loadtime||0:00:26.852024||0||0
+2015-12-01 15:02:01.967142||measurement||loadtime||0:00:26.816012||3||0
+2015-12-01 15:02:02.790209||measurement||loadtime||0:00:26.795048||1||0
+2015-12-01 15:02:06.331651||measurement||price||2015-12-01 15:01:46.938331@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:02:08.571179||measurement||price||2015-12-01 15:02:02.001992@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 15:02:13.514109||measurement||loadtime||0:00:29.019122||4||1
+2015-12-01 15:02:14.400115||measurement||price||2015-12-01 15:02:08.641023@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:02:14.409872||measurement||price||2015-12-01 15:01:54.533799@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:02:15.209148||measurement||price||2015-12-01 15:02:09.524145@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 15:02:21.532296||measurement||price||2015-12-01 15:02:02.001992@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 15:02:21.663188||measurement||loadtime||0:00:29.400013||2||1
+2015-12-01 15:02:24.389709||error||collecting ads||Error||3||0
+2015-12-01 15:02:26.712511||measurement||price||2015-12-01 15:02:08.641023@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:02:27.574644||measurement||price||2015-12-01 15:02:09.524145@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 15:02:28.731711||measurement||loadtime||0:00:29.155325||5||1
+2015-12-01 15:02:33.799068||measurement||loadtime||0:00:26.842714||0||0
+2015-12-01 15:02:34.688973||measurement||loadtime||0:00:26.893828||1||0
+2015-12-01 15:02:36.085020||measurement||price||2015-12-01 15:02:29.408344@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||1
+2015-12-01 15:02:37.267396||error||collecting ads||Error||4||1
+2015-12-01 15:02:46.110482||measurement||price||2015-12-01 15:02:40.507296@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:02:46.616076||error||collecting ads||Error||3||0
+2015-12-01 15:02:47.019234||measurement||price||2015-12-01 15:02:41.491833@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 15:02:48.911820||measurement||price||2015-12-01 15:02:29.408344@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||1
+2015-12-01 15:02:52.587867||error||collecting ads||Error||5||1
+2015-12-01 15:02:56.112977||measurement||loadtime||0:00:29.444567||2||1
+2015-12-01 15:02:58.441510||measurement||price||2015-12-01 15:02:40.507296@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:02:59.358274||measurement||price||2015-12-01 15:02:41.491833@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 15:03:01.128677||error||collecting ads||Error||4||1
+2015-12-01 15:03:05.549542||measurement||loadtime||0:00:26.745272||0||0
+2015-12-01 15:03:06.463158||measurement||loadtime||0:00:26.772027||1||0
+2015-12-01 15:03:06.843596||measurement||price||2015-12-01 15:02:59.835709@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:03:08.827924||error||collecting ads||Error||3||0
+2015-12-01 15:03:10.349233||measurement||price||2015-12-01 15:03:03.457444@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:03:14.978493||measurement||price||2015-12-01 15:03:08.698076@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:03:19.743283||measurement||price||2015-12-01 15:02:59.835709@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:03:23.467167||measurement||price||2015-12-01 15:03:03.457444@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:03:26.961502||measurement||loadtime||0:00:29.368421||5||1
+2015-12-01 15:03:27.797322||error||collecting ads||Error||0||0
+2015-12-01 15:03:28.081473||measurement||price||2015-12-01 15:03:08.698076@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:03:28.772356||error||collecting ads||Error||1||0
+2015-12-01 15:03:30.679332||measurement||loadtime||0:00:29.561770||2||1
+2015-12-01 15:03:31.727989||error||collecting ads||Error||3||0
+2015-12-01 15:03:35.263205||measurement||loadtime||0:00:29.129310||4||1
+2015-12-01 15:03:41.207752||measurement||price||2015-12-01 15:03:35.470961@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 15:03:43.989681||measurement||price||2015-12-01 15:03:38.419306@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 15:03:44.723791||measurement||price||2015-12-01 15:03:38.394659@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:03:48.907846||measurement||price||2015-12-01 15:03:42.517787@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:03:50.171197||error||collecting ads||Error||0||0
+2015-12-01 15:03:51.338140||error||collecting ads||Error||5||1
+2015-12-01 15:03:53.540933||measurement||price||2015-12-01 15:03:35.470961@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 15:03:56.328355||measurement||price||2015-12-01 15:03:38.419306@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 15:03:57.702667||measurement||price||2015-12-01 15:03:38.394659@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:04:00.655167||measurement||loadtime||0:00:26.880031||1||0
+2015-12-01 15:04:01.952629||measurement||price||2015-12-01 15:03:42.517787@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:04:02.547693||measurement||price||2015-12-01 15:03:56.846389@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:04:03.446314||measurement||loadtime||0:00:26.715156||3||0
+2015-12-01 15:04:04.903823||measurement||loadtime||0:00:29.223134||2||1
+2015-12-01 15:04:05.419082||measurement||price||2015-12-01 15:03:58.547611@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:04:09.147144||measurement||loadtime||0:00:28.880015||4||1
+2015-12-01 15:04:12.872220||measurement||price||2015-12-01 15:04:07.257999@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 15:04:14.888723||measurement||price||2015-12-01 15:03:56.846389@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:04:15.727423||measurement||price||2015-12-01 15:04:10.123826@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 15:04:18.538407||measurement||price||2015-12-01 15:03:58.547611@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:04:18.996966||measurement||price||2015-12-01 15:04:12.238262@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:04:21.999173||measurement||loadtime||0:00:26.822735||0||0
+2015-12-01 15:04:23.138982||measurement||price||2015-12-01 15:04:16.539591@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 15:04:25.209584||measurement||price||2015-12-01 15:04:07.257999@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 15:04:25.741493||measurement||loadtime||0:00:29.398137||5||1
+2015-12-01 15:04:28.068420||measurement||price||2015-12-01 15:04:10.123826@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 15:04:32.038793||measurement||price||2015-12-01 15:04:12.238262@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:04:32.327194||measurement||loadtime||0:00:26.669314||1||0
+2015-12-01 15:04:34.249545||measurement||price||2015-12-01 15:04:28.651132@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:04:35.177522||measurement||loadtime||0:00:26.725970||3||0
+2015-12-01 15:04:36.007272||measurement||price||2015-12-01 15:04:16.539591@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 15:04:39.258802||measurement||loadtime||0:00:29.351627||2||1
+2015-12-01 15:04:39.744257||measurement||price||2015-12-01 15:04:33.141104@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:04:43.192355||measurement||loadtime||0:00:29.040049||4||1
+2015-12-01 15:04:45.085621||measurement||price||2015-12-01 15:04:39.415489@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 15:04:46.552701||measurement||price||2015-12-01 15:04:28.651132@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:04:47.454794||measurement||price||2015-12-01 15:04:41.860093@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 15:04:52.633208||measurement||price||2015-12-01 15:04:33.141104@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:04:53.420488||measurement||price||2015-12-01 15:04:46.738261@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:04:53.667200||measurement||loadtime||0:00:26.664039||0||0
+2015-12-01 15:04:57.375978||measurement||price||2015-12-01 15:04:50.721294@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:04:57.421012||measurement||price||2015-12-01 15:04:39.415489@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 15:04:59.761721||measurement||price||2015-12-01 15:04:41.860093@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 15:04:59.851229||measurement||loadtime||0:00:29.104480||5||1
+2015-12-01 15:05:04.528518||measurement||loadtime||0:00:27.196106||1||0
+2015-12-01 15:05:06.446199||measurement||price||2015-12-01 15:04:46.738261@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:05:06.849809||measurement||loadtime||0:00:26.667055||3||0
+2015-12-01 15:05:10.291440||measurement||price||2015-12-01 15:04:50.721294@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:05:13.663190||measurement||loadtime||0:00:29.403099||2||1
+2015-12-01 15:05:15.930791||error||collecting ads||Error||0||0
+2015-12-01 15:05:16.827804||measurement||price||2015-12-01 15:05:11.205891@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 15:05:17.524399||measurement||loadtime||0:00:29.330150||4||1
+2015-12-01 15:05:19.133898||measurement||price||2015-12-01 15:05:13.567598@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:05:23.822936||error||collecting ads||Error||5||1
+2015-12-01 15:05:27.568703||measurement||price||2015-12-01 15:05:20.922556@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:05:29.127922||measurement||price||2015-12-01 15:05:11.205891@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 15:05:31.465607||measurement||price||2015-12-01 15:05:13.567598@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:05:36.209047||measurement||loadtime||0:00:26.675310||1||0
+2015-12-01 15:05:38.052013||measurement||price||2015-12-01 15:05:31.035787@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:05:38.319181||error||collecting ads||Error||0||0
+2015-12-01 15:05:38.576393||measurement||loadtime||0:00:26.721361||3||0
+2015-12-01 15:05:40.504537||measurement||price||2015-12-01 15:05:20.922556@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:05:41.767777||error||collecting ads||Error||4||1
+2015-12-01 15:05:47.722494||measurement||loadtime||0:00:29.054091||2||1
+2015-12-01 15:05:48.498524||measurement||price||2015-12-01 15:05:42.924147@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 15:05:50.933562||measurement||price||2015-12-01 15:05:45.330290@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:05:50.962863||measurement||price||2015-12-01 15:05:31.035787@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:05:58.203163||measurement||loadtime||0:00:29.379923||5||1
+2015-12-01 15:06:00.637295||error||collecting ads||Error||0||0
+2015-12-01 15:06:00.791346||measurement||price||2015-12-01 15:05:42.924147@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 15:06:01.829626||measurement||price||2015-12-01 15:05:54.963218@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:06:03.278023||measurement||price||2015-12-01 15:05:45.330290@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:06:05.602022||error||collecting ads||Error||4||1
+2015-12-01 15:06:07.875172||measurement||loadtime||0:00:26.665069||1||0
+2015-12-01 15:06:10.390496||measurement||loadtime||0:00:26.811330||3||0
+2015-12-01 15:06:11.929715||measurement||price||2015-12-01 15:06:05.589184@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:06:12.931448||measurement||price||2015-12-01 15:06:07.361756@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:06:14.874021||measurement||price||2015-12-01 15:05:54.963218@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:06:19.578699||measurement||price||2015-12-01 15:06:12.863334@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 15:06:20.141669||measurement||price||2015-12-01 15:06:14.508088@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 15:06:22.106297||measurement||loadtime||0:00:29.378607||2||1
+2015-12-01 15:06:22.663559||measurement||price||2015-12-01 15:06:17.024621@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 15:06:24.759942||measurement||price||2015-12-01 15:06:05.589184@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:06:25.264277||measurement||price||2015-12-01 15:06:07.361756@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:06:31.991502||measurement||loadtime||0:00:28.783137||5||1
+2015-12-01 15:06:32.374768||measurement||loadtime||0:00:26.737085||0||0
+2015-12-01 15:06:32.374883||event||progress-marker||measurement-end||0||0
+2015-12-01 15:06:32.438970||measurement||price||2015-12-01 15:06:14.508088@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 15:06:32.459275||measurement||price||2015-12-01 15:06:12.863334@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 15:06:34.996944||measurement||price||2015-12-01 15:06:17.024621@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 15:06:36.157643||measurement||price||2015-12-01 15:06:29.522101@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:06:39.521185||measurement||loadtime||0:00:26.642026||1||0
+2015-12-01 15:06:39.645611||measurement||loadtime||0:00:29.038383||4||1
+2015-12-01 15:06:42.104002||measurement||loadtime||0:00:26.708313||3||0
+2015-12-01 15:06:42.104128||event||progress-marker||measurement-end||3||0
+2015-12-01 15:06:46.278077||measurement||price||2015-12-01 15:06:39.831562@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:06:49.200942||measurement||price||2015-12-01 15:06:29.522101@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:06:51.906989||measurement||price||2015-12-01 15:06:46.327437@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 15:06:53.957528||measurement||price||2015-12-01 15:06:47.135552@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:06:56.427662||measurement||loadtime||0:00:29.316142||2||1
+2015-12-01 15:06:59.329463||measurement||price||2015-12-01 15:06:39.831562@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:07:04.208660||measurement||price||2015-12-01 15:06:46.327437@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 15:07:06.554704||measurement||loadtime||0:00:29.557985||5||1
+2015-12-01 15:07:07.011291||measurement||price||2015-12-01 15:06:47.135552@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:07:10.478406||measurement||price||2015-12-01 15:07:03.624388@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:07:11.304116||measurement||loadtime||0:00:26.778395||1||0
+2015-12-01 15:07:11.304250||event||progress-marker||measurement-end||1||0
+2015-12-01 15:07:14.231156||measurement||loadtime||0:00:29.580306||4||1
+2015-12-01 15:07:20.655188||measurement||price||2015-12-01 15:07:14.061315@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 15:07:23.466459||measurement||price||2015-12-01 15:07:03.624388@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:07:30.803415||measurement||loadtime||0:00:29.372259||2||1
+2015-12-01 15:07:33.507543||measurement||price||2015-12-01 15:07:14.061315@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 15:07:38.057653||error||collecting ads||Error||4||1
+2015-12-01 15:07:38.057752||event||progress-marker||measurement-end||4||1
+2015-12-01 15:07:40.706686||measurement||loadtime||0:00:29.147525||5||1
+2015-12-01 15:07:44.759917||measurement||price||2015-12-01 15:07:38.154728@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:07:54.771924||measurement||price||2015-12-01 15:07:48.350385@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:07:57.633672||measurement||price||2015-12-01 15:07:38.154728@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:08:04.815943||measurement||loadtime||0:00:29.007272||2||1
+2015-12-01 15:08:07.726581||measurement||price||2015-12-01 15:07:48.350385@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:08:14.946574||measurement||loadtime||0:00:29.234649||5||1
+2015-12-01 15:08:18.556265||measurement||price||2015-12-01 15:08:12.059296@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:08:29.143858||measurement||price||2015-12-01 15:08:22.190733@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:08:31.545876||measurement||price||2015-12-01 15:08:12.059296@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:08:38.743974||measurement||loadtime||0:00:28.922793||2||1
+2015-12-01 15:08:42.011803||measurement||price||2015-12-01 15:08:22.190733@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:08:49.211447||measurement||loadtime||0:00:29.259627||5||1
+2015-12-01 15:08:53.817172||measurement||price||2015-12-01 15:08:47.585447@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:09:06.790714||measurement||price||2015-12-01 15:08:47.585447@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:09:12.857135||error||collecting ads||Error||5||1
+2015-12-01 15:09:14.022049||measurement||loadtime||0:00:30.272843||2||1
+2015-12-01 15:09:14.022187||event||progress-marker||measurement-end||2||1
+2015-12-01 15:09:27.000307||measurement||price||2015-12-01 15:09:20.111793@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:09:39.911852||measurement||price||2015-12-01 15:09:20.111793@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:09:47.123970||measurement||loadtime||0:00:29.261568||5||1
+2015-12-01 15:10:00.980792||measurement||price||2015-12-01 15:09:54.707637@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:10:13.818935||measurement||price||2015-12-01 15:09:54.707637@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:10:21.047798||measurement||loadtime||0:00:28.918492||5||1
+2015-12-01 15:10:21.047937||event||progress-marker||measurement-end||5||1
+2015-12-01 15:10:21.547058||meta||block_id end||4
+2015-12-01 15:10:21.547415||meta||block_id start||5
+2015-12-01 15:10:21.547448||meta||assignment||5@|2@|0@|3@|1@|4
+2015-12-01 15:10:23.118443||event||progress-marker||training-start||2||0
+2015-12-01 15:10:23.118548||event||progress-marker||training-end||2||0
+2015-12-01 15:10:23.149021||event||progress-marker||training-start||0||0
+2015-12-01 15:10:23.149120||event||progress-marker||training-end||0||0
+2015-12-01 15:10:23.173177||event||progress-marker||training-start||5||0
+2015-12-01 15:10:23.173271||event||progress-marker||training-end||5||0
+2015-12-01 15:10:28.137900||event||progress-marker||measurement-start||2||0
+2015-12-01 15:10:28.168689||event||progress-marker||measurement-start||0||0
+2015-12-01 15:10:28.193006||event||progress-marker||measurement-start||5||0
+2015-12-01 15:10:35.876933||event||progress-marker||training-start||3||1
+2015-12-01 15:10:35.877037||event||progress-marker||training-end||3||1
+2015-12-01 15:10:40.892256||event||progress-marker||measurement-start||3||1
+2015-12-01 15:10:41.657322||measurement||price||2015-12-01 15:10:35.492794@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:10:41.664034||measurement||price||2015-12-01 15:10:35.567407@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:10:51.667291||error||collecting ads||Error||5||0
+2015-12-01 15:10:53.967414||measurement||price||2015-12-01 15:10:35.492794@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:10:53.997255||measurement||price||2015-12-01 15:10:35.567407@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:10:55.650266||measurement||price||2015-12-01 15:10:48.975353@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:11:01.083523||measurement||loadtime||0:00:27.909663||0||0
+2015-12-01 15:11:01.112301||measurement||loadtime||0:00:27.969195||2||0
+2015-12-01 15:11:08.708847||measurement||price||2015-12-01 15:10:48.975353@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:11:13.373676||measurement||price||2015-12-01 15:11:07.787643@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:11:13.631220||measurement||price||2015-12-01 15:11:07.808780@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:11:13.878918||error||collecting ads||Error||5||0
+2015-12-01 15:11:16.025252||measurement||loadtime||0:00:30.127745||3||1
+2015-12-01 15:11:25.707797||measurement||price||2015-12-01 15:11:07.787643@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:11:25.961169||measurement||price||2015-12-01 15:11:07.808780@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:11:26.318443||measurement||price||2015-12-01 15:11:20.642623@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:11:27.736226||event||progress-marker||training-start||1||1
+2015-12-01 15:11:27.736372||event||progress-marker||training-end||1||1
+2015-12-01 15:11:32.755451||event||progress-marker||measurement-start||1||1
+2015-12-01 15:11:32.820050||measurement||loadtime||0:00:26.732186||0||0
+2015-12-01 15:11:33.080084||measurement||loadtime||0:00:26.962593||2||0
+2015-12-01 15:11:38.668945||measurement||price||2015-12-01 15:11:20.642623@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:11:40.192871||error||collecting ads||Error||3||1
+2015-12-01 15:11:45.294794||measurement||price||2015-12-01 15:11:39.602119@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:11:45.791503||measurement||loadtime||0:00:26.907375||5||0
+2015-12-01 15:11:47.484575||measurement||price||2015-12-01 15:11:40.703208@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:11:54.131641||measurement||price||2015-12-01 15:11:47.420846@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:11:55.434453||error||collecting ads||Error||2||0
+2015-12-01 15:11:57.631918||measurement||price||2015-12-01 15:11:39.602119@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:11:57.987957||measurement||price||2015-12-01 15:11:52.439657@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:12:00.849123||measurement||price||2015-12-01 15:11:40.703208@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:12:04.739772||measurement||loadtime||0:00:26.916626||0||0
+2015-12-01 15:12:07.217328||measurement||price||2015-12-01 15:11:47.420846@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:12:07.672413||measurement||price||2015-12-01 15:12:02.094349@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:12:08.042314||measurement||loadtime||0:00:30.283120||1||1
+2015-12-01 15:12:10.319100||measurement||price||2015-12-01 15:11:52.439657@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:12:14.419180||measurement||loadtime||0:00:29.225079||3||1
+2015-12-01 15:12:17.009278||measurement||price||2015-12-01 15:12:11.396339@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:12:17.434923||measurement||loadtime||0:00:26.638960||5||0
+2015-12-01 15:12:20.029340||measurement||price||2015-12-01 15:12:02.094349@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:12:22.079912||measurement||price||2015-12-01 15:12:15.659615@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:12:27.143627||measurement||loadtime||0:00:26.703937||2||0
+2015-12-01 15:12:28.435908||measurement||price||2015-12-01 15:12:21.842666@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:12:29.347403||measurement||price||2015-12-01 15:12:11.396339@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:12:29.783312||measurement||price||2015-12-01 15:12:24.133626@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:12:30.838589||event||progress-marker||training-start||4||1
+2015-12-01 15:12:30.838733||event||progress-marker||training-end||4||1
+2015-12-01 15:12:34.988245||measurement||price||2015-12-01 15:12:15.659615@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:12:35.856658||event||progress-marker||measurement-start||4||1
+2015-12-01 15:12:36.464318||measurement||loadtime||0:00:26.719319||0||0
+2015-12-01 15:12:39.318700||measurement||price||2015-12-01 15:12:33.753205@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:12:41.485468||measurement||price||2015-12-01 15:12:21.842666@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:12:42.125339||measurement||price||2015-12-01 15:12:24.133626@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:12:42.203143||measurement||loadtime||0:00:29.155606||1||1
+2015-12-01 15:12:48.698263||measurement||loadtime||0:00:29.274770||3||1
+2015-12-01 15:12:48.855687||measurement||price||2015-12-01 15:12:43.287618@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:12:49.249941||measurement||loadtime||0:00:26.810769||5||0
+2015-12-01 15:12:51.637823||measurement||price||2015-12-01 15:12:33.753205@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:12:56.002811||measurement||price||2015-12-01 15:12:49.642484@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:12:58.745598||measurement||loadtime||0:00:26.596743||2||0
+2015-12-01 15:13:00.109841||error||collecting ads||Error||4||1
+2015-12-01 15:13:01.206392||measurement||price||2015-12-01 15:12:43.287618@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:13:01.550534||measurement||price||2015-12-01 15:12:55.862910@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:13:02.570240||measurement||price||2015-12-01 15:12:56.149622@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:13:08.323276||measurement||loadtime||0:00:26.853769||0||0
+2015-12-01 15:13:09.069100||measurement||price||2015-12-01 15:12:49.642484@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:13:13.884842||measurement||price||2015-12-01 15:12:55.862910@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:13:13.943565||measurement||price||2015-12-01 15:13:07.751507@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 15:13:15.480653||measurement||price||2015-12-01 15:12:56.149622@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:13:16.266847||measurement||loadtime||0:00:29.063099||1||1
+2015-12-01 15:13:20.648518||measurement||price||2015-12-01 15:13:15.012040@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:13:21.012434||measurement||loadtime||0:00:26.757255||5||0
+2015-12-01 15:13:21.134340||error||collecting ads||Error||2||0
+2015-12-01 15:13:22.700756||measurement||loadtime||0:00:28.997278||3||1
+2015-12-01 15:13:26.818708||measurement||price||2015-12-01 15:13:07.751507@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 15:13:30.510446||measurement||price||2015-12-01 15:13:23.519532@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 15:13:32.997020||measurement||price||2015-12-01 15:13:15.012040@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:13:33.356963||measurement||price||2015-12-01 15:13:27.663349@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:13:33.505827||measurement||price||2015-12-01 15:13:27.814753@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:13:34.033656||measurement||loadtime||0:00:28.918578||4||1
+2015-12-01 15:13:36.658628||measurement||price||2015-12-01 15:13:29.975872@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:13:40.112613||measurement||loadtime||0:00:26.784115||0||0
+2015-12-01 15:13:43.542597||measurement||price||2015-12-01 15:13:23.519532@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 15:13:45.719156||measurement||price||2015-12-01 15:13:27.663349@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:13:45.846477||measurement||price||2015-12-01 15:13:27.814753@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:13:48.113149||measurement||price||2015-12-01 15:13:41.917806@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 15:13:49.655920||measurement||price||2015-12-01 15:13:29.975872@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:13:50.751759||measurement||loadtime||0:00:29.481816||1||1
+2015-12-01 15:13:52.438229||measurement||price||2015-12-01 15:13:46.792905@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:13:52.844277||measurement||loadtime||0:00:26.829121||5||0
+2015-12-01 15:13:52.953104||measurement||loadtime||0:00:26.813960||2||0
+2015-12-01 15:13:56.852616||measurement||loadtime||0:00:29.149465||3||1
+2015-12-01 15:14:01.069761||measurement||price||2015-12-01 15:13:41.917806@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 15:14:04.774029||measurement||price||2015-12-01 15:13:46.792905@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:14:04.965046||measurement||price||2015-12-01 15:13:57.963116@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:14:05.755418||measurement||price||2015-12-01 15:14:00.124861@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||0
+2015-12-01 15:14:08.294314||measurement||loadtime||0:00:29.255451||4||1
+2015-12-01 15:14:10.931331||measurement||price||2015-12-01 15:14:04.218516@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:14:11.895673||measurement||loadtime||0:00:26.777807||0||0
+2015-12-01 15:14:16.038650||error||collecting ads||Error||5||0
+2015-12-01 15:14:18.089537||measurement||price||2015-12-01 15:14:00.124861@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||0
+2015-12-01 15:14:18.243272||measurement||price||2015-12-01 15:13:57.963116@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:14:23.984311||measurement||price||2015-12-01 15:14:04.218516@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:14:24.400886||measurement||price||2015-12-01 15:14:18.775325@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:14:25.202891||measurement||loadtime||0:00:27.244564||2||0
+2015-12-01 15:14:25.498931||measurement||loadtime||0:00:29.741953||1||1
+2015-12-01 15:14:29.069040||measurement||price||2015-12-01 15:14:23.489034@|Coast@|$9.54@|Coast HP1 Focusing 220 Lumen LED Flashlight||5||0
+2015-12-01 15:14:31.200431||measurement||loadtime||0:00:29.342612||3||1
+2015-12-01 15:14:31.990748||error||collecting ads||Error||4||1
+2015-12-01 15:14:36.717250||measurement||price||2015-12-01 15:14:18.775325@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:14:37.646074||measurement||price||2015-12-01 15:14:31.953184@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:14:39.721507||measurement||price||2015-12-01 15:14:32.858440@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:14:41.425096||measurement||price||2015-12-01 15:14:23.489034@|Coast@|$31.41@|Coast HL7 Focusing 285 Lumen LED Headlamp||5||0
+2015-12-01 15:14:43.802530||measurement||loadtime||0:00:26.901643||0||0
+2015-12-01 15:14:45.287663||measurement||price||2015-12-01 15:14:38.528154@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:14:46.503132||measurement||price||2015-12-01 15:14:40.123123@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 15:14:48.517575||measurement||loadtime||0:00:27.473689||5||0
+2015-12-01 15:14:49.983974||measurement||price||2015-12-01 15:14:31.953184@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:14:52.567647||measurement||price||2015-12-01 15:14:32.858440@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:14:57.091554||measurement||loadtime||0:00:26.883468||2||0
+2015-12-01 15:14:58.274912||measurement||price||2015-12-01 15:14:38.528154@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:14:59.446608||measurement||price||2015-12-01 15:14:40.123123@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 15:14:59.767227||measurement||loadtime||0:00:29.263060||1||1
+2015-12-01 15:15:01.532937||measurement||price||2015-12-01 15:14:55.972775@|Stanley@|$9.06@|Stanley 33-425 Powerlock 25-Foot by 1-Inch Measuring Tape...||5||0
+2015-12-01 15:15:05.484835||measurement||loadtime||0:00:29.279199||3||1
+2015-12-01 15:15:06.123311||error||collecting ads||Error||0||0
+2015-12-01 15:15:06.670222||measurement||loadtime||0:00:29.675088||4||1
+2015-12-01 15:15:09.419506||measurement||price||2015-12-01 15:15:03.770748@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:15:13.561131||measurement||price||2015-12-01 15:15:07.176802@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:15:13.872298||measurement||price||2015-12-01 15:14:55.972775@|Stanley@|$99.95@|STANLEY STMT73795 Mixed Tool Set, 210-Piece||5||0
+2015-12-01 15:15:18.750659||measurement||price||2015-12-01 15:15:13.090719@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||0||0
+2015-12-01 15:15:20.729028||measurement||price||2015-12-01 15:15:14.589457@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 15:15:20.999154||measurement||loadtime||0:00:27.476325||5||0
+2015-12-01 15:15:21.767609||measurement||price||2015-12-01 15:15:03.770748@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:15:26.407049||measurement||price||2015-12-01 15:15:07.176802@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:15:28.883168||measurement||loadtime||0:00:26.786414||2||0
+2015-12-01 15:15:29.667243||error||collecting ads||Error||3||1
+2015-12-01 15:15:31.091121||measurement||price||2015-12-01 15:15:13.090719@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||0||0
+2015-12-01 15:15:33.569923||measurement||price||2015-12-01 15:15:14.589457@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 15:15:33.599091||measurement||loadtime||0:00:28.827902||1||1
+2015-12-01 15:15:33.682825||measurement||price||2015-12-01 15:15:28.134835@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:15:38.203159||measurement||loadtime||0:00:27.074646||0||0
+2015-12-01 15:15:40.771169||measurement||loadtime||0:00:29.095737||4||1
+2015-12-01 15:15:41.252870||measurement||price||2015-12-01 15:15:35.560083@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:15:46.020530||measurement||price||2015-12-01 15:15:28.134835@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:15:50.408860||measurement||price||2015-12-01 15:15:44.809455@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:15:53.132855||measurement||loadtime||0:00:27.129715||5||0
+2015-12-01 15:15:53.599009||measurement||price||2015-12-01 15:15:35.560083@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:15:53.664839||error||collecting ads||Error||3||1
+2015-12-01 15:15:54.609509||measurement||price||2015-12-01 15:15:48.321355@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:15:57.647090||error||collecting ads||Error||1||1
+2015-12-01 15:16:00.707159||measurement||loadtime||0:00:26.818793||2||0
+2015-12-01 15:16:02.728858||measurement||price||2015-12-01 15:15:44.809455@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:16:05.914642||measurement||price||2015-12-01 15:16:00.297354@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||5||0
+2015-12-01 15:16:07.441107||measurement||price||2015-12-01 15:15:48.321355@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:16:09.817447||measurement||loadtime||0:00:26.610289||0||0
+2015-12-01 15:16:11.692445||measurement||price||2015-12-01 15:16:04.942900@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:16:13.063396||measurement||price||2015-12-01 15:16:07.497755@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:16:14.639187||measurement||loadtime||0:00:28.863078||4||1
+2015-12-01 15:16:17.839958||error||collecting ads||Error||3||1
+2015-12-01 15:16:18.264212||measurement||price||2015-12-01 15:16:00.297354@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||5||0
+2015-12-01 15:16:22.513550||measurement||price||2015-12-01 15:16:16.922659@|At-A-Glance@|$23.97@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||0
+2015-12-01 15:16:24.583988||measurement||price||2015-12-01 15:16:04.942900@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:16:25.384920||measurement||loadtime||0:00:27.246857||5||0
+2015-12-01 15:16:25.399627||measurement||price||2015-12-01 15:16:07.497755@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:16:28.566055||measurement||price||2015-12-01 15:16:22.288358@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:16:31.771192||measurement||loadtime||0:00:29.120003||1||1
+2015-12-01 15:16:31.849711||measurement||price||2015-12-01 15:16:25.281100@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:16:32.509982||measurement||loadtime||0:00:26.797563||2||0
+2015-12-01 15:16:34.820893||measurement||price||2015-12-01 15:16:16.922659@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||0
+2015-12-01 15:16:41.509416||measurement||price||2015-12-01 15:16:22.288358@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:16:41.934928||measurement||loadtime||0:00:27.112254||0||0
+2015-12-01 15:16:44.958323||measurement||price||2015-12-01 15:16:39.286523@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:16:44.973407||measurement||price||2015-12-01 15:16:25.281100@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:16:47.718066||error||collecting ads||Error||5||0
+2015-12-01 15:16:48.707182||measurement||loadtime||0:00:29.064013||4||1
+2015-12-01 15:16:52.202807||measurement||loadtime||0:00:29.360322||3||1
+2015-12-01 15:16:54.209833||measurement||price||2015-12-01 15:16:48.628075@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:16:55.836719||error||collecting ads||Error||1||1
+2015-12-01 15:16:57.289886||measurement||price||2015-12-01 15:16:39.286523@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:16:59.958537||measurement||price||2015-12-01 15:16:54.354413@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:17:04.400819||measurement||loadtime||0:00:26.885624||2||0
+2015-12-01 15:17:06.527087||measurement||price||2015-12-01 15:16:48.628075@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:17:06.753851||measurement||price||2015-12-01 15:17:00.299416@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:17:10.092124||measurement||price||2015-12-01 15:17:04.019439@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:17:12.277516||measurement||price||2015-12-01 15:16:54.354413@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:17:12.470659||error||collecting ads||Error||4||1
+2015-12-01 15:17:13.641737||measurement||loadtime||0:00:26.701614||0||0
+2015-12-01 15:17:17.187893||measurement||price||2015-12-01 15:17:11.603187@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:17:19.391157||measurement||loadtime||0:00:26.668026||5||0
+2015-12-01 15:17:19.740308||measurement||price||2015-12-01 15:17:00.299416@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:17:23.157745||measurement||price||2015-12-01 15:17:04.019439@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:17:25.941286||measurement||price||2015-12-01 15:17:20.342801@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:17:26.951156||measurement||loadtime||0:00:29.743183||3||1
+2015-12-01 15:17:29.530325||measurement||price||2015-12-01 15:17:11.603187@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:17:30.379613||measurement||loadtime||0:00:29.540462||1||1
+2015-12-01 15:17:32.210094||measurement||price||2015-12-01 15:17:26.601795@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:17:36.638924||measurement||loadtime||0:00:27.232891||2||0
+2015-12-01 15:17:36.747823||error||collecting ads||Error||4||1
+2015-12-01 15:17:38.289238||measurement||price||2015-12-01 15:17:20.342801@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:17:41.041471||measurement||price||2015-12-01 15:17:35.152667@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:17:44.545737||measurement||price||2015-12-01 15:17:26.601795@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:17:45.407433||measurement||loadtime||0:00:26.760497||0||0
+2015-12-01 15:17:49.026958||measurement||price||2015-12-01 15:17:43.244088@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:17:51.048240||measurement||price||2015-12-01 15:17:44.802696@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:17:51.664432||measurement||loadtime||0:00:27.272953||5||0
+2015-12-01 15:17:53.894588||measurement||price||2015-12-01 15:17:35.152667@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:17:54.591309||error||collecting ads||Error||1||1
+2015-12-01 15:17:57.706314||measurement||price||2015-12-01 15:17:52.071916@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:18:01.143273||measurement||loadtime||0:00:29.186951||3||1
+2015-12-01 15:18:01.368887||measurement||price||2015-12-01 15:17:43.244088@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:18:03.869411||measurement||price||2015-12-01 15:17:44.802696@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:18:04.021200||measurement||price||2015-12-01 15:17:58.355420@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:18:08.481103||measurement||loadtime||0:00:26.836971||2||0
+2015-12-01 15:18:08.894874||measurement||price||2015-12-01 15:18:02.496825@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||1
+2015-12-01 15:18:10.038676||measurement||price||2015-12-01 15:17:52.071916@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:18:11.119723||measurement||loadtime||0:00:29.368533||4||1
+2015-12-01 15:18:16.380279||measurement||price||2015-12-01 15:17:58.355420@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:18:17.156068||measurement||loadtime||0:00:26.743432||0||0
+2015-12-01 15:18:20.776186||measurement||price||2015-12-01 15:18:15.130023@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||2||0
+2015-12-01 15:18:21.826621||measurement||price||2015-12-01 15:18:02.496825@|Warner Bros@|$49.95@|Jurassic World Team Pack - LEGO Dimensions||1||1
+2015-12-01 15:18:23.495156||measurement||loadtime||0:00:26.828009||5||0
+2015-12-01 15:18:25.320584||error||collecting ads||Error||3||1
+2015-12-01 15:18:29.041179||measurement||loadtime||0:00:29.447734||1||1
+2015-12-01 15:18:29.554104||measurement||price||2015-12-01 15:18:23.942256@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:18:35.199892||error||collecting ads||Error||4||1
+2015-12-01 15:18:39.168317||measurement||price||2015-12-01 15:18:32.644617@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:18:41.891632||measurement||price||2015-12-01 15:18:23.942256@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:18:43.141775||error||collecting ads||Error||2||0
+2015-12-01 15:18:43.170500||measurement||price||2015-12-01 15:18:36.384933@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:18:45.870147||error||collecting ads||Error||5||0
+2015-12-01 15:18:49.009798||measurement||loadtime||0:00:26.848492||0||0
+2015-12-01 15:18:49.377772||measurement||price||2015-12-01 15:18:43.269191@|Sony@| $348.90   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||4||1
+2015-12-01 15:18:52.066129||measurement||price||2015-12-01 15:18:32.644617@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:18:55.578080||measurement||price||2015-12-01 15:18:49.939252@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:18:56.207370||measurement||price||2015-12-01 15:18:36.384933@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:18:58.744895||measurement||price||2015-12-01 15:18:53.171072@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:18:59.290862||measurement||loadtime||0:00:28.965029||3||1
+2015-12-01 15:19:01.426383||measurement||price||2015-12-01 15:18:55.846534@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:19:02.290764||measurement||price||2015-12-01 15:18:43.269191@|Electronic Arts@| $53.83   @|Star Wars: Battlefront - Standard Edition - Xbox One||4||1
+2015-12-01 15:19:03.407410||measurement||loadtime||0:00:29.361012||1||1
+2015-12-01 15:19:07.924123||measurement||price||2015-12-01 15:18:49.939252@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:19:09.485809||measurement||loadtime||0:00:29.280696||4||1
+2015-12-01 15:19:11.081253||measurement||price||2015-12-01 15:18:53.171072@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:19:13.338583||measurement||price||2015-12-01 15:19:06.734154@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:19:13.763577||measurement||price||2015-12-01 15:18:55.846534@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:19:15.035217||measurement||loadtime||0:00:26.888213||2||0
+2015-12-01 15:19:17.550736||measurement||price||2015-12-01 15:19:10.799074@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:19:18.191224||measurement||loadtime||0:00:27.316079||5||0
+2015-12-01 15:19:20.880301||measurement||loadtime||0:00:26.866427||0||0
+2015-12-01 15:19:23.302171||measurement||price||2015-12-01 15:19:17.255987@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 15:19:26.223048||measurement||price||2015-12-01 15:19:06.734154@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:19:27.574410||measurement||price||2015-12-01 15:19:21.967492@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:19:30.553450||measurement||price||2015-12-01 15:19:10.799074@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:19:30.583494||measurement||price||2015-12-01 15:19:24.906563@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:19:33.314278||measurement||price||2015-12-01 15:19:27.685471@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:19:33.422062||measurement||loadtime||0:00:29.125959||3||1
+2015-12-01 15:19:36.179493||measurement||price||2015-12-01 15:19:17.255987@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 15:19:37.919176||measurement||loadtime||0:00:29.506565||1||1
+2015-12-01 15:19:39.907854||measurement||price||2015-12-01 15:19:21.967492@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:19:42.907217||measurement||price||2015-12-01 15:19:24.906563@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:19:43.366568||measurement||loadtime||0:00:28.875488||4||1
+2015-12-01 15:19:45.650409||measurement||price||2015-12-01 15:19:27.685471@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:19:47.023175||measurement||loadtime||0:00:26.982730||2||0
+2015-12-01 15:19:47.564912||measurement||price||2015-12-01 15:19:40.933267@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:19:50.023511||measurement||loadtime||0:00:26.827101||5||0
+2015-12-01 15:19:52.771186||measurement||loadtime||0:00:26.885695||0||0
+2015-12-01 15:19:57.663600||measurement||price||2015-12-01 15:19:51.443921@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||4||1
+2015-12-01 15:20:00.644873||measurement||price||2015-12-01 15:19:40.933267@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:20:01.860133||error||collecting ads||Error||1||1
+2015-12-01 15:20:02.343269||measurement||price||2015-12-01 15:19:56.718619@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:20:05.088255||measurement||price||2015-12-01 15:19:59.446256@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:20:07.867581||measurement||loadtime||0:00:29.440364||3||1
+2015-12-01 15:20:09.295863||error||collecting ads||Error||2||0
+2015-12-01 15:20:10.601432||measurement||price||2015-12-01 15:19:51.443921@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||4||1
+2015-12-01 15:20:14.664431||measurement||price||2015-12-01 15:19:56.718619@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:20:16.094894||measurement||price||2015-12-01 15:20:09.301299@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:20:17.432182||measurement||price||2015-12-01 15:19:59.446256@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:20:17.818108||measurement||loadtime||0:00:29.446284||4||1
+2015-12-01 15:20:21.643437||measurement||price||2015-12-01 15:20:16.073330@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||2||0
+2015-12-01 15:20:21.783190||measurement||loadtime||0:00:26.755973||5||0
+2015-12-01 15:20:21.783314||event||progress-marker||measurement-end||5||0
+2015-12-01 15:20:22.215259||measurement||price||2015-12-01 15:20:15.756059@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||3||1
+2015-12-01 15:20:24.548827||measurement||loadtime||0:00:26.773635||0||0
+2015-12-01 15:20:29.068735||measurement||price||2015-12-01 15:20:09.301299@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:20:31.821800||measurement||price||2015-12-01 15:20:25.689984@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 15:20:35.182959||measurement||price||2015-12-01 15:20:15.756059@|Warner Bros@|$49.95@|Jurassic World Team Pack - LEGO Dimensions||3||1
+2015-12-01 15:20:36.271129||measurement||loadtime||0:00:29.405731||1||1
+2015-12-01 15:20:36.992271||measurement||price||2015-12-01 15:20:31.351357@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:20:42.361081||measurement||loadtime||0:00:29.488281||3||1
+2015-12-01 15:20:44.020563||error||collecting ads||Error||2||0
+2015-12-01 15:20:44.020687||event||progress-marker||measurement-end||2||0
+2015-12-01 15:20:44.814032||measurement||price||2015-12-01 15:20:25.689984@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 15:20:49.327839||measurement||price||2015-12-01 15:20:31.351357@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:20:52.010075||measurement||loadtime||0:00:29.186736||4||1
+2015-12-01 15:20:56.443183||measurement||loadtime||0:00:26.890411||0||0
+2015-12-01 15:20:56.443325||event||progress-marker||measurement-end||0||0
+2015-12-01 15:20:56.648416||measurement||price||2015-12-01 15:20:50.320441@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:21:00.607260||error||collecting ads||Error||1||1
+2015-12-01 15:21:09.892463||measurement||price||2015-12-01 15:20:50.320441@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:21:15.752757||error||collecting ads||Error||4||1
+2015-12-01 15:21:17.121813||measurement||loadtime||0:00:29.755496||3||1
+2015-12-01 15:21:17.121936||event||progress-marker||measurement-end||3||1
+2015-12-01 15:21:24.477138||error||collecting ads||Error||1||1
+2015-12-01 15:21:38.492228||measurement||price||2015-12-01 15:21:31.717031@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:21:39.710602||error||collecting ads||Error||4||1
+2015-12-01 15:21:51.359503||measurement||price||2015-12-01 15:21:31.717031@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:21:53.919205||measurement||price||2015-12-01 15:21:47.921683@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 15:21:58.558003||measurement||loadtime||0:00:29.075640||1||1
+2015-12-01 15:21:58.558144||event||progress-marker||measurement-end||1||1
+2015-12-01 15:22:06.865492||measurement||price||2015-12-01 15:21:47.921683@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 15:22:14.079712||measurement||loadtime||0:00:29.363876||4||1
+2015-12-01 15:22:28.127546||measurement||price||2015-12-01 15:22:21.871627@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 15:22:40.990324||measurement||price||2015-12-01 15:22:21.871627@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 15:22:48.197052||measurement||loadtime||0:00:29.112090||4||1
+2015-12-01 15:22:48.197201||event||progress-marker||measurement-end||4||1
+2015-12-01 15:22:48.666982||meta||block_id end||5
+2015-12-01 15:22:48.667385||meta||block_id start||6
+2015-12-01 15:22:48.667419||meta||assignment||5@|0@|4@|3@|2@|1
+2015-12-01 15:22:50.254980||event||progress-marker||training-start||4||0
+2015-12-01 15:22:50.255116||event||progress-marker||training-end||4||0
+2015-12-01 15:22:50.268277||event||progress-marker||training-start||5||0
+2015-12-01 15:22:50.268385||event||progress-marker||training-end||5||0
+2015-12-01 15:22:50.278272||event||progress-marker||training-start||0||0
+2015-12-01 15:22:50.278364||event||progress-marker||training-end||0||0
+2015-12-01 15:22:55.278257||event||progress-marker||measurement-start||4||0
+2015-12-01 15:22:55.285396||event||progress-marker||measurement-start||5||0
+2015-12-01 15:22:55.302701||event||progress-marker||measurement-start||0||0
+2015-12-01 15:23:08.671122||measurement||price||2015-12-01 15:23:02.552951@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:23:08.910921||measurement||price||2015-12-01 15:23:03.063325@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:23:18.727736||error||collecting ads||Error||5||0
+2015-12-01 15:23:20.993396||measurement||price||2015-12-01 15:23:02.552951@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:23:21.248782||measurement||price||2015-12-01 15:23:03.063325@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:23:28.107061||measurement||loadtime||0:00:27.799876||0||0
+2015-12-01 15:23:28.368289||measurement||loadtime||0:00:28.084818||4||0
+2015-12-01 15:23:40.799583||measurement||price||2015-12-01 15:23:34.771837@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:23:40.949421||measurement||price||2015-12-01 15:23:35.140543@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:23:43.942251||error||collecting ads||Error||5||0
+2015-12-01 15:23:53.126239||measurement||price||2015-12-01 15:23:34.771837@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:23:53.284621||measurement||price||2015-12-01 15:23:35.140543@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:23:56.330235||measurement||price||2015-12-01 15:23:50.664222@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:24:00.239176||measurement||loadtime||0:00:27.128037||0||0
+2015-12-01 15:24:00.408023||measurement||loadtime||0:00:27.036871||4||0
+2015-12-01 15:24:03.257775||event||progress-marker||training-start||3||1
+2015-12-01 15:24:03.257927||event||progress-marker||training-end||3||1
+2015-12-01 15:24:08.283530||event||progress-marker||measurement-start||3||1
+2015-12-01 15:24:08.673023||measurement||price||2015-12-01 15:23:50.664222@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:24:12.492674||measurement||price||2015-12-01 15:24:06.890213@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:24:12.697608||measurement||price||2015-12-01 15:24:07.131425@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:24:15.784539||measurement||loadtime||0:00:26.838548||5||0
+2015-12-01 15:24:24.794106||measurement||price||2015-12-01 15:24:06.890213@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:24:25.054473||measurement||price||2015-12-01 15:24:07.131425@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:24:28.051016||measurement||price||2015-12-01 15:24:22.479012@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:24:31.876113||measurement||loadtime||0:00:26.631720||0||0
+2015-12-01 15:24:32.166235||measurement||loadtime||0:00:26.754344||4||0
+2015-12-01 15:24:32.711756||error||collecting ads||Error||3||1
+2015-12-01 15:24:33.040293||event||progress-marker||training-start||2||1
+2015-12-01 15:24:33.040428||event||progress-marker||training-end||2||1
+2015-12-01 15:24:38.057717||event||progress-marker||measurement-start||2||1
+2015-12-01 15:24:40.394616||measurement||price||2015-12-01 15:24:22.479012@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:24:44.462729||measurement||price||2015-12-01 15:24:38.723214@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:24:47.037195||measurement||price||2015-12-01 15:24:40.157215@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:24:47.525738||measurement||loadtime||0:00:26.735984||5||0
+2015-12-01 15:24:54.485712||error||collecting ads||Error||4||0
+2015-12-01 15:24:56.757061||measurement||price||2015-12-01 15:24:38.723214@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:24:59.867084||measurement||price||2015-12-01 15:24:54.256239@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:24:59.991232||measurement||price||2015-12-01 15:24:40.157215@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:25:02.456072||error||collecting ads||Error||2||1
+2015-12-01 15:25:03.845191||measurement||loadtime||0:00:26.968546||0||0
+2015-12-01 15:25:06.850176||measurement||price||2015-12-01 15:25:01.281239@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:25:07.191170||measurement||loadtime||0:00:29.476022||3||1
+2015-12-01 15:25:12.219052||measurement||price||2015-12-01 15:24:54.256239@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:25:16.232018||measurement||price||2015-12-01 15:25:10.654359@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:25:16.681858||measurement||price||2015-12-01 15:25:09.895300@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:25:19.179204||measurement||price||2015-12-01 15:25:01.281239@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:25:19.340226||measurement||loadtime||0:00:26.813164||5||0
+2015-12-01 15:25:20.992917||measurement||price||2015-12-01 15:25:14.484059@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:25:25.268485||event||progress-marker||training-start||1||1
+2015-12-01 15:25:25.268603||event||progress-marker||training-end||1||1
+2015-12-01 15:25:26.295178||measurement||loadtime||0:00:26.804249||4||0
+2015-12-01 15:25:28.558739||measurement||price||2015-12-01 15:25:10.654359@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:25:29.577279||measurement||price||2015-12-01 15:25:09.895300@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:25:30.290282||event||progress-marker||measurement-start||1||1
+2015-12-01 15:25:31.709951||measurement||price||2015-12-01 15:25:26.226178@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:25:33.899073||measurement||price||2015-12-01 15:25:14.484059@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:25:35.667539||measurement||loadtime||0:00:26.820392||0||0
+2015-12-01 15:25:36.795130||measurement||loadtime||0:00:29.335860||2||1
+2015-12-01 15:25:38.512003||measurement||price||2015-12-01 15:25:32.930284@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:25:41.098826||measurement||loadtime||0:00:28.903683||3||1
+2015-12-01 15:25:44.048952||measurement||price||2015-12-01 15:25:26.226178@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:25:44.863414||measurement||price||2015-12-01 15:25:38.491495@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:25:47.937582||measurement||price||2015-12-01 15:25:42.314104@|@|$249.00@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||0||0
+2015-12-01 15:25:50.823966||measurement||price||2015-12-01 15:25:32.930284@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:25:51.151925||measurement||loadtime||0:00:26.806441||5||0
+2015-12-01 15:25:54.910919||measurement||price||2015-12-01 15:25:48.360890@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:25:57.720001||measurement||price||2015-12-01 15:25:38.491495@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:25:57.935144||measurement||loadtime||0:00:26.634775||4||0
+2015-12-01 15:26:00.280949||measurement||price||2015-12-01 15:25:42.314104@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||0||0
+2015-12-01 15:26:00.807464||error||collecting ads||Error||2||1
+2015-12-01 15:26:03.554065||measurement||price||2015-12-01 15:25:57.845070@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:26:04.941445||measurement||loadtime||0:00:29.649185||1||1
+2015-12-01 15:26:07.395912||measurement||loadtime||0:00:26.723164||0||0
+2015-12-01 15:26:07.792585||measurement||price||2015-12-01 15:25:48.360890@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:26:10.238330||measurement||price||2015-12-01 15:26:04.631150@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:26:14.624253||measurement||price||2015-12-01 15:26:08.093150@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:26:14.994911||measurement||loadtime||0:00:28.890852||3||1
+2015-12-01 15:26:15.865035||measurement||price||2015-12-01 15:25:57.845070@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:26:22.586953||measurement||price||2015-12-01 15:26:04.631150@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:26:22.975190||measurement||loadtime||0:00:26.818900||5||0
+2015-12-01 15:26:27.517617||measurement||price||2015-12-01 15:26:08.093150@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:26:28.940929||error||collecting ads||Error||1||1
+2015-12-01 15:26:29.224092||measurement||price||2015-12-01 15:26:22.259181@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:26:29.689517||error||collecting ads||Error||0||0
+2015-12-01 15:26:29.711165||measurement||loadtime||0:00:26.770806||4||0
+2015-12-01 15:26:34.711159||measurement||loadtime||0:00:28.898491||2||1
+2015-12-01 15:26:42.305623||measurement||price||2015-12-01 15:26:22.259181@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:26:48.859814||measurement||price||2015-12-01 15:26:43.464281@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:26:49.524479||measurement||loadtime||0:00:29.524307||3||1
+2015-12-01 15:26:57.874270||measurement||price||2015-12-01 15:26:52.522959@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:27:01.162694||measurement||price||2015-12-01 15:26:43.464281@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:27:08.245221||measurement||loadtime||0:00:40.264819||5||0
+2015-12-01 15:27:09.785008||error||collecting ads||Error||4||0
+2015-12-01 15:27:10.224901||measurement||price||2015-12-01 15:26:52.522959@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:27:17.319189||measurement||loadtime||0:00:42.628036||0||0
+2015-12-01 15:27:21.073406||measurement||price||2015-12-01 15:27:07.478801@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:27:27.055903||measurement||price||2015-12-01 15:27:16.473995@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:27:31.777098||measurement||price||2015-12-01 15:27:26.263098@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:27:33.937660||measurement||price||2015-12-01 15:27:07.478801@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:27:36.749100||error||collecting ads||Error||5||0
+2015-12-01 15:27:37.810571||error||collecting ads||Error||4||0
+2015-12-01 15:27:40.065877||measurement||price||2015-12-01 15:27:16.473995@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:27:41.171390||measurement||loadtime||0:01:01.455023||2||1
+2015-12-01 15:27:41.286492||error||collecting ads||Error||1||1
+2015-12-01 15:27:44.098639||measurement||price||2015-12-01 15:27:26.263098@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:27:47.269482||measurement||loadtime||0:00:52.740228||3||1
+2015-12-01 15:27:49.038004||measurement||price||2015-12-01 15:27:43.463968@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:27:50.368491||measurement||price||2015-12-01 15:27:44.714682@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:27:51.212787||measurement||loadtime||0:00:28.891342||0||0
+2015-12-01 15:27:55.534869||measurement||price||2015-12-01 15:27:49.431097@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||1||1
+2015-12-01 15:28:01.344250||measurement||price||2015-12-01 15:27:43.463968@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:28:02.719628||measurement||price||2015-12-01 15:27:44.714682@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:28:04.418759||measurement||price||2015-12-01 15:27:59.025369@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:28:06.605811||error||collecting ads||Error||2||1
+2015-12-01 15:28:08.379428||measurement||price||2015-12-01 15:27:49.431097@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||1||1
+2015-12-01 15:28:08.444125||measurement||loadtime||0:00:26.689780||5||0
+2015-12-01 15:28:09.828049||measurement||loadtime||0:00:27.012283||4||0
+2015-12-01 15:28:11.187498||error||collecting ads||Error||3||1
+2015-12-01 15:28:15.591766||measurement||loadtime||0:00:29.300625||1||1
+2015-12-01 15:28:16.778943||measurement||price||2015-12-01 15:27:59.025369@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:28:20.543600||measurement||price||2015-12-01 15:28:14.000127@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:28:22.062635||measurement||price||2015-12-01 15:28:16.461576@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:28:23.906627||measurement||loadtime||0:00:27.691470||0||0
+2015-12-01 15:28:25.136256||measurement||price||2015-12-01 15:28:18.592334@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:28:30.923804||error||collecting ads||Error||5||0
+2015-12-01 15:28:33.424334||measurement||price||2015-12-01 15:28:14.000127@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:28:34.376002||measurement||price||2015-12-01 15:28:16.461576@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:28:37.566494||measurement||price||2015-12-01 15:28:31.984860@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:28:38.036662||measurement||price||2015-12-01 15:28:18.592334@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:28:39.771139||error||collecting ads||Error||1||1
+2015-12-01 15:28:40.632309||measurement||loadtime||0:00:29.021286||2||1
+2015-12-01 15:28:41.482384||measurement||loadtime||0:00:26.649122||4||0
+2015-12-01 15:28:45.255190||measurement||loadtime||0:00:29.064048||3||1
+2015-12-01 15:28:49.863698||measurement||price||2015-12-01 15:28:31.984860@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:28:53.153574||error||collecting ads||Error||5||0
+2015-12-01 15:28:54.623330||measurement||price||2015-12-01 15:28:48.334977@|At-A-Glance@|$23.97@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||1
+2015-12-01 15:28:56.954080||measurement||loadtime||0:00:28.046054||0||0
+2015-12-01 15:28:59.525485||measurement||price||2015-12-01 15:28:53.306679@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:29:03.783329||error||collecting ads||Error||1||1
+2015-12-01 15:29:03.874782||error||collecting ads||Error||4||0
+2015-12-01 15:29:05.516820||measurement||price||2015-12-01 15:28:59.896051@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:29:07.471601||measurement||price||2015-12-01 15:28:48.334977@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||1
+2015-12-01 15:29:09.274859||measurement||price||2015-12-01 15:29:03.683236@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:29:12.532943||measurement||price||2015-12-01 15:28:53.306679@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:29:14.707970||measurement||loadtime||0:00:29.070422||2||1
+2015-12-01 15:29:16.237459||measurement||price||2015-12-01 15:29:10.594038@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:29:17.880626||measurement||price||2015-12-01 15:28:59.896051@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:29:19.777649||measurement||loadtime||0:00:29.518499||3||1
+2015-12-01 15:29:21.601309||measurement||price||2015-12-01 15:29:03.683236@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:29:24.992208||measurement||loadtime||0:00:26.833415||5||0
+2015-12-01 15:29:27.474898||error||collecting ads||Error||1||1
+2015-12-01 15:29:28.580912||measurement||price||2015-12-01 15:29:10.594038@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:29:28.710202||measurement||loadtime||0:00:26.751052||0||0
+2015-12-01 15:29:30.227122||measurement||price||2015-12-01 15:29:22.210230@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:29:35.692889||measurement||loadtime||0:00:26.817321||4||0
+2015-12-01 15:29:37.249062||measurement||price||2015-12-01 15:29:31.657827@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:29:41.028265||measurement||price||2015-12-01 15:29:35.350546@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 15:29:43.208072||measurement||price||2015-12-01 15:29:22.210230@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:29:43.715674||error||collecting ads||Error||3||1
+2015-12-01 15:29:49.603619||measurement||price||2015-12-01 15:29:31.657827@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:29:50.439203||measurement||loadtime||0:00:30.729587||2||1
+2015-12-01 15:29:51.511113||error||collecting ads||Error||1||1
+2015-12-01 15:29:53.373677||measurement||price||2015-12-01 15:29:35.350546@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 15:29:56.723804||measurement||loadtime||0:00:26.726389||5||0
+2015-12-01 15:29:57.689489||measurement||price||2015-12-01 15:29:51.091806@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:29:57.971732||error||collecting ads||Error||4||0
+2015-12-01 15:30:00.455850||measurement||loadtime||0:00:26.740444||0||0
+2015-12-01 15:30:04.290570||measurement||price||2015-12-01 15:29:57.709699@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:30:05.479944||measurement||price||2015-12-01 15:29:59.340418@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:30:09.392813||measurement||price||2015-12-01 15:30:03.780091@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||5||0
+2015-12-01 15:30:10.208265||measurement||price||2015-12-01 15:30:04.606953@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:30:10.639593||measurement||price||2015-12-01 15:29:51.091806@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:30:13.058641||measurement||price||2015-12-01 15:30:07.617255@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-01 15:30:17.282104||measurement||price||2015-12-01 15:29:57.709699@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:30:17.835868||measurement||loadtime||0:00:29.116710||3||1
+2015-12-01 15:30:18.385612||measurement||price||2015-12-01 15:29:59.340418@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:30:21.735985||measurement||price||2015-12-01 15:30:03.780091@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||5||0
+2015-12-01 15:30:22.556004||measurement||price||2015-12-01 15:30:04.606953@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:30:24.503173||measurement||loadtime||0:00:29.058765||2||1
+2015-12-01 15:30:25.416522||measurement||price||2015-12-01 15:30:07.617255@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||0||0
+2015-12-01 15:30:25.631423||measurement||loadtime||0:00:29.115101||1||1
+2015-12-01 15:30:28.854138||measurement||loadtime||0:00:27.125106||5||0
+2015-12-01 15:30:29.678004||measurement||loadtime||0:00:26.701052||4||0
+2015-12-01 15:30:32.527152||measurement||loadtime||0:00:27.066080||0||0
+2015-12-01 15:30:41.957822||measurement||price||2015-12-01 15:30:36.423453@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:30:42.132775||error||collecting ads||Error||3||1
+2015-12-01 15:30:48.588943||error||collecting ads||Error||2||1
+2015-12-01 15:30:49.493149||error||collecting ads||Error||1||1
+2015-12-01 15:30:51.136147||error||collecting ads||Error||5||0
+2015-12-01 15:30:54.285056||measurement||price||2015-12-01 15:30:36.423453@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:30:54.784640||error||collecting ads||Error||0||0
+2015-12-01 15:30:56.204132||measurement||price||2015-12-01 15:30:49.503680@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:31:01.397027||measurement||loadtime||0:00:26.713874||4||0
+2015-12-01 15:31:03.371793||measurement||price||2015-12-01 15:30:57.135710@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:31:03.493843||measurement||price||2015-12-01 15:30:57.885161@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:31:07.369137||measurement||price||2015-12-01 15:31:01.821315@|Lexmark@|$594.99@|Lexmark MS810n Mono Laser Printer||0||0
+2015-12-01 15:31:09.159762||measurement||price||2015-12-01 15:30:49.503680@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:31:13.097360||error||collecting ads||Error||2||1
+2015-12-01 15:31:13.652240||measurement||price||2015-12-01 15:31:08.081581@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:31:15.813488||measurement||price||2015-12-01 15:30:57.885161@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:31:16.376883||measurement||loadtime||0:00:29.238892||3||1
+2015-12-01 15:31:16.448807||measurement||price||2015-12-01 15:30:57.135710@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:31:19.704750||measurement||price||2015-12-01 15:31:01.821315@|Lexmark@|$460.99@|Lexmark MS610dn Mono Laser Printer||0||0
+2015-12-01 15:31:22.911200||measurement||loadtime||0:00:26.769722||5||0
+2015-12-01 15:31:23.643162||measurement||loadtime||0:00:29.144782||1||1
+2015-12-01 15:31:25.987271||measurement||price||2015-12-01 15:31:08.081581@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:31:26.821100||measurement||loadtime||0:00:27.031215||0||0
+2015-12-01 15:31:30.404660||measurement||price||2015-12-01 15:31:23.824693@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:31:33.091176||measurement||loadtime||0:00:26.691932||4||0
+2015-12-01 15:31:35.178673||measurement||price||2015-12-01 15:31:29.596518@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:31:37.147332||error||collecting ads||Error||2||1
+2015-12-01 15:31:37.917120||measurement||price||2015-12-01 15:31:31.659838@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 15:31:39.065600||measurement||price||2015-12-01 15:31:33.503958@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:31:43.300167||measurement||price||2015-12-01 15:31:23.824693@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:31:47.485035||measurement||price||2015-12-01 15:31:29.596518@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:31:50.505124||measurement||loadtime||0:00:29.123030||3||1
+2015-12-01 15:31:50.937273||measurement||price||2015-12-01 15:31:31.659838@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 15:31:51.401896||measurement||price||2015-12-01 15:31:33.503958@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:31:54.598441||measurement||loadtime||0:00:26.682011||5||0
+2015-12-01 15:31:56.599789||error||collecting ads||Error||4||0
+2015-12-01 15:31:58.151165||measurement||loadtime||0:00:29.504014||1||1
+2015-12-01 15:31:58.519156||measurement||loadtime||0:00:26.692785||0||0
+2015-12-01 15:32:01.268819||error||collecting ads||Error||2||1
+2015-12-01 15:32:04.353579||measurement||price||2015-12-01 15:31:57.805039@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:32:06.945120||measurement||price||2015-12-01 15:32:01.294371@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:32:10.925551||measurement||price||2015-12-01 15:32:05.348967@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 15:32:17.371932||measurement||price||2015-12-01 15:31:57.805039@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:32:18.861814||error||collecting ads||Error||4||0
+2015-12-01 15:32:19.301565||measurement||price||2015-12-01 15:32:01.294371@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:32:22.030636||error||collecting ads||Error||1||1
+2015-12-01 15:32:23.266999||measurement||price||2015-12-01 15:32:05.348967@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 15:32:24.567507||measurement||loadtime||0:00:29.057178||3||1
+2015-12-01 15:32:25.203914||error||collecting ads||Error||2||1
+2015-12-01 15:32:26.407189||measurement||loadtime||0:00:26.803526||5||0
+2015-12-01 15:32:30.377629||measurement||loadtime||0:00:26.854501||0||0
+2015-12-01 15:32:31.138674||measurement||price||2015-12-01 15:32:25.525272@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:32:35.939921||measurement||price||2015-12-01 15:32:29.680420@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:32:42.993090||measurement||price||2015-12-01 15:32:37.373178@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-01 15:32:43.472090||measurement||price||2015-12-01 15:32:25.525272@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:32:48.785860||error||collecting ads||Error||5||0
+2015-12-01 15:32:48.785949||event||progress-marker||measurement-end||5||0
+2015-12-01 15:32:48.822561||measurement||price||2015-12-01 15:32:29.680420@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:32:48.877991||error||collecting ads||Error||3||1
+2015-12-01 15:32:49.158695||error||collecting ads||Error||2||1
+2015-12-01 15:32:50.581259||measurement||loadtime||0:00:26.716726||4||0
+2015-12-01 15:32:50.581400||event||progress-marker||measurement-end||4||0
+2015-12-01 15:32:55.329611||measurement||price||2015-12-01 15:32:37.373178@|Warner Bros@|$49.95@|Jurassic World Team Pack - LEGO Dimensions||0||0
+2015-12-01 15:32:56.035152||measurement||loadtime||0:00:28.999309||1||1
+2015-12-01 15:33:02.440422||measurement||loadtime||0:00:27.057594||0||0
+2015-12-01 15:33:02.768337||measurement||price||2015-12-01 15:32:56.160795@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:33:03.296775||measurement||price||2015-12-01 15:32:56.455878@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:33:09.988998||measurement||price||2015-12-01 15:33:03.708753@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:33:14.711732||measurement||price||2015-12-01 15:33:09.184918@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 15:33:15.612224||measurement||price||2015-12-01 15:32:56.160795@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:33:16.303148||measurement||price||2015-12-01 15:32:56.455878@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:33:22.789691||measurement||loadtime||0:00:28.906435||3||1
+2015-12-01 15:33:22.834493||measurement||price||2015-12-01 15:33:03.708753@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:33:23.507606||measurement||loadtime||0:00:29.343660||2||1
+2015-12-01 15:33:27.059784||measurement||price||2015-12-01 15:33:09.184918@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 15:33:30.032474||measurement||loadtime||0:00:28.992145||1||1
+2015-12-01 15:33:34.163911||measurement||loadtime||0:00:26.718274||0||0
+2015-12-01 15:33:34.164048||event||progress-marker||measurement-end||0||0
+2015-12-01 15:33:36.853983||measurement||price||2015-12-01 15:33:30.123898@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:33:47.374593||error||collecting ads||Error||2||1
+2015-12-01 15:33:49.652897||measurement||price||2015-12-01 15:33:30.123898@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:33:54.056126||error||collecting ads||Error||1||1
+2015-12-01 15:33:56.852650||measurement||loadtime||0:00:29.057758||3||1
+2015-12-01 15:34:01.252854||measurement||price||2015-12-01 15:33:54.883741@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:34:14.259054||measurement||price||2015-12-01 15:33:54.883741@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:34:17.795289||error||collecting ads||Error||1||1
+2015-12-01 15:34:20.734160||error||collecting ads||Error||3||1
+2015-12-01 15:34:21.454827||measurement||loadtime||0:00:29.075006||2||1
+2015-12-01 15:34:32.841673||measurement||price||2015-12-01 15:34:26.849686@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 15:34:35.398974||measurement||price||2015-12-01 15:34:28.796818@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:34:44.824285||error||collecting ads||Error||3||1
+2015-12-01 15:34:44.824388||event||progress-marker||measurement-end||3||1
+2015-12-01 15:34:45.895137||measurement||price||2015-12-01 15:34:26.849686@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 15:34:48.372150||measurement||price||2015-12-01 15:34:28.796818@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:34:53.132053||measurement||loadtime||0:00:30.331519||1||1
+2015-12-01 15:34:55.571170||measurement||loadtime||0:00:29.111038||2||1
+2015-12-01 15:34:55.571314||event||progress-marker||measurement-end||2||1
+2015-12-01 15:35:06.906875||measurement||price||2015-12-01 15:35:00.736421@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:35:19.898571||measurement||price||2015-12-01 15:35:00.736421@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:35:27.138744||measurement||loadtime||0:00:29.001451||1||1
+2015-12-01 15:35:41.049787||measurement||price||2015-12-01 15:35:34.916924@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:35:53.884424||measurement||price||2015-12-01 15:35:34.916924@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:36:01.082979||measurement||loadtime||0:00:28.938979||1||1
+2015-12-01 15:36:01.083156||event||progress-marker||measurement-end||1||1
+2015-12-01 15:36:01.478053||meta||block_id end||6
+2015-12-01 15:36:01.478369||meta||block_id start||7
+2015-12-01 15:36:01.478401||meta||assignment||3@|4@|1@|0@|2@|5
+2015-12-01 15:36:03.046091||event||progress-marker||training-start||3||0
+2015-12-01 15:36:03.046184||event||progress-marker||training-end||3||0
+2015-12-01 15:36:03.063277||event||progress-marker||training-start||4||0
+2015-12-01 15:36:03.063837||event||progress-marker||training-end||4||0
+2015-12-01 15:36:08.069594||event||progress-marker||measurement-start||3||0
+2015-12-01 15:36:08.085533||event||progress-marker||measurement-start||4||0
+2015-12-01 15:36:21.593883||measurement||price||2015-12-01 15:36:15.387250@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:36:31.037201||error||collecting ads||Error||3||0
+2015-12-01 15:36:33.925599||measurement||price||2015-12-01 15:36:15.387250@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:36:41.032021||measurement||loadtime||0:00:27.943879||4||0
+2015-12-01 15:36:43.594103||measurement||price||2015-12-01 15:36:38.177525@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 15:36:55.940285||measurement||price||2015-12-01 15:36:38.177525@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 15:37:03.051180||measurement||loadtime||0:00:27.008741||3||0
+2015-12-01 15:37:03.424288||error||collecting ads||Error||4||0
+2015-12-01 15:37:15.753902||measurement||price||2015-12-01 15:37:10.171956@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:37:16.258515||event||progress-marker||training-start||0||1
+2015-12-01 15:37:16.258674||event||progress-marker||training-end||0||1
+2015-12-01 15:37:21.287014||event||progress-marker||measurement-start||0||1
+2015-12-01 15:37:25.678287||error||collecting ads||Error||3||0
+2015-12-01 15:37:28.099655||measurement||price||2015-12-01 15:37:10.171956@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:37:34.986825||event||progress-marker||training-start||2||1
+2015-12-01 15:37:34.986933||event||progress-marker||training-end||2||1
+2015-12-01 15:37:35.212874||measurement||loadtime||0:00:26.783385||4||0
+2015-12-01 15:37:35.912332||measurement||price||2015-12-01 15:37:29.043372@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:37:37.955145||event||progress-marker||training-start||5||1
+2015-12-01 15:37:37.955303||event||progress-marker||training-end||5||1
+2015-12-01 15:37:38.993249||measurement||price||2015-12-01 15:37:33.576844@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 15:37:40.009604||event||progress-marker||measurement-start||2||1
+2015-12-01 15:37:42.986636||event||progress-marker||measurement-start||5||1
+2015-12-01 15:37:47.485190||measurement||price||2015-12-01 15:37:41.884992@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:37:48.788803||measurement||price||2015-12-01 15:37:29.043372@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:37:51.390024||measurement||price||2015-12-01 15:37:33.576844@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 15:37:56.016004||measurement||loadtime||0:00:29.723746||0||1
+2015-12-01 15:37:58.495229||measurement||loadtime||0:00:27.811709||3||0
+2015-12-01 15:37:59.814694||measurement||price||2015-12-01 15:37:41.884992@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:38:04.395660||error||collecting ads||Error||2||1
+2015-12-01 15:38:06.925347||measurement||loadtime||0:00:26.707244||4||0
+2015-12-01 15:38:07.438536||error||collecting ads||Error||5||1
+2015-12-01 15:38:11.132923||measurement||price||2015-12-01 15:38:05.700358@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:38:19.055426||measurement||price||2015-12-01 15:38:13.042067@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||1
+2015-12-01 15:38:19.310695||measurement||price||2015-12-01 15:38:13.756334@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:38:20.286684||error||collecting ads||Error||0||1
+2015-12-01 15:38:23.480354||measurement||price||2015-12-01 15:38:05.700358@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:38:30.585286||measurement||loadtime||0:00:27.086114||3||0
+2015-12-01 15:38:31.643422||measurement||price||2015-12-01 15:38:13.756334@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:38:31.739600||error||collecting ads||Error||5||1
+2015-12-01 15:38:32.080281||measurement||price||2015-12-01 15:38:13.042067@|Warner Bros@|$49.95@|Jurassic World Team Pack - LEGO Dimensions||2||1
+2015-12-01 15:38:34.570139||measurement||price||2015-12-01 15:38:28.162059@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:38:38.755192||measurement||loadtime||0:00:26.824580||4||0
+2015-12-01 15:38:39.292839||measurement||loadtime||0:00:29.896800||2||1
+2015-12-01 15:38:43.308242||measurement||price||2015-12-01 15:38:37.903577@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:38:45.750000||measurement||price||2015-12-01 15:38:39.036526@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:38:47.482626||measurement||price||2015-12-01 15:38:28.162059@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:38:51.070528||measurement||price||2015-12-01 15:38:45.477026@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:38:54.722658||measurement||loadtime||0:00:29.431473||0||1
+2015-12-01 15:38:55.639986||measurement||price||2015-12-01 15:38:37.903577@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:38:58.632363||measurement||price||2015-12-01 15:38:39.036526@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:39:02.752389||measurement||loadtime||0:00:27.163602||3||0
+2015-12-01 15:39:03.252452||error||collecting ads||Error||2||1
+2015-12-01 15:39:03.404020||measurement||price||2015-12-01 15:38:45.477026@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:39:05.850476||measurement||loadtime||0:00:29.106524||5||1
+2015-12-01 15:39:08.697964||measurement||price||2015-12-01 15:39:01.960236@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:39:10.511404||measurement||loadtime||0:00:26.750990||4||0
+2015-12-01 15:39:15.482510||measurement||price||2015-12-01 15:39:09.997820@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:39:17.359954||measurement||price||2015-12-01 15:39:10.847248@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:39:19.895333||measurement||price||2015-12-01 15:39:13.309648@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:39:21.565171||measurement||price||2015-12-01 15:39:01.960236@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:39:22.810397||measurement||price||2015-12-01 15:39:17.193668@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:39:27.828883||measurement||price||2015-12-01 15:39:09.997820@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:39:28.763203||measurement||loadtime||0:00:29.037905||0||1
+2015-12-01 15:39:30.227912||measurement||price||2015-12-01 15:39:10.847248@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:39:32.706982||measurement||price||2015-12-01 15:39:13.309648@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:39:34.935204||measurement||loadtime||0:00:27.177566||3||0
+2015-12-01 15:39:35.157273||measurement||price||2015-12-01 15:39:17.193668@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:39:37.459163||measurement||loadtime||0:00:29.201477||2||1
+2015-12-01 15:39:39.892121||measurement||loadtime||0:00:29.036952||5||1
+2015-12-01 15:39:42.267285||measurement||loadtime||0:00:26.750691||4||0
+2015-12-01 15:39:42.903322||measurement||price||2015-12-01 15:39:36.068937@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:39:51.350189||measurement||price||2015-12-01 15:39:45.203729@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:39:54.648688||measurement||price||2015-12-01 15:39:49.042860@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:39:55.894133||measurement||price||2015-12-01 15:39:36.068937@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:39:57.663864||error||collecting ads||Error||3||0
+2015-12-01 15:40:03.092514||measurement||loadtime||0:00:29.324068||0||1
+2015-12-01 15:40:04.117643||error||collecting ads||Error||5||1
+2015-12-01 15:40:04.227015||measurement||price||2015-12-01 15:39:45.203729@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:40:06.996802||measurement||price||2015-12-01 15:39:49.042860@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:40:10.774606||measurement||price||2015-12-01 15:40:05.222474@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||3||0
+2015-12-01 15:40:11.424554||measurement||loadtime||0:00:28.961418||2||1
+2015-12-01 15:40:14.107183||measurement||loadtime||0:00:26.836019||4||0
+2015-12-01 15:40:16.986563||measurement||price||2015-12-01 15:40:10.476208@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:40:18.230306||measurement||price||2015-12-01 15:40:11.363639@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:40:23.138626||measurement||price||2015-12-01 15:40:05.222474@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||3||0
+2015-12-01 15:40:25.682843||measurement||price||2015-12-01 15:40:18.721675@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:40:29.838123||measurement||price||2015-12-01 15:40:10.476208@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:40:30.243174||measurement||loadtime||0:00:27.574332||3||0
+2015-12-01 15:40:31.137736||measurement||price||2015-12-01 15:40:11.363639@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:40:36.442845||error||collecting ads||Error||4||0
+2015-12-01 15:40:37.021755||measurement||loadtime||0:00:28.923945||0||1
+2015-12-01 15:40:38.352384||measurement||loadtime||0:00:29.229555||5||1
+2015-12-01 15:40:38.720714||measurement||price||2015-12-01 15:40:18.721675@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:40:42.857556||measurement||price||2015-12-01 15:40:37.471459@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:40:45.939163||measurement||loadtime||0:00:29.510520||2||1
+2015-12-01 15:40:48.766656||measurement||price||2015-12-01 15:40:43.087855@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:40:50.920217||measurement||price||2015-12-01 15:40:44.537836@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:40:55.210002||measurement||price||2015-12-01 15:40:37.471459@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:41:00.141930||measurement||price||2015-12-01 15:40:53.847192@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:41:01.098867||measurement||price||2015-12-01 15:40:43.087855@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:41:02.318010||measurement||loadtime||0:00:27.069600||3||0
+2015-12-01 15:41:02.348955||error||collecting ads||Error||5||1
+2015-12-01 15:41:03.846377||measurement||price||2015-12-01 15:40:44.537836@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:41:08.217147||measurement||loadtime||0:00:26.769074||4||0
+2015-12-01 15:41:11.033008||measurement||loadtime||0:00:29.010717||0||1
+2015-12-01 15:41:13.270535||measurement||price||2015-12-01 15:40:53.847192@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:41:15.080630||measurement||price||2015-12-01 15:41:09.720636@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:41:16.555890||measurement||price||2015-12-01 15:41:10.005892@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:41:20.488895||measurement||loadtime||0:00:29.544549||2||1
+2015-12-01 15:41:24.839359||measurement||price||2015-12-01 15:41:18.198961@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:41:27.417704||measurement||price||2015-12-01 15:41:09.720636@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:41:29.474953||measurement||price||2015-12-01 15:41:10.005892@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:41:30.518778||error||collecting ads||Error||4||0
+2015-12-01 15:41:34.280627||measurement||price||2015-12-01 15:41:27.865811@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:41:34.550067||measurement||loadtime||0:00:27.226822||3||0
+2015-12-01 15:41:36.703336||measurement||loadtime||0:00:29.349193||5||1
+2015-12-01 15:41:37.797693||measurement||price||2015-12-01 15:41:18.198961@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:41:45.010265||measurement||loadtime||0:00:28.972806||0||1
+2015-12-01 15:41:47.282137||measurement||price||2015-12-01 15:41:27.865811@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:41:47.456579||measurement||price||2015-12-01 15:41:41.966887@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:41:50.929374||measurement||price||2015-12-01 15:41:44.008135@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 15:41:52.809748||error||collecting ads||Error||4||0
+2015-12-01 15:41:54.511568||measurement||loadtime||0:00:29.017453||2||1
+2015-12-01 15:41:59.052252||measurement||price||2015-12-01 15:41:52.524486@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:41:59.799723||measurement||price||2015-12-01 15:41:41.966887@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:42:03.833771||measurement||price||2015-12-01 15:41:44.008135@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 15:42:05.111478||measurement||price||2015-12-01 15:41:59.511198@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:42:06.915493||measurement||loadtime||0:00:27.360131||3||0
+2015-12-01 15:42:08.749107||measurement||price||2015-12-01 15:42:02.532197@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||1
+2015-12-01 15:42:11.038303||measurement||loadtime||0:00:29.329767||5||1
+2015-12-01 15:42:12.113814||measurement||price||2015-12-01 15:41:52.524486@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:42:17.434258||measurement||price||2015-12-01 15:41:59.511198@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:42:19.313213||measurement||loadtime||0:00:29.297726||0||1
+2015-12-01 15:42:19.640892||measurement||price||2015-12-01 15:42:14.247712@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 15:42:21.585297||measurement||price||2015-12-01 15:42:02.532197@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||2||1
+2015-12-01 15:42:24.543167||measurement||loadtime||0:00:26.728204||4||0
+2015-12-01 15:42:28.803574||measurement||loadtime||0:00:29.288417||2||1
+2015-12-01 15:42:31.979336||measurement||price||2015-12-01 15:42:14.247712@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 15:42:33.334415||measurement||price||2015-12-01 15:42:26.537247@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:42:35.210808||error||collecting ads||Error||5||1
+2015-12-01 15:42:36.773951||measurement||price||2015-12-01 15:42:31.171377@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:42:39.094388||measurement||loadtime||0:00:27.174424||3||0
+2015-12-01 15:42:42.606763||measurement||price||2015-12-01 15:42:36.040921@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:42:46.183615||measurement||price||2015-12-01 15:42:26.537247@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:42:49.140446||measurement||price||2015-12-01 15:42:31.171377@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:42:53.395194||measurement||loadtime||0:00:29.076726||0||1
+2015-12-01 15:42:55.413331||measurement||price||2015-12-01 15:42:36.040921@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:42:56.250901||measurement||loadtime||0:00:26.702524||4||0
+2015-12-01 15:42:59.202373||error||collecting ads||Error||5||1
+2015-12-01 15:43:01.776237||error||collecting ads||Error||3||0
+2015-12-01 15:43:02.611184||measurement||loadtime||0:00:28.802440||2||1
+2015-12-01 15:43:07.499744||measurement||price||2015-12-01 15:43:00.730568@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:43:08.558946||measurement||price||2015-12-01 15:43:02.938012@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:43:12.881478||measurement||price||2015-12-01 15:43:06.573202@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 15:43:14.519581||measurement||price||2015-12-01 15:43:09.110031@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:43:16.390646||measurement||price||2015-12-01 15:43:09.859076@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:43:20.356231||measurement||price||2015-12-01 15:43:00.730568@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:43:20.919757||measurement||price||2015-12-01 15:43:02.938012@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:43:25.743421||measurement||price||2015-12-01 15:43:06.573202@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 15:43:26.876350||measurement||price||2015-12-01 15:43:09.110031@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:43:27.555210||measurement||loadtime||0:00:29.157345||0||1
+2015-12-01 15:43:28.033451||measurement||loadtime||0:00:26.778300||4||0
+2015-12-01 15:43:29.202169||measurement||price||2015-12-01 15:43:09.859076@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:43:32.956874||measurement||loadtime||0:00:28.752066||5||1
+2015-12-01 15:43:33.973017||measurement||loadtime||0:00:27.191577||3||0
+2015-12-01 15:43:36.395153||measurement||loadtime||0:00:28.780013||2||1
+2015-12-01 15:43:42.532724||measurement||price||2015-12-01 15:43:34.892756@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:43:46.921405||measurement||price||2015-12-01 15:43:40.373234@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 15:43:47.272549||measurement||price||2015-12-01 15:43:41.630497@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 15:43:50.293882||error||collecting ads||Error||4||0
+2015-12-01 15:43:50.635615||measurement||price||2015-12-01 15:43:43.848754@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:43:55.630625||measurement||price||2015-12-01 15:43:34.892756@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:43:59.619023||measurement||price||2015-12-01 15:43:41.630497@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 15:43:59.775466||measurement||price||2015-12-01 15:43:40.373234@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 15:44:02.832223||measurement||loadtime||0:00:30.271772||0||1
+2015-12-01 15:44:03.025910||measurement||price||2015-12-01 15:43:57.408837@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:44:03.665978||measurement||price||2015-12-01 15:43:43.848754@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:44:06.726667||measurement||loadtime||0:00:27.748458||3||0
+2015-12-01 15:44:06.994750||measurement||loadtime||0:00:29.032646||5||1
+2015-12-01 15:44:10.867210||measurement||loadtime||0:00:29.471036||2||1
+2015-12-01 15:44:15.368025||measurement||price||2015-12-01 15:43:57.408837@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:44:16.973014||measurement||price||2015-12-01 15:44:10.120952@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:44:21.047056||measurement||price||2015-12-01 15:44:14.240132@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:44:22.481067||measurement||loadtime||0:00:27.183379||4||0
+2015-12-01 15:44:25.450151||measurement||price||2015-12-01 15:44:18.855209@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:44:29.573553||error||collecting ads||Error||3||0
+2015-12-01 15:44:29.861955||measurement||price||2015-12-01 15:44:10.120952@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:44:34.035420||measurement||price||2015-12-01 15:44:14.240132@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:44:35.170987||measurement||price||2015-12-01 15:44:29.596238@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:44:37.099511||measurement||loadtime||0:00:29.262051||0||1
+2015-12-01 15:44:38.369449||measurement||price||2015-12-01 15:44:18.855209@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:44:41.248362||measurement||loadtime||0:00:29.251391||5||1
+2015-12-01 15:44:42.071794||measurement||price||2015-12-01 15:44:36.693759@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 15:44:45.570311||measurement||loadtime||0:00:29.699140||2||1
+2015-12-01 15:44:47.496156||measurement||price||2015-12-01 15:44:29.596238@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:44:51.266372||measurement||price||2015-12-01 15:44:44.414332@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:44:54.404476||measurement||price||2015-12-01 15:44:36.693759@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 15:44:54.626801||measurement||loadtime||0:00:27.140488||4||0
+2015-12-01 15:44:55.371709||measurement||price||2015-12-01 15:44:48.513346@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:44:59.805861||measurement||price||2015-12-01 15:44:52.876974@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 15:45:01.523160||measurement||loadtime||0:00:26.944410||3||0
+2015-12-01 15:45:04.142355||measurement||price||2015-12-01 15:44:44.414332@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:45:06.980107||measurement||price||2015-12-01 15:45:01.343317@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:45:08.342358||measurement||price||2015-12-01 15:44:48.513346@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:45:11.367314||measurement||loadtime||0:00:29.262572||0||1
+2015-12-01 15:45:12.756558||measurement||price||2015-12-01 15:44:52.876974@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 15:45:14.214686||measurement||price||2015-12-01 15:45:08.416227@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 15:45:15.542615||measurement||loadtime||0:00:29.291433||5||1
+2015-12-01 15:45:19.310728||measurement||price||2015-12-01 15:45:01.343317@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:45:19.997547||measurement||loadtime||0:00:29.422417||2||1
+2015-12-01 15:45:26.427096||measurement||loadtime||0:00:26.795045||4||0
+2015-12-01 15:45:26.491954||measurement||price||2015-12-01 15:45:08.416227@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 15:45:29.597102||measurement||price||2015-12-01 15:45:23.009302@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 15:45:33.575230||measurement||loadtime||0:00:27.047018||3||0
+2015-12-01 15:45:34.219967||measurement||price||2015-12-01 15:45:27.759983@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:45:35.659351||error||collecting ads||Error||0||1
+2015-12-01 15:45:38.729902||measurement||price||2015-12-01 15:45:33.170464@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:45:42.568162||measurement||price||2015-12-01 15:45:23.009302@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 15:45:46.296755||measurement||price||2015-12-01 15:45:40.898828@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 15:45:47.139582||measurement||price||2015-12-01 15:45:27.759983@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:45:49.727412||measurement||price||2015-12-01 15:45:43.073189@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:45:49.770349||measurement||loadtime||0:00:29.223160||5||1
+2015-12-01 15:45:51.078870||measurement||price||2015-12-01 15:45:33.170464@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:45:54.366885||measurement||loadtime||0:00:29.364387||2||1
+2015-12-01 15:45:58.198793||measurement||loadtime||0:00:26.766474||4||0
+2015-12-01 15:45:58.198894||event||progress-marker||measurement-end||4||0
+2015-12-01 15:45:58.652175||measurement||price||2015-12-01 15:45:40.898828@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 15:46:02.602308||measurement||price||2015-12-01 15:45:43.073189@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:46:03.525377||measurement||price||2015-12-01 15:45:57.534817@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:46:05.771193||measurement||loadtime||0:00:27.190717||3||0
+2015-12-01 15:46:05.771319||event||progress-marker||measurement-end||3||0
+2015-12-01 15:46:08.949723||measurement||price||2015-12-01 15:46:01.991110@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:46:09.813445||measurement||loadtime||0:00:29.148901||0||1
+2015-12-01 15:46:16.553754||measurement||price||2015-12-01 15:45:57.534817@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:46:21.997995||measurement||price||2015-12-01 15:46:01.991110@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:46:23.751146||measurement||loadtime||0:00:28.975583||5||1
+2015-12-01 15:46:23.777173||measurement||price||2015-12-01 15:46:17.130377@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:46:29.358784||measurement||loadtime||0:00:29.986649||2||1
+2015-12-01 15:46:36.597726||measurement||price||2015-12-01 15:46:17.130377@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:46:37.776096||measurement||price||2015-12-01 15:46:31.064715@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:46:43.780172||measurement||loadtime||0:00:28.961497||0||1
+2015-12-01 15:46:50.742679||measurement||price||2015-12-01 15:46:31.064715@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:46:53.786128||error||collecting ads||Error||2||1
+2015-12-01 15:46:57.938924||measurement||loadtime||0:00:29.185905||5||1
+2015-12-01 15:46:58.029364||measurement||price||2015-12-01 15:46:51.570329@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:47:07.547272||measurement||price||2015-12-01 15:47:01.046837@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:47:11.188192||measurement||price||2015-12-01 15:46:51.570329@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:47:11.742210||measurement||price||2015-12-01 15:47:05.261643@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 15:47:18.401847||measurement||loadtime||0:00:29.616429||0||1
+2015-12-01 15:47:20.407814||measurement||price||2015-12-01 15:47:01.046837@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:47:24.828905||measurement||price||2015-12-01 15:47:05.261643@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 15:47:27.605260||measurement||loadtime||0:00:28.813860||2||1
+2015-12-01 15:47:32.011174||measurement||loadtime||0:00:29.071731||5||1
+2015-12-01 15:47:41.920430||measurement||price||2015-12-01 15:47:35.374963@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 15:47:42.001921||error||collecting ads||Error||0||1
+2015-12-01 15:47:54.863789||measurement||price||2015-12-01 15:47:35.374963@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 15:47:55.892059||error||collecting ads||Error||5||1
+2015-12-01 15:47:55.892162||event||progress-marker||measurement-end||5||1
+2015-12-01 15:47:56.059684||measurement||price||2015-12-01 15:47:49.318314@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:48:02.081502||measurement||loadtime||0:00:29.474344||2||1
+2015-12-01 15:48:08.903293||measurement||price||2015-12-01 15:47:49.318314@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:48:15.883330||measurement||price||2015-12-01 15:48:09.306110@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 15:48:16.087941||measurement||loadtime||0:00:29.084749||0||1
+2015-12-01 15:48:16.088084||event||progress-marker||measurement-end||0||1
+2015-12-01 15:48:28.938435||measurement||price||2015-12-01 15:48:09.306110@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 15:48:36.123948||measurement||loadtime||0:00:29.037226||2||1
+2015-12-01 15:48:36.124079||event||progress-marker||measurement-end||2||1
+2015-12-01 15:48:36.543404||meta||block_id end||7
+2015-12-01 15:48:36.543735||meta||block_id start||8
+2015-12-01 15:48:36.543767||meta||assignment||5@|4@|2@|3@|1@|0
+2015-12-01 15:48:38.129814||event||progress-marker||training-start||4||0
+2015-12-01 15:48:38.129912||event||progress-marker||training-end||4||0
+2015-12-01 15:48:38.162722||event||progress-marker||training-start||2||0
+2015-12-01 15:48:38.162824||event||progress-marker||training-end||2||0
+2015-12-01 15:48:38.180283||event||progress-marker||training-start||5||0
+2015-12-01 15:48:38.180380||event||progress-marker||training-end||5||0
+2015-12-01 15:48:43.156187||event||progress-marker||measurement-start||4||0
+2015-12-01 15:48:43.189243||event||progress-marker||measurement-start||2||0
+2015-12-01 15:48:43.200486||event||progress-marker||measurement-start||5||0
+2015-12-01 15:48:57.074142||measurement||price||2015-12-01 15:48:51.675282@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:48:57.329746||measurement||price||2015-12-01 15:48:50.482900@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:49:09.408951||measurement||price||2015-12-01 15:48:51.675282@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:49:09.679922||measurement||price||2015-12-01 15:48:50.482900@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:49:11.395497||error||collecting ads||Error||2||0
+2015-12-01 15:49:16.519275||measurement||loadtime||0:00:28.316072||5||0
+2015-12-01 15:49:16.785177||measurement||loadtime||0:00:28.623768||4||0
+2015-12-01 15:49:28.889831||measurement||price||2015-12-01 15:49:23.190398@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:49:34.019394||error||collecting ads||Error||2||0
+2015-12-01 15:49:39.177721||error||collecting ads||Error||4||0
+2015-12-01 15:49:41.237107||measurement||price||2015-12-01 15:49:23.190398@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:49:46.742387||measurement||price||2015-12-01 15:49:41.310029@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:49:48.350222||measurement||loadtime||0:00:26.825730||5||0
+2015-12-01 15:49:49.711018||event||progress-marker||training-start||3||1
+2015-12-01 15:49:49.711145||event||progress-marker||training-end||3||1
+2015-12-01 15:49:52.344245||measurement||price||2015-12-01 15:49:46.865099@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:49:54.733259||event||progress-marker||measurement-start||3||1
+2015-12-01 15:49:56.838528||event||progress-marker||training-start||1||1
+2015-12-01 15:49:56.838627||event||progress-marker||training-end||1||1
+2015-12-01 15:49:59.103570||measurement||price||2015-12-01 15:49:41.310029@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:50:00.677890||measurement||price||2015-12-01 15:49:55.039305@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:50:01.866108||event||progress-marker||measurement-start||1||1
+2015-12-01 15:50:04.680019||measurement||price||2015-12-01 15:49:46.865099@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:50:06.210125||measurement||loadtime||0:00:27.185482||2||0
+2015-12-01 15:50:09.122562||measurement||price||2015-12-01 15:50:02.481993@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:50:11.771170||measurement||loadtime||0:00:27.589448||4||0
+2015-12-01 15:50:13.003079||measurement||price||2015-12-01 15:49:55.039305@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:50:16.534930||measurement||price||2015-12-01 15:50:10.033879@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 15:50:19.324108||measurement||price||2015-12-01 15:50:13.924055@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:50:20.115615||measurement||loadtime||0:00:26.760186||5||0
+2015-12-01 15:50:23.286381||measurement||price||2015-12-01 15:50:02.481993@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:50:24.031611||measurement||price||2015-12-01 15:50:18.512669@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:50:29.397804||measurement||price||2015-12-01 15:50:10.033879@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 15:50:30.541970||measurement||loadtime||0:00:30.806813||3||1
+2015-12-01 15:50:31.676104||measurement||price||2015-12-01 15:50:13.924055@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:50:36.309245||measurement||price||2015-12-01 15:50:18.512669@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:50:36.627185||measurement||loadtime||0:00:29.755847||1||1
+2015-12-01 15:50:38.788173||measurement||loadtime||0:00:27.573123||2||0
+2015-12-01 15:50:42.442423||error||collecting ads||Error||5||0
+2015-12-01 15:50:43.400585||measurement||loadtime||0:00:26.625425||4||0
+2015-12-01 15:50:44.595187||measurement||price||2015-12-01 15:50:37.891397@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:50:45.626441||event||progress-marker||training-start||0||1
+2015-12-01 15:50:45.626547||event||progress-marker||training-end||0||1
+2015-12-01 15:50:50.532771||measurement||price||2015-12-01 15:50:44.136149@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:50:50.647856||event||progress-marker||measurement-start||0||1
+2015-12-01 15:50:51.460116||measurement||price||2015-12-01 15:50:46.112452@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:50:55.079681||measurement||price||2015-12-01 15:50:49.551386@|At-A-Glance@|$23.97@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||5||0
+2015-12-01 15:50:57.427432||measurement||price||2015-12-01 15:50:37.891397@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:51:03.406055||measurement||price||2015-12-01 15:50:44.136149@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:51:03.797668||measurement||price||2015-12-01 15:50:46.112452@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:51:04.643768||measurement||loadtime||0:00:29.096589||3||1
+2015-12-01 15:51:05.668690||error||collecting ads||Error||4||0
+2015-12-01 15:51:07.435438||measurement||price||2015-12-01 15:50:49.551386@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||5||0
+2015-12-01 15:51:10.603447||measurement||loadtime||0:00:28.973954||1||1
+2015-12-01 15:51:10.908984||measurement||loadtime||0:00:27.117845||2||0
+2015-12-01 15:51:14.551164||measurement||loadtime||0:00:27.103523||5||0
+2015-12-01 15:51:15.086973||error||collecting ads||Error||0||1
+2015-12-01 15:51:18.677806||measurement||price||2015-12-01 15:51:13.160403@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:51:18.840774||measurement||price||2015-12-01 15:51:12.462205@|@|$118.00@|BLU Studio 7.0 II -Unlocked Smartphone - US GSM - Gold||3||1
+2015-12-01 15:51:24.819371||measurement||price||2015-12-01 15:51:18.030446@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:51:26.914434||measurement||price||2015-12-01 15:51:21.308772@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:51:29.026304||measurement||price||2015-12-01 15:51:22.452521@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:51:31.009763||measurement||price||2015-12-01 15:51:13.160403@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:51:31.697760||measurement||price||2015-12-01 15:51:12.462205@|@|$199.00@|BLU Vivo Air LTE Smartphone - GSM Unlocked - Black||3||1
+2015-12-01 15:51:34.385660||error||collecting ads||Error||2||0
+2015-12-01 15:51:37.837312||measurement||price||2015-12-01 15:51:18.030446@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:51:38.106381||measurement||loadtime||0:00:27.432449||4||0
+2015-12-01 15:51:38.910942||measurement||loadtime||0:00:29.261952||3||1
+2015-12-01 15:51:39.257665||measurement||price||2015-12-01 15:51:21.308772@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:51:41.922954||measurement||price||2015-12-01 15:51:22.452521@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:51:45.043168||measurement||loadtime||0:00:29.434530||1||1
+2015-12-01 15:51:46.371808||measurement||loadtime||0:00:26.816674||5||0
+2015-12-01 15:51:46.995352||measurement||price||2015-12-01 15:51:41.651122@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:51:49.143070||measurement||loadtime||0:00:29.051853||0||1
+2015-12-01 15:51:50.401283||measurement||price||2015-12-01 15:51:44.743527@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:51:52.973703||measurement||price||2015-12-01 15:51:46.341883@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:51:58.768354||measurement||price||2015-12-01 15:51:53.073335@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:51:59.353140||measurement||price||2015-12-01 15:51:41.651122@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:51:59.493106||measurement||price||2015-12-01 15:51:53.498192@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:52:02.750891||measurement||price||2015-12-01 15:51:44.743527@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:52:03.119724||measurement||price||2015-12-01 15:51:56.482075@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:52:06.099275||measurement||price||2015-12-01 15:51:46.341883@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:52:06.467200||measurement||loadtime||0:00:27.080032||2||0
+2015-12-01 15:52:09.867188||measurement||loadtime||0:00:26.755599||4||0
+2015-12-01 15:52:11.107234||measurement||price||2015-12-01 15:51:53.073335@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:52:12.389597||measurement||price||2015-12-01 15:51:53.498192@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:52:13.311831||measurement||loadtime||0:00:29.396684||3||1
+2015-12-01 15:52:16.004979||measurement||price||2015-12-01 15:51:56.482075@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:52:18.219166||measurement||loadtime||0:00:26.842163||5||0
+2015-12-01 15:52:19.170607||measurement||price||2015-12-01 15:52:13.737313@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:52:19.599159||measurement||loadtime||0:00:29.550781||1||1
+2015-12-01 15:52:22.100727||measurement||price||2015-12-01 15:52:16.588301@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:52:23.223314||measurement||loadtime||0:00:29.078136||0||1
+2015-12-01 15:52:27.179721||measurement||price||2015-12-01 15:52:20.575937@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:52:31.002793||measurement||price||2015-12-01 15:52:25.330176@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:52:31.502105||measurement||price||2015-12-01 15:52:13.737313@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:52:34.431927||measurement||price||2015-12-01 15:52:16.588301@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:52:37.190758||measurement||price||2015-12-01 15:52:30.717388@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:52:38.622856||measurement||loadtime||0:00:27.150405||2||0
+2015-12-01 15:52:40.254759||measurement||price||2015-12-01 15:52:20.575937@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:52:41.543304||measurement||loadtime||0:00:26.675709||4||0
+2015-12-01 15:52:43.359556||measurement||price||2015-12-01 15:52:25.330176@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:52:43.461401||error||collecting ads||Error||1||1
+2015-12-01 15:52:47.459699||measurement||loadtime||0:00:29.144486||3||1
+2015-12-01 15:52:50.061313||measurement||price||2015-12-01 15:52:30.717388@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:52:50.468656||measurement||loadtime||0:00:27.244284||5||0
+2015-12-01 15:52:51.697869||measurement||price||2015-12-01 15:52:46.273743@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:52:53.756315||measurement||price||2015-12-01 15:52:48.138078@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:52:57.259348||measurement||loadtime||0:00:29.030804||0||1
+2015-12-01 15:53:01.583589||measurement||price||2015-12-01 15:52:54.828719@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:53:04.066179||measurement||price||2015-12-01 15:52:46.273743@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:53:06.094749||measurement||price||2015-12-01 15:52:48.138078@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:53:07.569340||error||collecting ads||Error||1||1
+2015-12-01 15:53:11.175439||measurement||loadtime||0:00:27.547333||2||0
+2015-12-01 15:53:11.333764||measurement||price||2015-12-01 15:53:04.564108@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:53:13.179155||measurement||loadtime||0:00:26.630611||4||0
+2015-12-01 15:53:13.203859||error||collecting ads||Error||5||0
+2015-12-01 15:53:14.508397||measurement||price||2015-12-01 15:52:54.828719@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:53:21.694522||measurement||loadtime||0:00:29.231389||3||1
+2015-12-01 15:53:24.297135||measurement||price||2015-12-01 15:53:04.564108@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:53:31.508750||measurement||loadtime||0:00:29.248540||0||1
+2015-12-01 15:53:31.654812||error||collecting ads||Error||1||1
+2015-12-01 15:53:33.741733||error||collecting ads||Error||2||0
+2015-12-01 15:53:35.545068||error||collecting ads||Error||4||0
+2015-12-01 15:53:35.605183||error||collecting ads||Error||5||0
+2015-12-01 15:53:45.415170||measurement||price||2015-12-01 15:53:38.745254@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:53:45.795495||error||collecting ads||Error||3||1
+2015-12-01 15:53:48.387166||measurement||price||2015-12-01 15:53:42.811000@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||5||0
+2015-12-01 15:53:55.582408||error||collecting ads||Error||1||1
+2015-12-01 15:53:56.447937||error||collecting ads||Error||2||0
+2015-12-01 15:53:58.327902||measurement||price||2015-12-01 15:53:38.745254@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:53:58.456489||error||collecting ads||Error||4||0
+2015-12-01 15:54:00.071046||measurement||price||2015-12-01 15:53:53.168409@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:54:05.519157||measurement||loadtime||0:00:29.005215||0||1
+2015-12-01 15:54:09.820150||measurement||price||2015-12-01 15:54:04.422813@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:54:10.493340||measurement||price||2015-12-01 15:54:03.919888@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:54:10.708804||error||collecting ads||Error||5||0
+2015-12-01 15:54:11.677741||measurement||price||2015-12-01 15:54:06.033735@|Lexmark@|$594.99@|Lexmark MS810n Mono Laser Printer||4||0
+2015-12-01 15:54:12.905466||measurement||price||2015-12-01 15:53:53.168409@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:54:19.557371||measurement||price||2015-12-01 15:54:12.739508@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:54:20.122096||measurement||loadtime||0:00:29.321362||3||1
+2015-12-01 15:54:22.163833||measurement||price||2015-12-01 15:54:04.422813@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:54:23.738334||measurement||price||2015-12-01 15:54:03.919888@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:54:24.046915||measurement||price||2015-12-01 15:54:06.033735@|Lexmark@|$460.99@|Lexmark MS610dn Mono Laser Printer||4||0
+2015-12-01 15:54:29.260662||measurement||loadtime||0:00:27.807487||2||0
+2015-12-01 15:54:31.020418||measurement||loadtime||0:00:30.432791||1||1
+2015-12-01 15:54:31.141030||measurement||loadtime||0:00:27.681882||4||0
+2015-12-01 15:54:32.594049||measurement||price||2015-12-01 15:54:12.739508@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:54:33.019982||error||collecting ads||Error||5||0
+2015-12-01 15:54:33.950308||measurement||price||2015-12-01 15:54:27.751179@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:54:39.791159||measurement||loadtime||0:00:29.268040||0||1
+2015-12-01 15:54:42.452691||measurement||price||2015-12-01 15:54:36.929405@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 15:54:43.439722||measurement||price||2015-12-01 15:54:37.805099@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 15:54:45.409995||measurement||price||2015-12-01 15:54:39.736862@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:54:46.971680||measurement||price||2015-12-01 15:54:27.751179@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:54:54.207160||measurement||loadtime||0:00:29.080015||3||1
+2015-12-01 15:54:54.214023||measurement||price||2015-12-01 15:54:47.345612@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:54:54.735840||measurement||price||2015-12-01 15:54:36.929405@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 15:54:55.383485||error||collecting ads||Error||1||1
+2015-12-01 15:54:55.715371||measurement||price||2015-12-01 15:54:37.805099@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 15:54:57.730595||measurement||price||2015-12-01 15:54:39.736862@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:55:01.819162||measurement||loadtime||0:00:27.553298||2||0
+2015-12-01 15:55:02.795159||measurement||loadtime||0:00:26.652018||4||0
+2015-12-01 15:55:04.839247||measurement||loadtime||0:00:26.817317||5||0
+2015-12-01 15:55:07.377163||measurement||price||2015-12-01 15:54:47.345612@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:55:08.416805||measurement||price||2015-12-01 15:55:01.540528@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 15:55:09.456161||measurement||price||2015-12-01 15:55:02.826450@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:55:14.614317||measurement||loadtime||0:00:29.817973||0||1
+2015-12-01 15:55:15.124012||measurement||price||2015-12-01 15:55:09.448422@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:55:17.557273||measurement||price||2015-12-01 15:55:11.979923@|@|$118.00@|BLU Studio 7.0 II -Unlocked Smartphone - US GSM - Gold||5||0
+2015-12-01 15:55:21.474416||measurement||price||2015-12-01 15:55:01.540528@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 15:55:22.427335||measurement||price||2015-12-01 15:55:02.826450@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:55:24.408747||error||collecting ads||Error||2||0
+2015-12-01 15:55:27.492205||measurement||price||2015-12-01 15:55:09.448422@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:55:28.691146||measurement||loadtime||0:00:29.478794||3||1
+2015-12-01 15:55:29.615838||measurement||loadtime||0:00:29.231336||1||1
+2015-12-01 15:55:29.841465||measurement||price||2015-12-01 15:55:11.979923@|@|$199.00@|BLU Vivo Air LTE Smartphone - GSM Unlocked - Black||5||0
+2015-12-01 15:55:34.604317||measurement||loadtime||0:00:26.807888||4||0
+2015-12-01 15:55:36.927154||measurement||loadtime||0:00:27.082714||5||0
+2015-12-01 15:55:38.842270||error||collecting ads||Error||0||1
+2015-12-01 15:55:43.800631||measurement||price||2015-12-01 15:55:37.092683@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 15:55:46.840361||measurement||price||2015-12-01 15:55:41.228867@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:55:46.903413||error||collecting ads||Error||2||0
+2015-12-01 15:55:49.227895||measurement||price||2015-12-01 15:55:43.747967@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:55:52.456542||error||collecting ads||Error||3||1
+2015-12-01 15:55:53.058993||measurement||price||2015-12-01 15:55:46.679617@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:55:56.879203||measurement||price||2015-12-01 15:55:37.092683@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 15:55:59.172744||measurement||price||2015-12-01 15:55:41.228867@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:56:01.564108||measurement||price||2015-12-01 15:55:43.747967@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:56:04.100109||measurement||loadtime||0:00:29.479058||1||1
+2015-12-01 15:56:06.161328||measurement||price||2015-12-01 15:55:46.679617@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:56:06.289424||measurement||loadtime||0:00:26.680315||4||0
+2015-12-01 15:56:06.629409||measurement||price||2015-12-01 15:55:59.722686@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:56:08.672114||measurement||loadtime||0:00:26.740976||5||0
+2015-12-01 15:56:09.555772||error||collecting ads||Error||2||0
+2015-12-01 15:56:13.407160||measurement||loadtime||0:00:29.559985||0||1
+2015-12-01 15:56:18.657208||measurement||price||2015-12-01 15:56:13.022990@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:56:19.577948||measurement||price||2015-12-01 15:55:59.722686@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:56:26.789712||measurement||loadtime||0:00:29.327936||3||1
+2015-12-01 15:56:27.939795||error||collecting ads||Error||1||1
+2015-12-01 15:56:31.001608||measurement||price||2015-12-01 15:56:13.022990@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:56:31.027950||error||collecting ads||Error||5||0
+2015-12-01 15:56:32.196288||error||collecting ads||Error||2||0
+2015-12-01 15:56:37.778847||error||collecting ads||Error||0||1
+2015-12-01 15:56:38.109137||measurement||loadtime||0:00:26.814494||4||0
+2015-12-01 15:56:41.059540||measurement||price||2015-12-01 15:56:34.179131@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:56:41.807488||measurement||price||2015-12-01 15:56:35.461277@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:56:43.331471||measurement||price||2015-12-01 15:56:37.733251@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 15:56:44.885712||measurement||price||2015-12-01 15:56:39.489507@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:56:50.501567||measurement||price||2015-12-01 15:56:44.806163@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:56:52.516166||measurement||price||2015-12-01 15:56:45.664469@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:56:53.858757||measurement||price||2015-12-01 15:56:34.179131@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:56:54.673428||measurement||price||2015-12-01 15:56:35.461277@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:56:55.683464||measurement||price||2015-12-01 15:56:37.733251@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 15:56:57.218999||measurement||price||2015-12-01 15:56:39.489507@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:57:01.104038||measurement||loadtime||0:00:29.309080||3||1
+2015-12-01 15:57:01.892158||measurement||loadtime||0:00:28.947140||1||1
+2015-12-01 15:57:02.793666||measurement||loadtime||0:00:26.760546||5||0
+2015-12-01 15:57:02.819318||measurement||price||2015-12-01 15:56:44.806163@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:57:04.326973||measurement||loadtime||0:00:27.127843||2||0
+2015-12-01 15:57:05.412166||measurement||price||2015-12-01 15:56:45.664469@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:57:09.907192||measurement||loadtime||0:00:26.796048||4||0
+2015-12-01 15:57:12.628006||measurement||loadtime||0:00:29.846781||0||1
+2015-12-01 15:57:15.282001||measurement||price||2015-12-01 15:57:09.657651@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:57:15.390474||measurement||price||2015-12-01 15:57:08.496407@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:57:16.261722||measurement||price||2015-12-01 15:57:09.993067@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||1
+2015-12-01 15:57:17.038322||measurement||price||2015-12-01 15:57:11.680921@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 15:57:22.223816||measurement||price||2015-12-01 15:57:16.649525@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 15:57:26.267331||measurement||price||2015-12-01 15:57:19.978180@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 15:57:27.571116||measurement||price||2015-12-01 15:57:09.657651@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:57:28.344227||measurement||price||2015-12-01 15:57:08.496407@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 15:57:29.097636||measurement||price||2015-12-01 15:57:09.993067@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||1
+2015-12-01 15:57:29.336895||measurement||price||2015-12-01 15:57:11.680921@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 15:57:34.566093||measurement||price||2015-12-01 15:57:16.649525@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 15:57:34.659153||measurement||loadtime||0:00:26.863405||5||0
+2015-12-01 15:57:35.561366||measurement||loadtime||0:00:29.452495||3||1
+2015-12-01 15:57:36.297042||measurement||loadtime||0:00:29.399661||1||1
+2015-12-01 15:57:36.430391||measurement||loadtime||0:00:27.099243||2||0
+2015-12-01 15:57:39.113139||measurement||price||2015-12-01 15:57:19.978180@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 15:57:41.678462||measurement||loadtime||0:00:26.766064||4||0
+2015-12-01 15:57:46.342719||measurement||loadtime||0:00:28.709510||0||1
+2015-12-01 15:57:47.039516||measurement||price||2015-12-01 15:57:41.342163@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 15:57:49.272341||measurement||price||2015-12-01 15:57:43.837221@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 15:57:49.551684||measurement||price||2015-12-01 15:57:43.017108@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 15:57:50.068187||measurement||price||2015-12-01 15:57:43.645256@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 15:57:54.289280||measurement||price||2015-12-01 15:57:48.742253@|Lexmark@|$594.99@|Lexmark MS810n Mono Laser Printer||4||0
+2015-12-01 15:57:59.384426||measurement||price||2015-12-01 15:57:41.342163@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 15:58:00.357738||measurement||price||2015-12-01 15:57:53.654148@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:58:01.568057||measurement||price||2015-12-01 15:57:43.837221@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 15:58:02.605235||measurement||price||2015-12-01 15:57:43.017108@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 15:58:03.056620||measurement||price||2015-12-01 15:57:43.645256@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 15:58:06.497492||measurement||loadtime||0:00:26.833165||5||0
+2015-12-01 15:58:06.632772||measurement||price||2015-12-01 15:57:48.742253@|Lexmark@|$460.99@|Lexmark MS610dn Mono Laser Printer||4||0
+2015-12-01 15:58:08.663115||measurement||loadtime||0:00:27.228192||2||0
+2015-12-01 15:58:08.663232||event||progress-marker||measurement-end||2||0
+2015-12-01 15:58:09.964751||measurement||loadtime||0:00:29.398166||3||1
+2015-12-01 15:58:10.258710||measurement||loadtime||0:00:28.959579||1||1
+2015-12-01 15:58:13.272729||measurement||price||2015-12-01 15:57:53.654148@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:58:13.747171||measurement||loadtime||0:00:27.063500||4||0
+2015-12-01 15:58:18.746743||measurement||price||2015-12-01 15:58:13.157036@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 15:58:20.483964||measurement||loadtime||0:00:29.136022||0||1
+2015-12-01 15:58:24.098029||measurement||price||2015-12-01 15:58:17.660239@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 15:58:26.137351||measurement||price||2015-12-01 15:58:20.593604@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 15:58:31.069915||measurement||price||2015-12-01 15:58:13.157036@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 15:58:33.785407||error||collecting ads||Error||3||1
+2015-12-01 15:58:34.566484||measurement||price||2015-12-01 15:58:27.765413@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 15:58:37.047730||measurement||price||2015-12-01 15:58:17.660239@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 15:58:38.190577||measurement||loadtime||0:00:26.687879||5||0
+2015-12-01 15:58:38.190689||event||progress-marker||measurement-end||5||0
+2015-12-01 15:58:38.461895||measurement||price||2015-12-01 15:58:20.593604@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 15:58:44.245975||measurement||loadtime||0:00:28.982069||1||1
+2015-12-01 15:58:45.571869||measurement||loadtime||0:00:26.820734||4||0
+2015-12-01 15:58:45.571987||event||progress-marker||measurement-end||4||0
+2015-12-01 15:58:47.394559||measurement||price||2015-12-01 15:58:27.765413@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 15:58:54.611225||measurement||loadtime||0:00:29.122024||0||1
+2015-12-01 15:58:57.780907||error||collecting ads||Error||3||1
+2015-12-01 15:59:08.254113||error||collecting ads||Error||1||1
+2015-12-01 15:59:11.905036||measurement||price||2015-12-01 15:59:05.767443@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 15:59:18.532161||error||collecting ads||Error||0||1
+2015-12-01 15:59:22.250263||measurement||price||2015-12-01 15:59:15.537463@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 15:59:24.793111||measurement||price||2015-12-01 15:59:05.767443@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 15:59:31.974850||measurement||loadtime||0:00:29.188716||3||1
+2015-12-01 15:59:32.416762||measurement||price||2015-12-01 15:59:25.781658@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 15:59:35.125416||measurement||price||2015-12-01 15:59:15.537463@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 15:59:42.322296||measurement||loadtime||0:00:29.062847||1||1
+2015-12-01 15:59:45.263894||measurement||price||2015-12-01 15:59:25.781658@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 15:59:45.967256||measurement||price||2015-12-01 15:59:39.316427@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 15:59:52.462093||measurement||loadtime||0:00:28.924677||0||1
+2015-12-01 15:59:58.872417||measurement||price||2015-12-01 15:59:39.316427@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:00:06.056032||measurement||loadtime||0:00:29.075928||3||1
+2015-12-01 16:00:06.548426||error||collecting ads||Error||1||1
+2015-12-01 16:00:06.548528||event||progress-marker||measurement-end||1||1
+2015-12-01 16:00:07.046823||measurement||price||2015-12-01 16:00:00.481664@|Irwin Tools@|$129.95@|Irwin Tools 1868997 Multiple Tool Set, 13-Piece||0||1
+2015-12-01 16:00:19.894539||measurement||price||2015-12-01 16:00:00.481664@|Irwin Tools@|$11.07@|IRWIN Tools VISE-GRIP Locking Pliers, Fast Release, Curved J...||0||1
+2015-12-01 16:00:27.079103||measurement||loadtime||0:00:29.615570||0||1
+2015-12-01 16:00:29.813891||error||collecting ads||Error||3||1
+2015-12-01 16:00:29.814031||event||progress-marker||measurement-end||3||1
+2015-12-01 16:00:41.084727||measurement||price||2015-12-01 16:00:34.546852@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:00:53.963303||measurement||price||2015-12-01 16:00:34.546852@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:01:01.153839||measurement||loadtime||0:00:29.069459||0||1
+2015-12-01 16:01:25.053381||error||collecting ads||Error||0||1
+2015-12-01 16:01:25.053485||event||progress-marker||measurement-end||0||1
+2015-12-01 16:01:25.476933||meta||block_id end||8
+2015-12-01 16:01:25.477143||meta||block_id start||9
+2015-12-01 16:01:25.477163||meta||assignment||4@|3@|1@|0@|5@|2
+2015-12-01 16:01:27.066737||event||progress-marker||training-start||4||0
+2015-12-01 16:01:27.066833||event||progress-marker||training-end||4||0
+2015-12-01 16:01:27.101300||event||progress-marker||training-start||1||0
+2015-12-01 16:01:27.101402||event||progress-marker||training-end||1||0
+2015-12-01 16:01:27.125093||event||progress-marker||training-start||3||0
+2015-12-01 16:01:27.127209||event||progress-marker||training-end||3||0
+2015-12-01 16:01:32.094568||event||progress-marker||measurement-start||4||0
+2015-12-01 16:01:32.134984||event||progress-marker||measurement-start||1||0
+2015-12-01 16:01:32.148353||event||progress-marker||measurement-start||3||0
+2015-12-01 16:01:46.635493||measurement||price||2015-12-01 16:01:39.985483@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:01:46.788812||measurement||price||2015-12-01 16:01:39.814783@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 16:01:56.611495||error||collecting ads||Error||4||0
+2015-12-01 16:01:58.981468||measurement||price||2015-12-01 16:01:39.985483@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:01:59.162139||measurement||price||2015-12-01 16:01:39.814783@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 16:02:06.091679||measurement||loadtime||0:00:28.940509||3||0
+2015-12-01 16:02:06.283501||measurement||loadtime||0:00:29.144343||1||0
+2015-12-01 16:02:08.825423||measurement||price||2015-12-01 16:02:03.219708@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:02:18.716135||measurement||price||2015-12-01 16:02:13.329902@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:02:18.838899||measurement||price||2015-12-01 16:02:13.414275@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:02:21.154391||measurement||price||2015-12-01 16:02:03.219708@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:02:28.262835||measurement||loadtime||0:00:26.646096||4||0
+2015-12-01 16:02:31.050114||measurement||price||2015-12-01 16:02:13.329902@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:02:31.187390||measurement||price||2015-12-01 16:02:13.414275@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:02:34.541758||event||progress-marker||training-start||0||1
+2015-12-01 16:02:34.541906||event||progress-marker||training-end||0||1
+2015-12-01 16:02:36.941946||event||progress-marker||training-start||2||1
+2015-12-01 16:02:36.942091||event||progress-marker||training-end||2||1
+2015-12-01 16:02:38.163055||measurement||loadtime||0:00:27.066540||3||0
+2015-12-01 16:02:38.307863||measurement||loadtime||0:00:27.020332||1||0
+2015-12-01 16:02:39.576025||event||progress-marker||measurement-start||0||1
+2015-12-01 16:02:41.976094||event||progress-marker||measurement-start||2||1
+2015-12-01 16:02:50.461453||error||collecting ads||Error||4||0
+2015-12-01 16:02:51.209494||measurement||price||2015-12-01 16:02:45.804338@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||0
+2015-12-01 16:02:54.037525||measurement||price||2015-12-01 16:02:47.486180@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:02:56.355337||measurement||price||2015-12-01 16:02:49.803342@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:03:00.910463||error||collecting ads||Error||1||0
+2015-12-01 16:03:02.694539||measurement||price||2015-12-01 16:02:57.062342@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:03:03.532436||measurement||price||2015-12-01 16:02:45.804338@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||0
+2015-12-01 16:03:06.922736||measurement||price||2015-12-01 16:02:47.486180@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:03:09.281652||measurement||price||2015-12-01 16:02:49.803342@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:03:10.615170||measurement||loadtime||0:00:27.446907||3||0
+2015-12-01 16:03:13.610011||measurement||price||2015-12-01 16:03:08.171556@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 16:03:14.112611||measurement||loadtime||0:00:29.532540||0||1
+2015-12-01 16:03:15.026141||measurement||price||2015-12-01 16:02:57.062342@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:03:16.475556||measurement||loadtime||0:00:29.494277||2||1
+2015-12-01 16:03:22.139169||measurement||loadtime||0:00:26.672527||4||0
+2015-12-01 16:03:23.103074||measurement||price||2015-12-01 16:03:17.719113@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:03:25.950046||measurement||price||2015-12-01 16:03:08.171556@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 16:03:30.509288||measurement||price||2015-12-01 16:03:24.116429@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 16:03:33.064830||measurement||loadtime||0:00:27.149113||1||0
+2015-12-01 16:03:34.912009||measurement||price||2015-12-01 16:03:29.360331@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||0
+2015-12-01 16:03:35.448425||measurement||price||2015-12-01 16:03:17.719113@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:03:38.076868||error||collecting ads||Error||0||1
+2015-12-01 16:03:42.567901||measurement||loadtime||0:00:26.947499||3||0
+2015-12-01 16:03:43.548276||measurement||price||2015-12-01 16:03:24.116429@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 16:03:45.430794||measurement||price||2015-12-01 16:03:40.075917@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:03:47.243471||measurement||price||2015-12-01 16:03:29.360331@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||0
+2015-12-01 16:03:50.733215||measurement||loadtime||0:00:29.252491||2||1
+2015-12-01 16:03:50.789760||event||progress-marker||training-start||5||1
+2015-12-01 16:03:50.789865||event||progress-marker||training-end||5||1
+2015-12-01 16:03:52.416622||measurement||price||2015-12-01 16:03:45.914009@|At-A-Glance@|$23.97@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||0||1
+2015-12-01 16:03:54.354983||measurement||loadtime||0:00:27.210603||4||0
+2015-12-01 16:03:55.182729||measurement||price||2015-12-01 16:03:49.727291@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:03:55.817053||event||progress-marker||measurement-start||5||1
+2015-12-01 16:03:57.761089||measurement||price||2015-12-01 16:03:40.075917@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:04:04.883144||measurement||loadtime||0:00:26.815170||1||0
+2015-12-01 16:04:05.270441||measurement||price||2015-12-01 16:03:45.914009@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||0||1
+2015-12-01 16:04:06.913834||measurement||price||2015-12-01 16:04:01.237329@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||4||0
+2015-12-01 16:04:07.524351||measurement||price||2015-12-01 16:03:49.727291@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:04:10.767535||measurement||price||2015-12-01 16:04:04.513763@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:04:12.455014||measurement||loadtime||0:00:29.375549||0||1
+2015-12-01 16:04:14.465001||error||collecting ads||Error||2||1
+2015-12-01 16:04:14.634273||measurement||loadtime||0:00:27.061152||3||0
+2015-12-01 16:04:19.261233||measurement||price||2015-12-01 16:04:01.237329@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||4||0
+2015-12-01 16:04:23.714788||measurement||price||2015-12-01 16:04:04.513763@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:04:26.374902||measurement||loadtime||0:00:27.016217||4||0
+2015-12-01 16:04:26.958496||measurement||price||2015-12-01 16:04:20.239442@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:04:27.324387||error||collecting ads||Error||1||0
+2015-12-01 16:04:27.768721||measurement||price||2015-12-01 16:04:22.299460@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:04:28.495901||measurement||price||2015-12-01 16:04:21.638382@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:04:30.932290||measurement||loadtime||0:00:30.110261||5||1
+2015-12-01 16:04:39.838701||measurement||price||2015-12-01 16:04:20.239442@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:04:40.117199||measurement||price||2015-12-01 16:04:22.299460@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:04:40.352595||measurement||price||2015-12-01 16:04:34.954900@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:04:41.318869||measurement||price||2015-12-01 16:04:21.638382@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:04:47.074786||measurement||loadtime||0:00:29.614485||0||1
+2015-12-01 16:04:47.281744||measurement||loadtime||0:00:27.642596||3||0
+2015-12-01 16:04:48.547941||measurement||loadtime||0:00:29.080944||2||1
+2015-12-01 16:04:48.644057||error||collecting ads||Error||4||0
+2015-12-01 16:04:52.704740||measurement||price||2015-12-01 16:04:34.954900@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:04:54.896138||error||collecting ads||Error||5||1
+2015-12-01 16:04:59.808135||measurement||loadtime||0:00:27.478545||1||0
+2015-12-01 16:04:59.932747||measurement||price||2015-12-01 16:04:54.526695@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:05:00.984224||measurement||price||2015-12-01 16:04:55.356588@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:05:01.630422||measurement||price||2015-12-01 16:04:54.517260@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:05:02.597384||measurement||price||2015-12-01 16:04:56.067167@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 16:05:08.971225||measurement||price||2015-12-01 16:05:02.163721@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 16:05:12.225232||measurement||price||2015-12-01 16:05:06.786990@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 16:05:12.265711||measurement||price||2015-12-01 16:04:54.526695@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:05:13.294247||measurement||price||2015-12-01 16:04:55.356588@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:05:14.611796||measurement||price||2015-12-01 16:04:54.517260@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:05:15.455935||measurement||price||2015-12-01 16:04:56.067167@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 16:05:19.374945||measurement||loadtime||0:00:27.091906||3||0
+2015-12-01 16:05:20.394725||measurement||loadtime||0:00:26.747565||4||0
+2015-12-01 16:05:21.807979||measurement||loadtime||0:00:29.727981||0||1
+2015-12-01 16:05:21.936328||measurement||price||2015-12-01 16:05:02.163721@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 16:05:22.671158||measurement||loadtime||0:00:29.117998||2||1
+2015-12-01 16:05:24.576594||measurement||price||2015-12-01 16:05:06.786990@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 16:05:29.132671||measurement||loadtime||0:00:29.231321||5||1
+2015-12-01 16:05:31.671689||measurement||loadtime||0:00:26.860901||1||0
+2015-12-01 16:05:32.315882||measurement||price||2015-12-01 16:05:26.936200@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:05:35.770248||measurement||price||2015-12-01 16:05:29.150177@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:05:42.621190||error||collecting ads||Error||4||0
+2015-12-01 16:05:44.089758||measurement||price||2015-12-01 16:05:38.724416@|@|$274.95@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||1||0
+2015-12-01 16:05:44.637490||measurement||price||2015-12-01 16:05:26.936200@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:05:46.411615||error||collecting ads||Error||2||1
+2015-12-01 16:05:48.641829||measurement||price||2015-12-01 16:05:29.150177@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:05:51.747160||measurement||loadtime||0:00:27.371224||3||0
+2015-12-01 16:05:52.978986||error||collecting ads||Error||5||1
+2015-12-01 16:05:54.857331||measurement||price||2015-12-01 16:05:49.271150@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:05:55.839623||measurement||loadtime||0:00:29.026446||0||1
+2015-12-01 16:05:56.390061||measurement||price||2015-12-01 16:05:38.724416@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||1||0
+2015-12-01 16:06:00.277427||measurement||price||2015-12-01 16:05:53.782674@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:06:03.477041||measurement||loadtime||0:00:26.800153||1||0
+2015-12-01 16:06:04.762911||measurement||price||2015-12-01 16:05:59.361465@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:06:07.007156||measurement||price||2015-12-01 16:06:00.748891@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 16:06:07.180548||measurement||price||2015-12-01 16:05:49.271150@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:06:13.129978||measurement||price||2015-12-01 16:05:53.782674@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:06:14.297586||measurement||loadtime||0:00:26.671156||4||0
+2015-12-01 16:06:16.406229||measurement||price||2015-12-01 16:06:11.023431@|Lonve@| $19.99   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||0
+2015-12-01 16:06:17.102513||measurement||price||2015-12-01 16:05:59.361465@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:06:19.880010||measurement||price||2015-12-01 16:06:00.748891@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 16:06:19.908176||error||collecting ads||Error||0||1
+2015-12-01 16:06:20.327161||measurement||loadtime||0:00:28.912025||2||1
+2015-12-01 16:06:24.209264||measurement||loadtime||0:00:27.456906||3||0
+2015-12-01 16:06:26.528600||measurement||price||2015-12-01 16:06:20.983564@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:06:27.103144||measurement||loadtime||0:00:29.120015||5||1
+2015-12-01 16:06:28.756716||measurement||price||2015-12-01 16:06:11.023431@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||0
+2015-12-01 16:06:35.871155||measurement||loadtime||0:00:27.392017||1||0
+2015-12-01 16:06:37.073332||measurement||price||2015-12-01 16:06:31.689162@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:06:38.853938||measurement||price||2015-12-01 16:06:20.983564@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:06:40.713885||measurement||price||2015-12-01 16:06:34.288260@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:06:43.625980||error||collecting ads||Error||0||1
+2015-12-01 16:06:44.160249||error||collecting ads||Error||2||1
+2015-12-01 16:06:45.962321||measurement||loadtime||0:00:26.661754||4||0
+2015-12-01 16:06:48.392288||measurement||price||2015-12-01 16:06:42.998163@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:06:49.396937||measurement||price||2015-12-01 16:06:31.689162@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:06:53.587186||measurement||price||2015-12-01 16:06:34.288260@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:06:56.512118||measurement||loadtime||0:00:27.300979||3||0
+2015-12-01 16:06:57.287964||measurement||price||2015-12-01 16:06:51.115482@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:06:58.370115||measurement||price||2015-12-01 16:06:51.581564@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:07:00.734459||measurement||price||2015-12-01 16:06:42.998163@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:07:00.815164||measurement||loadtime||0:00:28.707994||5||1
+2015-12-01 16:07:07.852675||measurement||loadtime||0:00:26.977528||1||0
+2015-12-01 16:07:08.268009||error||collecting ads||Error||4||0
+2015-12-01 16:07:09.292315||measurement||price||2015-12-01 16:07:03.925353@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:07:10.152197||measurement||price||2015-12-01 16:06:51.115482@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:07:11.326566||measurement||price||2015-12-01 16:06:51.581564@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:07:14.563403||measurement||price||2015-12-01 16:07:07.973505@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:07:17.376529||measurement||loadtime||0:00:28.745356||0||1
+2015-12-01 16:07:18.551692||measurement||loadtime||0:00:29.386237||2||1
+2015-12-01 16:07:20.802772||measurement||price||2015-12-01 16:07:15.199860@|@|$118.00@|BLU Studio 7.0 II -Unlocked Smartphone - US GSM - Gold||4||0
+2015-12-01 16:07:21.133583||measurement||price||2015-12-01 16:07:15.721514@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||0
+2015-12-01 16:07:21.626981||measurement||price||2015-12-01 16:07:03.925353@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:07:27.494287||measurement||price||2015-12-01 16:07:07.973505@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:07:28.775466||measurement||loadtime||0:00:27.259780||3||0
+2015-12-01 16:07:32.112275||measurement||price||2015-12-01 16:07:25.760440@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 16:07:33.137840||measurement||price||2015-12-01 16:07:15.199860@|@|$199.00@|BLU Vivo Air LTE Smartphone - GSM Unlocked - Black||4||0
+2015-12-01 16:07:33.606978||measurement||price||2015-12-01 16:07:15.721514@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||1||0
+2015-12-01 16:07:34.680001||measurement||loadtime||0:00:28.859639||5||1
+2015-12-01 16:07:40.243270||measurement||loadtime||0:00:26.972101||4||0
+2015-12-01 16:07:40.716552||measurement||loadtime||0:00:27.858658||1||0
+2015-12-01 16:07:41.126356||error||collecting ads||Error||0||1
+2015-12-01 16:07:41.337511||measurement||price||2015-12-01 16:07:35.818515@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:07:45.113914||measurement||price||2015-12-01 16:07:25.760440@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 16:07:52.335895||measurement||loadtime||0:00:28.778995||2||1
+2015-12-01 16:07:52.540691||measurement||price||2015-12-01 16:07:47.018741@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:07:53.681841||measurement||price||2015-12-01 16:07:35.818515@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:07:55.535274||measurement||price||2015-12-01 16:07:48.710927@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:07:58.382987||error||collecting ads||Error||5||1
+2015-12-01 16:08:00.797052||measurement||loadtime||0:00:27.017869||3||0
+2015-12-01 16:08:03.466255||error||collecting ads||Error||1||0
+2015-12-01 16:08:04.860368||measurement||price||2015-12-01 16:07:47.018741@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:08:06.327069||measurement||price||2015-12-01 16:07:59.872568@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:08:08.803381||measurement||price||2015-12-01 16:07:48.710927@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:08:11.945582||measurement||loadtime||0:00:26.698447||4||0
+2015-12-01 16:08:12.260659||measurement||price||2015-12-01 16:08:05.651390@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:08:13.412223||measurement||price||2015-12-01 16:08:08.029018@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:08:16.043147||measurement||loadtime||0:00:29.911584||0||1
+2015-12-01 16:08:19.259066||measurement||price||2015-12-01 16:07:59.872568@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:08:24.702957||measurement||price||2015-12-01 16:08:19.121098@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 16:08:25.101331||measurement||price||2015-12-01 16:08:05.651390@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:08:25.746705||measurement||price||2015-12-01 16:08:08.029018@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:08:25.936527||error||collecting ads||Error||1||0
+2015-12-01 16:08:26.491626||measurement||loadtime||0:00:29.150484||2||1
+2015-12-01 16:08:30.330665||measurement||price||2015-12-01 16:08:23.347068@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:08:32.319182||measurement||loadtime||0:00:28.932004||5||1
+2015-12-01 16:08:32.859158||measurement||loadtime||0:00:27.056879||3||0
+2015-12-01 16:08:37.028904||measurement||price||2015-12-01 16:08:19.121098@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 16:08:38.492534||measurement||price||2015-12-01 16:08:33.120904@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 16:08:40.477041||measurement||price||2015-12-01 16:08:33.750578@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:08:43.180473||measurement||price||2015-12-01 16:08:23.347068@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:08:44.142666||measurement||loadtime||0:00:27.191845||4||0
+2015-12-01 16:08:45.480275||measurement||price||2015-12-01 16:08:40.142812@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:08:46.528967||measurement||price||2015-12-01 16:08:39.886577@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:08:50.394490||measurement||loadtime||0:00:29.346114||0||1
+2015-12-01 16:08:50.839608||measurement||price||2015-12-01 16:08:33.120904@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 16:08:53.375697||measurement||price||2015-12-01 16:08:33.750578@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:08:56.314800||measurement||price||2015-12-01 16:08:50.696432@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:08:57.828724||measurement||price||2015-12-01 16:08:40.142812@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:08:57.951157||measurement||loadtime||0:00:27.009395||1||0
+2015-12-01 16:08:59.354309||measurement||price||2015-12-01 16:08:39.886577@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:09:00.579190||measurement||loadtime||0:00:29.082340||2||1
+2015-12-01 16:09:04.174167||measurement||price||2015-12-01 16:08:57.664164@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:09:04.947148||measurement||loadtime||0:00:27.082806||3||0
+2015-12-01 16:09:06.575449||measurement||loadtime||0:00:29.251059||5||1
+2015-12-01 16:09:08.645900||measurement||price||2015-12-01 16:08:50.696432@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:09:10.573524||measurement||price||2015-12-01 16:09:05.152668@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:09:15.752766||measurement||loadtime||0:00:26.604880||4||0
+2015-12-01 16:09:17.007614||measurement||price||2015-12-01 16:08:57.664164@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:09:17.532466||measurement||price||2015-12-01 16:09:12.125234@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:09:22.912194||measurement||price||2015-12-01 16:09:05.152668@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:09:24.235615||measurement||loadtime||0:00:28.835927||0||1
+2015-12-01 16:09:24.239252||error||collecting ads||Error||2||1
+2015-12-01 16:09:29.835749||measurement||price||2015-12-01 16:09:12.125234@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:09:30.023198||measurement||loadtime||0:00:27.066816||1||0
+2015-12-01 16:09:30.517457||error||collecting ads||Error||5||1
+2015-12-01 16:09:36.923142||measurement||loadtime||0:00:26.970829||3||0
+2015-12-01 16:09:37.845068||error||collecting ads||Error||4||0
+2015-12-01 16:09:38.451732||measurement||price||2015-12-01 16:09:31.609770@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:09:42.596153||measurement||price||2015-12-01 16:09:37.174192@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 16:09:44.964427||measurement||price||2015-12-01 16:09:38.799446@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||5||1
+2015-12-01 16:09:47.947202||error||collecting ads||Error||2||1
+2015-12-01 16:09:49.911833||measurement||price||2015-12-01 16:09:44.528818@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:09:50.139507||measurement||price||2015-12-01 16:09:44.501068@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:09:51.493196||measurement||price||2015-12-01 16:09:31.609770@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:09:54.939858||measurement||price||2015-12-01 16:09:37.174192@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 16:09:57.819974||measurement||price||2015-12-01 16:09:38.799446@|Black  Decker@|$69.68@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||5||1
+2015-12-01 16:09:58.696430||measurement||loadtime||0:00:29.455598||0||1
+2015-12-01 16:10:01.632666||measurement||price||2015-12-01 16:09:55.174358@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 16:10:02.047465||measurement||loadtime||0:00:27.023015||1||0
+2015-12-01 16:10:02.215930||measurement||price||2015-12-01 16:09:44.528818@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:10:02.493359||measurement||price||2015-12-01 16:09:44.501068@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:10:05.020489||measurement||loadtime||0:00:29.497813||5||1
+2015-12-01 16:10:09.308180||measurement||loadtime||0:00:27.382860||3||0
+2015-12-01 16:10:09.607161||measurement||loadtime||0:00:26.756899||4||0
+2015-12-01 16:10:12.595664||measurement||price||2015-12-01 16:10:05.981957@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:10:14.476388||measurement||price||2015-12-01 16:09:55.174358@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 16:10:18.826889||measurement||price||2015-12-01 16:10:12.340164@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 16:10:21.732903||measurement||loadtime||0:00:28.780463||2||1
+2015-12-01 16:10:21.809267||measurement||price||2015-12-01 16:10:16.472201@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:10:24.635190||error||collecting ads||Error||1||0
+2015-12-01 16:10:25.635790||measurement||price||2015-12-01 16:10:05.981957@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:10:31.653963||measurement||price||2015-12-01 16:10:12.340164@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 16:10:31.804868||error||collecting ads||Error||4||0
+2015-12-01 16:10:32.836621||measurement||loadtime||0:00:29.137439||0||1
+2015-12-01 16:10:34.161079||measurement||price||2015-12-01 16:10:16.472201@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:10:35.714085||measurement||price||2015-12-01 16:10:28.929092@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:10:38.861157||measurement||loadtime||0:00:28.837984||5||1
+2015-12-01 16:10:41.235152||measurement||loadtime||0:00:26.925750||3||0
+2015-12-01 16:10:44.059472||measurement||price||2015-12-01 16:10:38.384691@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 16:10:47.001141||measurement||price||2015-12-01 16:10:40.183835@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:10:47.082244||error||collecting ads||Error||1||0
+2015-12-01 16:10:48.693059||measurement||price||2015-12-01 16:10:28.929092@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:10:52.570500||measurement||price||2015-12-01 16:10:46.058967@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 16:10:53.749373||measurement||price||2015-12-01 16:10:48.274870@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:10:55.929338||measurement||loadtime||0:00:29.194189||2||1
+2015-12-01 16:10:56.391960||measurement||price||2015-12-01 16:10:38.384691@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 16:10:59.572869||measurement||price||2015-12-01 16:10:54.181176@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 16:10:59.938870||measurement||price||2015-12-01 16:10:40.183835@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:11:03.499183||measurement||loadtime||0:00:26.689099||4||0
+2015-12-01 16:11:03.499294||event||progress-marker||measurement-end||4||0
+2015-12-01 16:11:05.475204||measurement||price||2015-12-01 16:10:46.058967@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 16:11:06.097724||measurement||price||2015-12-01 16:10:48.274870@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:11:07.167450||measurement||loadtime||0:00:29.328296||0||1
+2015-12-01 16:11:09.486615||measurement||price||2015-12-01 16:11:03.136328@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 16:11:11.909710||measurement||price||2015-12-01 16:10:54.181176@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 16:11:12.672525||measurement||loadtime||0:00:28.808825||5||1
+2015-12-01 16:11:13.219212||measurement||loadtime||0:00:26.978868||3||0
+2015-12-01 16:11:19.003179||measurement||loadtime||0:00:26.915737||1||0
+2015-12-01 16:11:19.003269||event||progress-marker||measurement-end||1||0
+2015-12-01 16:11:21.118619||measurement||price||2015-12-01 16:11:14.432128@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 16:11:22.473749||measurement||price||2015-12-01 16:11:03.136328@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 16:11:26.202177||measurement||price||2015-12-01 16:11:20.763679@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:11:29.667823||measurement||loadtime||0:00:28.736539||2||1
+2015-12-01 16:11:33.987193||measurement||price||2015-12-01 16:11:14.432128@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 16:11:36.561260||error||collecting ads||Error||5||1
+2015-12-01 16:11:38.559928||measurement||price||2015-12-01 16:11:20.763679@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:11:41.222854||measurement||loadtime||0:00:29.053518||0||1
+2015-12-01 16:11:43.224530||measurement||price||2015-12-01 16:11:36.817769@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 16:11:45.675155||measurement||loadtime||0:00:27.450738||3||0
+2015-12-01 16:11:50.425457||measurement||price||2015-12-01 16:11:43.838809@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:11:55.242152||measurement||price||2015-12-01 16:11:48.519144@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:11:56.148836||measurement||price||2015-12-01 16:11:36.817769@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 16:11:58.261461||measurement||price||2015-12-01 16:11:52.744479@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:12:03.299253||measurement||price||2015-12-01 16:11:43.838809@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:12:03.350064||measurement||loadtime||0:00:28.677004||2||1
+2015-12-01 16:12:08.069912||measurement||price||2015-12-01 16:11:48.519144@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:12:10.499909||measurement||loadtime||0:00:28.933416||5||1
+2015-12-01 16:12:10.615593||measurement||price||2015-12-01 16:11:52.744479@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:12:15.270084||measurement||loadtime||0:00:29.041987||0||1
+2015-12-01 16:12:17.735897||measurement||loadtime||0:00:27.056754||3||0
+2015-12-01 16:12:17.735978||event||progress-marker||measurement-end||3||0
+2015-12-01 16:12:24.230539||measurement||price||2015-12-01 16:12:17.849029@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:12:27.080823||error||collecting ads||Error||2||1
+2015-12-01 16:12:29.599705||measurement||price||2015-12-01 16:12:23.112916@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:12:37.057103||measurement||price||2015-12-01 16:12:17.849029@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:12:40.822086||measurement||price||2015-12-01 16:12:34.237441@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 16:12:42.539101||measurement||price||2015-12-01 16:12:23.112916@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:12:44.240446||measurement||loadtime||0:00:28.735301||5||1
+2015-12-01 16:12:49.734826||measurement||loadtime||0:00:29.459499||0||1
+2015-12-01 16:12:53.648750||measurement||price||2015-12-01 16:12:34.237441@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 16:12:58.284548||measurement||price||2015-12-01 16:12:51.696276@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:13:00.859174||measurement||loadtime||0:00:28.773103||2||1
+2015-12-01 16:13:00.859304||event||progress-marker||measurement-end||2||1
+2015-12-01 16:13:03.691797||measurement||price||2015-12-01 16:12:56.975902@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:13:11.253944||measurement||price||2015-12-01 16:12:51.696276@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:13:16.497684||measurement||price||2015-12-01 16:12:56.975902@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:13:18.450805||measurement||loadtime||0:00:29.209405||5||1
+2015-12-01 16:13:23.695195||measurement||loadtime||0:00:28.955120||0||1
+2015-12-01 16:13:23.695320||event||progress-marker||measurement-end||0||1
+2015-12-01 16:13:32.338040||measurement||price||2015-12-01 16:13:25.711709@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:13:45.332791||measurement||price||2015-12-01 16:13:25.711709@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:13:52.544917||measurement||loadtime||0:00:29.088856||5||1
+2015-12-01 16:14:06.017275||measurement||price||2015-12-01 16:13:59.763570@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:14:18.837449||measurement||price||2015-12-01 16:13:59.763570@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:14:26.054525||measurement||loadtime||0:00:28.504362||5||1
+2015-12-01 16:14:26.054700||event||progress-marker||measurement-end||5||1
+2015-12-01 16:14:26.547175||meta||block_id end||9
+2015-12-01 16:14:26.547523||meta||block_id start||10
+2015-12-01 16:14:26.547553||meta||assignment||5@|4@|2@|3@|1@|0
+2015-12-01 16:14:28.099980||event||progress-marker||training-start||4||0
+2015-12-01 16:14:28.100073||event||progress-marker||training-end||4||0
+2015-12-01 16:14:28.144956||event||progress-marker||training-start||2||0
+2015-12-01 16:14:28.145220||event||progress-marker||training-end||2||0
+2015-12-01 16:14:33.129370||event||progress-marker||measurement-start||4||0
+2015-12-01 16:14:33.175524||event||progress-marker||measurement-start||2||0
+2015-12-01 16:14:46.451689||measurement||price||2015-12-01 16:14:40.462306@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 16:14:48.979062||measurement||price||2015-12-01 16:14:40.731374@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 16:14:58.791728||measurement||price||2015-12-01 16:14:40.462306@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 16:15:01.327796||measurement||price||2015-12-01 16:14:40.731374@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||2||0
+2015-12-01 16:15:03.399570||event||progress-marker||training-start||1||1
+2015-12-01 16:15:03.399711||event||progress-marker||training-end||1||1
+2015-12-01 16:15:05.910069||measurement||loadtime||0:00:27.777039||4||0
+2015-12-01 16:15:08.429818||event||progress-marker||measurement-start||1||1
+2015-12-01 16:15:08.438452||measurement||loadtime||0:00:30.259326||2||0
+2015-12-01 16:15:18.157493||measurement||price||2015-12-01 16:15:12.609300@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 16:15:21.267945||measurement||price||2015-12-01 16:15:15.610759@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:15:30.482979||measurement||price||2015-12-01 16:15:12.609300@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 16:15:32.791376||error||collecting ads||Error||1||1
+2015-12-01 16:15:33.059999||event||progress-marker||training-start||3||1
+2015-12-01 16:15:33.060143||event||progress-marker||training-end||3||1
+2015-12-01 16:15:33.560932||measurement||price||2015-12-01 16:15:15.610759@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:15:34.779792||event||progress-marker||training-start||0||1
+2015-12-01 16:15:34.779938||event||progress-marker||training-end||0||1
+2015-12-01 16:15:37.595187||measurement||loadtime||0:00:26.679898||4||0
+2015-12-01 16:15:38.090181||event||progress-marker||measurement-start||3||1
+2015-12-01 16:15:39.817372||event||progress-marker||measurement-start||0||1
+2015-12-01 16:15:40.657044||measurement||loadtime||0:00:27.217083||2||0
+2015-12-01 16:15:46.446883||measurement||price||2015-12-01 16:15:39.923049@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:15:49.789739||measurement||price||2015-12-01 16:15:44.248020@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:15:52.728111||measurement||price||2015-12-01 16:15:46.273867@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:15:52.988093||measurement||price||2015-12-01 16:15:47.366763@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:15:54.055586||measurement||price||2015-12-01 16:15:47.796010@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:16:01.356144||measurement||price||2015-12-01 16:15:39.923049@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:16:02.134760||measurement||price||2015-12-01 16:15:44.248020@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:16:05.336403||measurement||price||2015-12-01 16:15:47.366763@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:16:08.598153||measurement||loadtime||0:00:30.801523||1||1
+2015-12-01 16:16:09.245420||measurement||loadtime||0:00:26.645042||4||0
+2015-12-01 16:16:12.454362||measurement||loadtime||0:00:26.792096||2||0
+2015-12-01 16:16:19.910865||measurement||price||2015-12-01 16:15:47.796010@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:16:20.910392||measurement||price||2015-12-01 16:15:46.273867@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:16:27.139179||measurement||loadtime||0:00:42.317121||0||1
+2015-12-01 16:16:28.168897||measurement||loadtime||0:00:45.073502||3||1
+2015-12-01 16:16:31.438175||measurement||price||2015-12-01 16:16:26.074357@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:16:40.811844||measurement||price||2015-12-01 16:16:34.512117@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:16:41.208626||error||collecting ads||Error||4||0
+2015-12-01 16:16:41.935584||measurement||price||2015-12-01 16:16:35.580016@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:16:42.003307||error||collecting ads||Error||1||1
+2015-12-01 16:16:43.773526||measurement||price||2015-12-01 16:16:26.074357@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:16:50.885225||measurement||loadtime||0:00:33.425640||2||0
+2015-12-01 16:16:53.474440||measurement||price||2015-12-01 16:16:47.873614@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 16:16:53.799154||measurement||price||2015-12-01 16:16:34.512117@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:16:54.784956||measurement||price||2015-12-01 16:16:35.580016@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:16:55.695100||measurement||price||2015-12-01 16:16:49.141312@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:17:01.023316||measurement||loadtime||0:00:28.880061||0||1
+2015-12-01 16:17:01.972308||measurement||loadtime||0:00:28.800631||3||1
+2015-12-01 16:17:03.129891||measurement||price||2015-12-01 16:16:57.467665@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:17:05.828780||measurement||price||2015-12-01 16:16:47.873614@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 16:17:08.551596||measurement||price||2015-12-01 16:16:49.141312@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:17:12.937957||measurement||loadtime||0:00:26.724099||4||0
+2015-12-01 16:17:15.106897||measurement||price||2015-12-01 16:17:08.466639@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:17:15.477891||measurement||price||2015-12-01 16:16:57.467665@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:17:15.767210||measurement||loadtime||0:00:28.758693||1||1
+2015-12-01 16:17:15.885721||measurement||price||2015-12-01 16:17:09.292814@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:17:22.595156||measurement||loadtime||0:00:26.708020||2||0
+2015-12-01 16:17:25.130066||measurement||price||2015-12-01 16:17:19.531700@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 16:17:27.956871||measurement||price||2015-12-01 16:17:08.466639@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:17:28.846548||measurement||price||2015-12-01 16:17:09.292814@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:17:29.565653||measurement||price||2015-12-01 16:17:23.008117@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 16:17:35.191934||measurement||loadtime||0:00:29.163049||0||1
+2015-12-01 16:17:35.686282||measurement||price||2015-12-01 16:17:30.071567@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 16:17:36.047717||measurement||loadtime||0:00:29.072544||3||1
+2015-12-01 16:17:37.459298||measurement||price||2015-12-01 16:17:19.531700@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 16:17:42.416866||measurement||price||2015-12-01 16:17:23.008117@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 16:17:44.575174||measurement||loadtime||0:00:26.634456||4||0
+2015-12-01 16:17:48.033371||measurement||price||2015-12-01 16:17:30.071567@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||2||0
+2015-12-01 16:17:48.944489||measurement||price||2015-12-01 16:17:42.357638@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 16:17:49.651460||measurement||loadtime||0:00:28.877618||1||1
+2015-12-01 16:17:49.935220||measurement||price||2015-12-01 16:17:43.448650@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:17:55.144547||measurement||loadtime||0:00:27.545801||2||0
+2015-12-01 16:17:56.802516||measurement||price||2015-12-01 16:17:51.243049@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 16:18:01.793526||measurement||price||2015-12-01 16:17:42.357638@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 16:18:02.908122||measurement||price||2015-12-01 16:17:43.448650@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:18:03.233223||measurement||price||2015-12-01 16:17:56.978208@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:18:07.494236||measurement||price||2015-12-01 16:18:01.839257@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:18:08.999072||measurement||loadtime||0:00:28.801858||0||1
+2015-12-01 16:18:09.163647||measurement||price||2015-12-01 16:17:51.243049@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 16:18:10.107295||measurement||loadtime||0:00:29.054348||3||1
+2015-12-01 16:18:16.015793||measurement||price||2015-12-01 16:17:56.978208@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:18:16.266059||measurement||loadtime||0:00:26.685681||4||0
+2015-12-01 16:18:19.842471||measurement||price||2015-12-01 16:18:01.839257@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:18:22.982956||measurement||price||2015-12-01 16:18:16.419550@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:18:23.231555||measurement||loadtime||0:00:28.574862||1||1
+2015-12-01 16:18:26.954086||measurement||loadtime||0:00:26.804308||2||0
+2015-12-01 16:18:33.918097||error||collecting ads||Error||3||1
+2015-12-01 16:18:36.023843||measurement||price||2015-12-01 16:18:16.419550@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:18:37.093575||measurement||price||2015-12-01 16:18:30.611836@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:18:38.548252||error||collecting ads||Error||4||0
+2015-12-01 16:18:39.215630||measurement||price||2015-12-01 16:18:33.648622@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:18:43.226379||measurement||loadtime||0:00:29.223433||0||1
+2015-12-01 16:18:47.727838||measurement||price||2015-12-01 16:18:41.139854@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:18:49.914646||measurement||price||2015-12-01 16:18:30.611836@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:18:50.957914||measurement||price||2015-12-01 16:18:45.320962@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:18:51.559668||measurement||price||2015-12-01 16:18:33.648622@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:18:57.129540||measurement||loadtime||0:00:28.892746||1||1
+2015-12-01 16:18:57.368734||measurement||price||2015-12-01 16:18:50.836335@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:18:58.682296||measurement||loadtime||0:00:26.723143||2||0
+2015-12-01 16:19:00.596253||measurement||price||2015-12-01 16:18:41.139854@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:19:03.298370||measurement||price||2015-12-01 16:18:45.320962@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:19:07.827380||measurement||loadtime||0:00:28.904041||3||1
+2015-12-01 16:19:10.410320||measurement||loadtime||0:00:26.856853||4||0
+2015-12-01 16:19:10.413862||measurement||price||2015-12-01 16:18:50.836335@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:19:10.780227||measurement||price||2015-12-01 16:19:04.450142@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:19:11.122433||measurement||price||2015-12-01 16:19:05.411840@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:19:17.608952||measurement||loadtime||0:00:29.377353||0||1
+2015-12-01 16:19:22.816131||measurement||price||2015-12-01 16:19:17.202202@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:19:23.462028||measurement||price||2015-12-01 16:19:05.411840@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:19:23.684060||measurement||price||2015-12-01 16:19:04.450142@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:19:30.567216||measurement||loadtime||0:00:26.879687||2||0
+2015-12-01 16:19:30.904462||measurement||loadtime||0:00:28.774415||1||1
+2015-12-01 16:19:31.301358||measurement||price||2015-12-01 16:19:25.002488@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:19:31.598974||error||collecting ads||Error||3||1
+2015-12-01 16:19:35.136263||measurement||price||2015-12-01 16:19:17.202202@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:19:42.247167||measurement||loadtime||0:00:26.831670||4||0
+2015-12-01 16:19:47.949308||measurement||price||2015-12-01 16:19:25.002488@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:19:55.180480||measurement||loadtime||0:00:32.566292||0||1
+2015-12-01 16:19:57.154427||measurement||price||2015-12-01 16:19:51.803505@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 16:20:02.114295||measurement||price||2015-12-01 16:19:56.744008@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:20:05.909316||measurement||price||2015-12-01 16:19:52.780757@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 16:20:09.589083||measurement||price||2015-12-01 16:19:51.803505@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||2||0
+2015-12-01 16:20:12.944253||measurement||price||2015-12-01 16:19:56.120423@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:20:14.468381||measurement||price||2015-12-01 16:19:56.744008@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:20:16.720960||measurement||loadtime||0:00:41.148503||2||0
+2015-12-01 16:20:18.702624||measurement||price||2015-12-01 16:19:52.780757@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 16:20:21.578759||measurement||loadtime||0:00:34.326398||4||0
+2015-12-01 16:20:25.879175||measurement||loadtime||0:00:49.274923||3||1
+2015-12-01 16:20:26.882051||measurement||price||2015-12-01 16:19:56.120423@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:20:30.590898||error||collecting ads||Error||0||1
+2015-12-01 16:20:34.100133||measurement||loadtime||0:00:58.190441||1||1
+2015-12-01 16:20:35.109903||measurement||price||2015-12-01 16:20:29.751413@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:20:36.273931||measurement||price||2015-12-01 16:20:30.892163@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||0
+2015-12-01 16:20:39.735082||measurement||price||2015-12-01 16:20:33.299281@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:20:44.254923||measurement||price||2015-12-01 16:20:37.853936@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 16:20:47.421222||measurement||price||2015-12-01 16:20:29.751413@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:20:48.184778||measurement||price||2015-12-01 16:20:41.804873@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||1
+2015-12-01 16:20:48.652131||measurement||price||2015-12-01 16:20:30.892163@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||0
+2015-12-01 16:20:52.508186||measurement||price||2015-12-01 16:20:33.299281@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:20:54.514330||measurement||loadtime||0:00:32.788848||2||0
+2015-12-01 16:20:55.760547||measurement||loadtime||0:00:29.177393||4||0
+2015-12-01 16:20:57.226720||measurement||price||2015-12-01 16:20:37.853936@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 16:20:59.724808||measurement||loadtime||0:00:28.841653||3||1
+2015-12-01 16:21:01.057456||measurement||price||2015-12-01 16:20:41.804873@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||1||1
+2015-12-01 16:21:04.428903||measurement||loadtime||0:00:28.832736||0||1
+2015-12-01 16:21:06.869123||measurement||price||2015-12-01 16:21:01.355242@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:21:08.307158||measurement||loadtime||0:00:29.201808||1||1
+2015-12-01 16:21:13.433387||measurement||price||2015-12-01 16:21:07.081450@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:21:18.334984||measurement||price||2015-12-01 16:21:11.817063@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:21:18.555509||error||collecting ads||Error||4||0
+2015-12-01 16:21:19.174583||measurement||price||2015-12-01 16:21:01.355242@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:21:22.381886||measurement||price||2015-12-01 16:21:15.854057@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:21:26.218251||measurement||price||2015-12-01 16:21:07.081450@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:21:26.287165||measurement||loadtime||0:00:26.767588||2||0
+2015-12-01 16:21:30.838534||measurement||price||2015-12-01 16:21:25.200006@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:21:31.285982||measurement||price||2015-12-01 16:21:11.817063@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:21:33.452084||measurement||loadtime||0:00:28.722069||3||1
+2015-12-01 16:21:35.203004||measurement||price||2015-12-01 16:21:15.854057@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:21:38.484969||measurement||price||2015-12-01 16:21:32.923130@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:21:38.487139||measurement||loadtime||0:00:29.053027||0||1
+2015-12-01 16:21:42.433074||measurement||loadtime||0:00:29.121881||1||1
+2015-12-01 16:21:43.175776||measurement||price||2015-12-01 16:21:25.200006@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:21:50.293352||measurement||loadtime||0:00:26.732627||4||0
+2015-12-01 16:21:50.838044||measurement||price||2015-12-01 16:21:32.923130@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:21:52.141546||measurement||price||2015-12-01 16:21:45.896835@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:21:56.019796||measurement||price||2015-12-01 16:21:49.675336@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:21:57.237973||error||collecting ads||Error||3||1
+2015-12-01 16:21:57.959250||measurement||loadtime||0:00:26.666867||2||0
+2015-12-01 16:22:02.478929||measurement||price||2015-12-01 16:21:56.904591@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:22:05.044943||measurement||price||2015-12-01 16:21:45.896835@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:22:08.856117||measurement||price||2015-12-01 16:21:49.675336@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:22:11.081984||measurement||price||2015-12-01 16:22:04.738910@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:22:12.294141||measurement||loadtime||0:00:28.801781||0||1
+2015-12-01 16:22:14.817388||measurement||price||2015-12-01 16:21:56.904591@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:22:16.105359||measurement||loadtime||0:00:28.670198||1||1
+2015-12-01 16:22:21.927184||measurement||loadtime||0:00:26.632885||4||0
+2015-12-01 16:22:22.264244||error||collecting ads||Error||3||1
+2015-12-01 16:22:23.404500||measurement||price||2015-12-01 16:22:04.738910@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:22:29.881088||measurement||price||2015-12-01 16:22:23.314236@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:22:30.515173||measurement||loadtime||0:00:27.552509||2||0
+2015-12-01 16:22:34.262509||measurement||price||2015-12-01 16:22:28.679647@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 16:22:36.118369||error||collecting ads||Error||0||1
+2015-12-01 16:22:36.356256||measurement||price||2015-12-01 16:22:29.906268@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:22:42.780367||measurement||price||2015-12-01 16:22:23.314236@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:22:46.597533||measurement||price||2015-12-01 16:22:28.679647@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 16:22:49.265307||measurement||price||2015-12-01 16:22:29.906268@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:22:49.974059||measurement||loadtime||0:00:28.866865||1||1
+2015-12-01 16:22:50.550690||measurement||price||2015-12-01 16:22:44.307240@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:22:52.747734||error||collecting ads||Error||2||0
+2015-12-01 16:22:53.707193||measurement||loadtime||0:00:26.774806||4||0
+2015-12-01 16:22:56.526098||measurement||loadtime||0:00:29.258944||3||1
+2015-12-01 16:23:03.357875||measurement||price||2015-12-01 16:22:44.307240@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:23:03.409899||measurement||price||2015-12-01 16:22:57.123618@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:23:04.915542||measurement||price||2015-12-01 16:22:59.359762@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:23:10.269888||measurement||price||2015-12-01 16:23:03.704865@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:23:10.577711||measurement||loadtime||0:00:29.454116||0||1
+2015-12-01 16:23:15.933512||error||collecting ads||Error||4||0
+2015-12-01 16:23:16.279900||measurement||price||2015-12-01 16:22:57.123618@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:23:17.255068||measurement||price||2015-12-01 16:22:59.359762@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:23:23.327842||measurement||price||2015-12-01 16:23:03.704865@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:23:23.491164||measurement||loadtime||0:00:28.512010||1||1
+2015-12-01 16:23:24.360497||measurement||loadtime||0:00:26.607550||2||0
+2015-12-01 16:23:25.078072||measurement||price||2015-12-01 16:23:18.353843@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:23:30.547522||measurement||loadtime||0:00:29.016230||3||1
+2015-12-01 16:23:38.030759||measurement||price||2015-12-01 16:23:18.353843@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:23:38.176097||error||collecting ads||Error||4||0
+2015-12-01 16:23:41.687309||measurement||price||2015-12-01 16:23:33.875555@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:23:45.243170||measurement||loadtime||0:00:29.664842||0||1
+2015-12-01 16:23:45.652735||measurement||price||2015-12-01 16:23:38.972679@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:23:49.192371||error||collecting ads||Error||2||0
+2015-12-01 16:23:50.445009||measurement||price||2015-12-01 16:23:44.849601@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 16:23:54.560608||measurement||price||2015-12-01 16:23:33.875555@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:23:58.524794||measurement||price||2015-12-01 16:23:38.972679@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:23:59.115996||measurement||price||2015-12-01 16:23:52.651227@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:24:01.460271||measurement||price||2015-12-01 16:23:55.828631@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:24:01.777263||measurement||loadtime||0:00:33.280866||1||1
+2015-12-01 16:24:02.772635||measurement||price||2015-12-01 16:23:44.849601@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 16:24:05.722441||measurement||loadtime||0:00:30.169693||3||1
+2015-12-01 16:24:09.891164||measurement||loadtime||0:00:26.709856||4||0
+2015-12-01 16:24:11.964731||measurement||price||2015-12-01 16:23:52.651227@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:24:13.821802||measurement||price||2015-12-01 16:23:55.828631@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:24:15.517276||measurement||price||2015-12-01 16:24:08.952131@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:24:19.179147||measurement||loadtime||0:00:28.930786||0||1
+2015-12-01 16:24:20.937471||measurement||loadtime||0:00:26.739903||2||0
+2015-12-01 16:24:22.175345||measurement||price||2015-12-01 16:24:16.562146@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 16:24:28.373046||measurement||price||2015-12-01 16:24:08.952131@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:24:29.827517||error||collecting ads||Error||3||1
+2015-12-01 16:24:33.218912||measurement||price||2015-12-01 16:24:27.601926@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:24:34.483828||measurement||price||2015-12-01 16:24:16.562146@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 16:24:35.603161||measurement||loadtime||0:00:28.820651||1||1
+2015-12-01 16:24:41.595169||measurement||loadtime||0:00:26.698806||4||0
+2015-12-01 16:24:41.595252||event||progress-marker||measurement-end||4||0
+2015-12-01 16:24:43.062991||error||collecting ads||Error||0||1
+2015-12-01 16:24:43.897619||measurement||price||2015-12-01 16:24:37.048092@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 16:24:45.525370||measurement||price||2015-12-01 16:24:27.601926@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:24:49.327621||measurement||price||2015-12-01 16:24:42.918086@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:24:52.635756||measurement||loadtime||0:00:26.695045||2||0
+2015-12-01 16:24:56.920012||measurement||price||2015-12-01 16:24:50.407389@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:24:56.950802||measurement||price||2015-12-01 16:24:37.048092@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 16:25:02.111465||measurement||price||2015-12-01 16:24:42.918086@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:25:04.179128||measurement||loadtime||0:00:29.346413||3||1
+2015-12-01 16:25:04.839554||measurement||price||2015-12-01 16:24:59.232775@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:25:09.328364||measurement||loadtime||0:00:28.719994||1||1
+2015-12-01 16:25:09.822617||measurement||price||2015-12-01 16:24:50.407389@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:25:17.039156||measurement||loadtime||0:00:28.970934||0||1
+2015-12-01 16:25:17.185855||measurement||price||2015-12-01 16:24:59.232775@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:25:17.994139||measurement||price||2015-12-01 16:25:11.550501@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:25:22.751002||measurement||price||2015-12-01 16:25:16.355999@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:25:24.308272||measurement||loadtime||0:00:26.669546||2||0
+2015-12-01 16:25:24.308396||event||progress-marker||measurement-end||2||0
+2015-12-01 16:25:31.084459||measurement||price||2015-12-01 16:25:11.550501@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:25:31.149103||measurement||price||2015-12-01 16:25:24.405467@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:25:35.608426||measurement||price||2015-12-01 16:25:16.355999@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:25:38.269324||measurement||loadtime||0:00:29.084982||3||1
+2015-12-01 16:25:42.808016||measurement||loadtime||0:00:28.474423||1||1
+2015-12-01 16:25:44.023699||measurement||price||2015-12-01 16:25:24.405467@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:25:51.231203||measurement||loadtime||0:00:29.186838||0||1
+2015-12-01 16:25:56.394278||measurement||price||2015-12-01 16:25:50.050585@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:26:02.220401||error||collecting ads||Error||3||1
+2015-12-01 16:26:05.170946||measurement||price||2015-12-01 16:25:58.477631@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:26:09.182634||measurement||price||2015-12-01 16:25:50.050585@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:26:16.102776||measurement||price||2015-12-01 16:26:09.586167@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:26:16.398324||measurement||loadtime||0:00:28.585076||1||1
+2015-12-01 16:26:18.195137||measurement||price||2015-12-01 16:25:58.477631@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:26:25.407206||measurement||loadtime||0:00:29.172044||0||1
+2015-12-01 16:26:28.963889||measurement||price||2015-12-01 16:26:09.586167@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:26:30.162047||measurement||price||2015-12-01 16:26:23.783921@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:26:36.162988||measurement||loadtime||0:00:28.937369||3||1
+2015-12-01 16:26:36.163142||event||progress-marker||measurement-end||3||1
+2015-12-01 16:26:39.232901||measurement||price||2015-12-01 16:26:32.669252@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 16:26:42.964825||measurement||price||2015-12-01 16:26:23.783921@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:26:50.193812||measurement||loadtime||0:00:28.790248||1||1
+2015-12-01 16:26:50.193955||event||progress-marker||measurement-end||1||1
+2015-12-01 16:26:52.105064||measurement||price||2015-12-01 16:26:32.669252@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 16:26:59.291685||measurement||loadtime||0:00:28.879167||0||1
+2015-12-01 16:26:59.291819||event||progress-marker||measurement-end||0||1
+2015-12-01 16:26:59.775991||meta||block_id end||10
+2015-12-01 16:26:59.776289||meta||block_id start||11
+2015-12-01 16:26:59.776319||meta||assignment||5@|0@|2@|3@|4@|1
+2015-12-01 16:27:01.341860||event||progress-marker||training-start||2||0
+2015-12-01 16:27:01.341969||event||progress-marker||training-end||2||0
+2015-12-01 16:27:01.399091||event||progress-marker||training-start||0||0
+2015-12-01 16:27:01.399192||event||progress-marker||training-end||0||0
+2015-12-01 16:27:01.401267||event||progress-marker||training-start||5||0
+2015-12-01 16:27:01.401375||event||progress-marker||training-end||5||0
+2015-12-01 16:27:06.375912||event||progress-marker||measurement-start||2||0
+2015-12-01 16:27:06.435532||event||progress-marker||measurement-start||5||0
+2015-12-01 16:27:06.435844||event||progress-marker||measurement-start||0||0
+2015-12-01 16:27:19.887158||measurement||price||2015-12-01 16:27:13.740411@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:27:20.016413||measurement||price||2015-12-01 16:27:14.112439@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:27:20.460873||measurement||price||2015-12-01 16:27:13.691452@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 16:27:32.235291||measurement||price||2015-12-01 16:27:13.740411@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:27:32.370642||measurement||price||2015-12-01 16:27:14.112439@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:27:32.808648||measurement||price||2015-12-01 16:27:13.691452@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 16:27:39.342018||measurement||loadtime||0:00:27.902840||0||0
+2015-12-01 16:27:39.474062||measurement||loadtime||0:00:28.094906||2||0
+2015-12-01 16:27:39.909258||measurement||loadtime||0:00:28.470083||5||0
+2015-12-01 16:27:51.873247||measurement||price||2015-12-01 16:27:46.007948@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:27:52.248678||measurement||price||2015-12-01 16:27:46.530498@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||2||0
+2015-12-01 16:27:52.458418||measurement||price||2015-12-01 16:27:46.622813@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 16:28:04.222949||measurement||price||2015-12-01 16:27:46.007948@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:28:04.585514||measurement||price||2015-12-01 16:27:46.530498@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||2||0
+2015-12-01 16:28:04.774728||measurement||price||2015-12-01 16:27:46.622813@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 16:28:11.332661||measurement||loadtime||0:00:26.985422||0||0
+2015-12-01 16:28:11.695177||measurement||loadtime||0:00:27.215920||2||0
+2015-12-01 16:28:11.891396||measurement||loadtime||0:00:26.981922||5||0
+2015-12-01 16:28:23.590726||measurement||price||2015-12-01 16:28:17.981599@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 16:28:24.386219||measurement||price||2015-12-01 16:28:18.687709@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:28:24.622613||measurement||price||2015-12-01 16:28:18.980025@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||5||0
+2015-12-01 16:28:35.925786||measurement||price||2015-12-01 16:28:17.981599@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 16:28:36.725642||measurement||price||2015-12-01 16:28:18.687709@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:28:36.947219||measurement||price||2015-12-01 16:28:18.980025@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||5||0
+2015-12-01 16:28:43.035184||measurement||loadtime||0:00:26.697305||0||0
+2015-12-01 16:28:43.832905||measurement||loadtime||0:00:27.133754||2||0
+2015-12-01 16:28:44.042522||measurement||loadtime||0:00:27.147375||5||0
+2015-12-01 16:28:47.555181||event||progress-marker||training-start||1||1
+2015-12-01 16:28:47.555337||event||progress-marker||training-end||1||1
+2015-12-01 16:28:52.583953||event||progress-marker||measurement-start||1||1
+2015-12-01 16:28:55.259114||measurement||price||2015-12-01 16:28:49.598645@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:28:56.148996||measurement||price||2015-12-01 16:28:50.498518@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:29:06.338757||error||collecting ads||Error||5||0
+2015-12-01 16:29:06.928659||measurement||price||2015-12-01 16:29:00.776345@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||1||1
+2015-12-01 16:29:07.587082||measurement||price||2015-12-01 16:28:49.598645@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:29:08.476467||measurement||price||2015-12-01 16:28:50.498518@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:29:14.707166||measurement||loadtime||0:00:26.666754||0||0
+2015-12-01 16:29:15.584650||measurement||loadtime||0:00:26.746541||2||0
+2015-12-01 16:29:15.976063||event||progress-marker||training-start||3||1
+2015-12-01 16:29:15.976162||event||progress-marker||training-end||3||1
+2015-12-01 16:29:18.576801||measurement||price||2015-12-01 16:29:13.028263@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 16:29:19.786490||measurement||price||2015-12-01 16:29:00.776345@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||1||1
+2015-12-01 16:29:21.004617||event||progress-marker||measurement-start||3||1
+2015-12-01 16:29:26.987950||measurement||loadtime||0:00:29.398787||1||1
+2015-12-01 16:29:28.314097||measurement||price||2015-12-01 16:29:22.864254@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:29:30.900865||measurement||price||2015-12-01 16:29:13.028263@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 16:29:35.334675||measurement||price||2015-12-01 16:29:28.835200@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 16:29:36.945948||error||collecting ads||Error||0||0
+2015-12-01 16:29:37.105856||event||progress-marker||training-start||4||1
+2015-12-01 16:29:37.105954||event||progress-marker||training-end||4||1
+2015-12-01 16:29:38.008247||measurement||loadtime||0:00:26.664255||5||0
+2015-12-01 16:29:40.664139||measurement||price||2015-12-01 16:29:22.864254@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:29:40.998093||measurement||price||2015-12-01 16:29:34.406592@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:29:42.138115||event||progress-marker||measurement-start||4||1
+2015-12-01 16:29:47.780408||measurement||loadtime||0:00:27.191353||2||0
+2015-12-01 16:29:48.308589||measurement||price||2015-12-01 16:29:28.835200@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 16:29:49.222369||measurement||price||2015-12-01 16:29:43.552258@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:29:50.232405||measurement||price||2015-12-01 16:29:44.645153@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:29:53.914010||measurement||price||2015-12-01 16:29:34.406592@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:29:55.504712||measurement||loadtime||0:00:29.494844||3||1
+2015-12-01 16:29:56.620072||measurement||price||2015-12-01 16:29:50.057152@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:29:59.994644||measurement||price||2015-12-01 16:29:54.375316@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:30:01.107180||measurement||loadtime||0:00:29.117438||1||1
+2015-12-01 16:30:01.531591||measurement||price||2015-12-01 16:29:43.552258@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:30:02.521490||measurement||price||2015-12-01 16:29:44.645153@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:30:08.652755||measurement||loadtime||0:00:26.701601||0||0
+2015-12-01 16:30:09.430745||measurement||price||2015-12-01 16:29:50.057152@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:30:09.611166||measurement||loadtime||0:00:26.600018||5||0
+2015-12-01 16:30:12.327278||measurement||price||2015-12-01 16:29:54.375316@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:30:14.982236||measurement||price||2015-12-01 16:30:08.470704@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:30:16.632335||measurement||loadtime||0:00:29.488989||4||1
+2015-12-01 16:30:19.444336||measurement||loadtime||0:00:26.658704||2||0
+2015-12-01 16:30:19.514508||error||collecting ads||Error||3||1
+2015-12-01 16:30:20.889168||measurement||price||2015-12-01 16:30:15.235322@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 16:30:28.049212||measurement||price||2015-12-01 16:30:08.470704@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:30:31.132786||measurement||price||2015-12-01 16:30:24.974806@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 16:30:31.803154||measurement||price||2015-12-01 16:30:26.119376@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:30:31.864414||error||collecting ads||Error||5||0
+2015-12-01 16:30:33.210019||measurement||price||2015-12-01 16:30:15.235322@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 16:30:33.389911||measurement||price||2015-12-01 16:30:26.789924@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:30:35.317466||measurement||loadtime||0:00:29.205098||1||1
+2015-12-01 16:30:40.321103||measurement||loadtime||0:00:26.663133||0||0
+2015-12-01 16:30:44.153905||measurement||price||2015-12-01 16:30:26.119376@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:30:44.354058||measurement||price||2015-12-01 16:30:24.974806@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 16:30:46.255262||measurement||price||2015-12-01 16:30:26.789924@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:30:49.044412||measurement||price||2015-12-01 16:30:42.659984@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:30:51.269668||measurement||loadtime||0:00:26.822504||2||0
+2015-12-01 16:30:51.568378||measurement||loadtime||0:00:29.930818||4||1
+2015-12-01 16:30:52.559553||measurement||price||2015-12-01 16:30:46.934043@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 16:30:53.454838||measurement||loadtime||0:00:28.935689||3||1
+2015-12-01 16:30:54.024002||error||collecting ads||Error||5||0
+2015-12-01 16:31:02.098697||measurement||price||2015-12-01 16:30:42.659984@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:31:03.926659||measurement||price||2015-12-01 16:30:58.281318@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:31:04.932854||measurement||price||2015-12-01 16:30:46.934043@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 16:31:06.805242||measurement||price||2015-12-01 16:31:00.176559@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:31:07.243374||measurement||price||2015-12-01 16:31:00.817480@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:31:09.304502||measurement||loadtime||0:00:28.981764||1||1
+2015-12-01 16:31:12.045594||measurement||loadtime||0:00:26.719255||0||0
+2015-12-01 16:31:15.673014||error||collecting ads||Error||4||1
+2015-12-01 16:31:16.266559||measurement||price||2015-12-01 16:30:58.281318@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:31:19.118130||measurement||price||2015-12-01 16:31:00.176559@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:31:20.134517||measurement||price||2015-12-01 16:31:00.817480@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:31:23.377238||measurement||loadtime||0:00:27.105352||2||0
+2015-12-01 16:31:24.358757||measurement||price||2015-12-01 16:31:18.761572@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 16:31:26.208182||measurement||loadtime||0:00:27.181027||5||0
+2015-12-01 16:31:27.356242||measurement||loadtime||0:00:28.897090||3||1
+2015-12-01 16:31:29.480608||measurement||price||2015-12-01 16:31:23.015547@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 16:31:33.007277||error||collecting ads||Error||1||1
+2015-12-01 16:31:35.572213||measurement||price||2015-12-01 16:31:29.979245@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:31:36.677863||measurement||price||2015-12-01 16:31:18.761572@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 16:31:42.282645||measurement||price||2015-12-01 16:31:23.015547@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 16:31:43.755167||measurement||loadtime||0:00:26.705207||0||0
+2015-12-01 16:31:47.917725||measurement||price||2015-12-01 16:31:29.979245@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:31:48.538417||error||collecting ads||Error||5||0
+2015-12-01 16:31:49.475187||measurement||loadtime||0:00:28.800004||4||1
+2015-12-01 16:31:51.180244||error||collecting ads||Error||3||1
+2015-12-01 16:31:55.031190||measurement||loadtime||0:00:26.648739||2||0
+2015-12-01 16:31:55.936832||measurement||price||2015-12-01 16:31:50.334009@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:31:56.888150||error||collecting ads||Error||1||1
+2015-12-01 16:32:00.730939||measurement||price||2015-12-01 16:31:55.185547@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 16:32:05.112267||measurement||price||2015-12-01 16:31:58.299492@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:32:07.334364||measurement||price||2015-12-01 16:32:01.730160@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:32:08.301771||measurement||price||2015-12-01 16:31:50.334009@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:32:13.055898||measurement||price||2015-12-01 16:31:55.185547@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 16:32:13.294742||error||collecting ads||Error||4||1
+2015-12-01 16:32:15.425967||measurement||loadtime||0:00:26.665553||0||0
+2015-12-01 16:32:17.957424||measurement||price||2015-12-01 16:31:58.299492@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:32:19.668658||measurement||price||2015-12-01 16:32:01.730160@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:32:20.172341||measurement||loadtime||0:00:26.628667||5||0
+2015-12-01 16:32:20.699794||error||collecting ads||Error||1||1
+2015-12-01 16:32:25.171076||measurement||loadtime||0:00:28.987913||3||1
+2015-12-01 16:32:26.780039||measurement||loadtime||0:00:26.744910||2||0
+2015-12-01 16:32:27.499349||measurement||price||2015-12-01 16:32:21.143570@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:32:27.772527||measurement||price||2015-12-01 16:32:22.051673@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:32:32.358115||measurement||price||2015-12-01 16:32:26.783851@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 16:32:34.613467||measurement||price||2015-12-01 16:32:27.999335@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:32:38.862167||measurement||price||2015-12-01 16:32:32.570715@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:32:39.067344||measurement||price||2015-12-01 16:32:33.463843@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:32:40.114792||measurement||price||2015-12-01 16:32:22.051673@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:32:40.881350||measurement||price||2015-12-01 16:32:21.143570@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:32:44.702990||measurement||price||2015-12-01 16:32:26.783851@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 16:32:47.230396||measurement||loadtime||0:00:26.800651||0||0
+2015-12-01 16:32:47.516734||measurement||price||2015-12-01 16:32:27.999335@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:32:48.088592||measurement||loadtime||0:00:29.788626||4||1
+2015-12-01 16:32:51.426778||measurement||price||2015-12-01 16:32:33.463843@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:32:51.694749||measurement||price||2015-12-01 16:32:32.570715@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:32:51.811151||measurement||loadtime||0:00:26.633594||5||0
+2015-12-01 16:32:54.730368||measurement||loadtime||0:00:29.025354||1||1
+2015-12-01 16:32:58.571149||measurement||loadtime||0:00:26.789969||2||0
+2015-12-01 16:32:58.923164||measurement||loadtime||0:00:28.746888||3||1
+2015-12-01 16:33:02.298092||measurement||price||2015-12-01 16:32:55.858742@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:33:04.017046||measurement||price||2015-12-01 16:32:58.443214@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:33:08.674642||measurement||price||2015-12-01 16:33:02.166027@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:33:09.527991||error||collecting ads||Error||0||0
+2015-12-01 16:33:11.143642||measurement||price||2015-12-01 16:33:05.546698@|Mitchell@|$73.90@|Mitchell 300 Pro Spinning Rod and Reel Combo, 7-Feet/Medium||2||0
+2015-12-01 16:33:12.929428||measurement||price||2015-12-01 16:33:06.429707@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:33:15.282986||measurement||price||2015-12-01 16:32:55.858742@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:33:16.349982||measurement||price||2015-12-01 16:32:58.443214@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:33:21.520000||measurement||price||2015-12-01 16:33:02.166027@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:33:22.531917||measurement||loadtime||0:00:29.438017||4||1
+2015-12-01 16:33:23.480452||measurement||loadtime||0:00:26.665317||5||0
+2015-12-01 16:33:23.482696||measurement||price||2015-12-01 16:33:05.546698@|Penn@|$89.65@|Penn Battle II Spinning Reel, 4000||2||0
+2015-12-01 16:33:25.826723||measurement||price||2015-12-01 16:33:06.429707@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:33:28.727526||measurement||loadtime||0:00:28.993435||1||1
+2015-12-01 16:33:30.595143||measurement||loadtime||0:00:27.020006||2||0
+2015-12-01 16:33:31.788388||error||collecting ads||Error||0||0
+2015-12-01 16:33:33.012332||measurement||loadtime||0:00:29.083990||3||1
+2015-12-01 16:33:35.760290||measurement||price||2015-12-01 16:33:30.154477@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:33:37.024805||measurement||price||2015-12-01 16:33:30.414721@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:33:42.569386||measurement||price||2015-12-01 16:33:35.980676@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 16:33:42.942029||measurement||price||2015-12-01 16:33:37.284416@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:33:44.192131||measurement||price||2015-12-01 16:33:38.466015@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:33:47.194313||measurement||price||2015-12-01 16:33:40.427308@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:33:48.105756||measurement||price||2015-12-01 16:33:30.154477@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:33:49.991503||measurement||price||2015-12-01 16:33:30.414721@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:33:55.223168||measurement||loadtime||0:00:26.737526||5||0
+2015-12-01 16:33:55.310441||measurement||price||2015-12-01 16:33:37.284416@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:33:55.405362||measurement||price||2015-12-01 16:33:35.980676@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 16:33:56.517364||measurement||price||2015-12-01 16:33:38.466015@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:33:57.235237||measurement||loadtime||0:00:29.698087||4||1
+2015-12-01 16:34:00.213712||measurement||price||2015-12-01 16:33:40.427308@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:34:02.423155||measurement||loadtime||0:00:26.822827||2||0
+2015-12-01 16:34:02.606605||measurement||loadtime||0:00:28.873837||1||1
+2015-12-01 16:34:03.611150||measurement||loadtime||0:00:26.817552||0||0
+2015-12-01 16:34:07.419169||measurement||loadtime||0:00:29.401640||3||1
+2015-12-01 16:34:07.442671||measurement||price||2015-12-01 16:34:01.820541@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:34:14.763761||measurement||price||2015-12-01 16:34:09.086348@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:34:15.863484||measurement||price||2015-12-01 16:34:10.218740@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:34:16.541091||measurement||price||2015-12-01 16:34:09.930755@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:34:19.789656||measurement||price||2015-12-01 16:34:01.820541@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:34:21.207073||error||collecting ads||Error||4||1
+2015-12-01 16:34:26.900952||measurement||loadtime||0:00:26.673808||5||0
+2015-12-01 16:34:27.112871||measurement||price||2015-12-01 16:34:09.086348@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:34:28.148421||measurement||price||2015-12-01 16:34:10.218740@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:34:29.338436||measurement||price||2015-12-01 16:34:09.930755@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:34:31.712330||error||collecting ads||Error||3||1
+2015-12-01 16:34:34.231139||measurement||loadtime||0:00:26.804023||2||0
+2015-12-01 16:34:35.239142||measurement||loadtime||0:00:26.624016||0||0
+2015-12-01 16:34:35.289369||measurement||price||2015-12-01 16:34:29.024931@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:34:36.534184||measurement||loadtime||0:00:28.923034||1||1
+2015-12-01 16:34:45.559821||measurement||price||2015-12-01 16:34:38.945843@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:34:46.561181||measurement||price||2015-12-01 16:34:40.936131@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:34:47.537024||measurement||price||2015-12-01 16:34:41.915744@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:34:48.217351||measurement||price||2015-12-01 16:34:29.024931@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:34:49.009708||error||collecting ads||Error||5||0
+2015-12-01 16:34:55.487197||measurement||loadtime||0:00:29.274900||4||1
+2015-12-01 16:34:58.425365||measurement||price||2015-12-01 16:34:38.945843@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:34:58.900376||measurement||price||2015-12-01 16:34:40.936131@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:34:59.870448||measurement||price||2015-12-01 16:34:41.915744@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:35:00.319924||error||collecting ads||Error||1||1
+2015-12-01 16:35:01.231552||measurement||price||2015-12-01 16:34:55.657900@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:35:05.626422||measurement||loadtime||0:00:28.908860||3||1
+2015-12-01 16:35:06.012414||measurement||loadtime||0:00:26.776069||2||0
+2015-12-01 16:35:06.984221||measurement||loadtime||0:00:26.741079||0||0
+2015-12-01 16:35:09.306270||measurement||price||2015-12-01 16:35:02.695406@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 16:35:13.572082||measurement||price||2015-12-01 16:34:55.657900@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:35:13.995149||measurement||price||2015-12-01 16:35:07.506319@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:35:18.295428||measurement||price||2015-12-01 16:35:12.653124@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:35:19.248734||measurement||price||2015-12-01 16:35:12.915932@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:35:19.457828||measurement||price||2015-12-01 16:35:13.763981@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:35:20.700124||measurement||loadtime||0:00:26.685158||5||0
+2015-12-01 16:35:22.371151||measurement||price||2015-12-01 16:35:02.695406@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 16:35:26.911432||measurement||price||2015-12-01 16:35:07.506319@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:35:29.576841||measurement||loadtime||0:00:29.084414||4||1
+2015-12-01 16:35:30.641208||measurement||price||2015-12-01 16:35:12.653124@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:35:31.829296||measurement||price||2015-12-01 16:35:13.763981@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:35:32.097612||measurement||price||2015-12-01 16:35:12.915932@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:35:34.136583||measurement||loadtime||0:00:28.811419||1||1
+2015-12-01 16:35:37.751622||measurement||loadtime||0:00:26.733972||2||0
+2015-12-01 16:35:38.940147||measurement||loadtime||0:00:26.953007||0||0
+2015-12-01 16:35:39.312601||measurement||loadtime||0:00:28.680961||3||1
+2015-12-01 16:35:42.985576||error||collecting ads||Error||5||0
+2015-12-01 16:35:43.566110||measurement||price||2015-12-01 16:35:36.984696@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:35:50.618657||measurement||price||2015-12-01 16:35:44.972111@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:35:51.305788||measurement||price||2015-12-01 16:35:45.622892@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 16:35:53.221036||measurement||price||2015-12-01 16:35:46.676343@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:35:55.150988||measurement||price||2015-12-01 16:35:49.581853@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||0
+2015-12-01 16:35:56.679925||measurement||price||2015-12-01 16:35:36.984696@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:35:58.054839||error||collecting ads||Error||1||1
+2015-12-01 16:36:02.969889||measurement||price||2015-12-01 16:35:44.972111@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:36:03.663714||measurement||price||2015-12-01 16:35:45.622892@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 16:36:03.893402||measurement||loadtime||0:00:29.311341||4||1
+2015-12-01 16:36:06.200882||measurement||price||2015-12-01 16:35:46.676343@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:36:07.486982||measurement||price||2015-12-01 16:35:49.581853@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||0
+2015-12-01 16:36:10.085197||measurement||loadtime||0:00:27.328251||2||0
+2015-12-01 16:36:10.788724||measurement||loadtime||0:00:26.843368||0||0
+2015-12-01 16:36:11.714625||measurement||price||2015-12-01 16:36:05.162188@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:36:13.385316||measurement||loadtime||0:00:29.070158||3||1
+2015-12-01 16:36:14.596403||measurement||loadtime||0:00:26.609247||5||0
+2015-12-01 16:36:22.367840||measurement||price||2015-12-01 16:36:16.748670@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:36:23.168531||measurement||price||2015-12-01 16:36:17.490508@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:36:24.713171||measurement||price||2015-12-01 16:36:05.162188@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:36:27.291361||measurement||price||2015-12-01 16:36:20.770425@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:36:27.569448||error||collecting ads||Error||4||1
+2015-12-01 16:36:31.921843||measurement||loadtime||0:00:28.862692||1||1
+2015-12-01 16:36:34.713829||measurement||price||2015-12-01 16:36:16.748670@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:36:35.514249||measurement||price||2015-12-01 16:36:17.490508@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:36:36.839669||error||collecting ads||Error||5||0
+2015-12-01 16:36:36.839789||event||progress-marker||measurement-end||5||0
+2015-12-01 16:36:40.265989||measurement||price||2015-12-01 16:36:20.770425@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:36:41.554150||measurement||price||2015-12-01 16:36:34.708361@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:36:41.819194||measurement||loadtime||0:00:26.728749||2||0
+2015-12-01 16:36:42.631203||measurement||loadtime||0:00:26.840060||0||0
+2015-12-01 16:36:46.175380||measurement||price||2015-12-01 16:36:39.890930@|SKLZ@|$46.46@|SKLZ Med Ball, 8 lb||1||1
+2015-12-01 16:36:47.479831||measurement||loadtime||0:00:29.092669||3||1
+2015-12-01 16:36:54.463237||measurement||price||2015-12-01 16:36:34.708361@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:36:54.535582||measurement||price||2015-12-01 16:36:48.935566@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:36:54.955386||measurement||price||2015-12-01 16:36:49.276461@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:36:59.038048||measurement||price||2015-12-01 16:36:39.890930@|SKLZ@|$44.99 - $247.20@|SKLZ Gold Flex Strength and Tempo Trainer||1||1
+2015-12-01 16:37:01.381090||measurement||price||2015-12-01 16:36:54.776146@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 16:37:01.679594||measurement||loadtime||0:00:29.104931||4||1
+2015-12-01 16:37:06.229132||measurement||loadtime||0:00:29.305986||1||1
+2015-12-01 16:37:06.879080||measurement||price||2015-12-01 16:36:48.935566@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:37:07.296854||measurement||price||2015-12-01 16:36:49.276461@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:37:13.997198||measurement||loadtime||0:00:27.172788||2||0
+2015-12-01 16:37:14.407183||measurement||loadtime||0:00:26.772041||0||0
+2015-12-01 16:37:14.407317||event||progress-marker||measurement-end||0||0
+2015-12-01 16:37:14.411202||measurement||price||2015-12-01 16:36:54.776146@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 16:37:15.874782||measurement||price||2015-12-01 16:37:09.348023@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||4||1
+2015-12-01 16:37:20.080322||measurement||price||2015-12-01 16:37:13.629538@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:37:21.623545||measurement||loadtime||0:00:29.138471||3||1
+2015-12-01 16:37:26.172476||measurement||price||2015-12-01 16:37:20.607643@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:37:28.737964||measurement||price||2015-12-01 16:37:09.348023@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||4||1
+2015-12-01 16:37:32.905917||measurement||price||2015-12-01 16:37:13.629538@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:37:35.942378||measurement||loadtime||0:00:29.257578||4||1
+2015-12-01 16:37:38.521358||measurement||price||2015-12-01 16:37:20.607643@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:37:40.087144||measurement||loadtime||0:00:28.855955||1||1
+2015-12-01 16:37:45.266545||error||collecting ads||Error||3||1
+2015-12-01 16:37:45.632653||measurement||loadtime||0:00:26.630261||2||0
+2015-12-01 16:37:45.632747||event||progress-marker||measurement-end||2||0
+2015-12-01 16:37:49.677861||measurement||price||2015-12-01 16:37:43.306466@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 16:37:53.664302||measurement||price||2015-12-01 16:37:47.320815@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 16:37:59.156773||measurement||price||2015-12-01 16:37:52.580506@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 16:38:02.597113||measurement||price||2015-12-01 16:37:43.306466@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 16:38:06.699181||measurement||price||2015-12-01 16:37:47.320815@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 16:38:09.803628||measurement||loadtime||0:00:28.855998||4||1
+2015-12-01 16:38:12.023103||measurement||price||2015-12-01 16:37:52.580506@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 16:38:13.880509||measurement||loadtime||0:00:28.788157||1||1
+2015-12-01 16:38:19.235179||measurement||loadtime||0:00:28.963402||3||1
+2015-12-01 16:38:23.833538||measurement||price||2015-12-01 16:38:17.397980@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:38:33.034779||measurement||price||2015-12-01 16:38:26.499204@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:38:36.859050||measurement||price||2015-12-01 16:38:17.397980@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:38:37.660470||error||collecting ads||Error||1||1
+2015-12-01 16:38:44.039157||measurement||loadtime||0:00:29.230288||4||1
+2015-12-01 16:38:45.909985||measurement||price||2015-12-01 16:38:26.499204@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:38:51.403055||measurement||price||2015-12-01 16:38:44.815935@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:38:53.110494||measurement||loadtime||0:00:28.870060||3||1
+2015-12-01 16:38:57.962574||measurement||price||2015-12-01 16:38:51.338385@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:39:04.242800||measurement||price||2015-12-01 16:38:44.815935@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:39:06.896800||measurement||price||2015-12-01 16:39:00.259818@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 16:39:10.823933||measurement||price||2015-12-01 16:38:51.338385@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:39:11.461498||measurement||loadtime||0:00:28.795676||1||1
+2015-12-01 16:39:11.461620||event||progress-marker||measurement-end||1||1
+2015-12-01 16:39:18.017193||measurement||loadtime||0:00:28.972813||4||1
+2015-12-01 16:39:19.788024||measurement||price||2015-12-01 16:39:00.259818@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 16:39:26.971158||measurement||loadtime||0:00:28.859212||3||1
+2015-12-01 16:39:40.702206||measurement||price||2015-12-01 16:39:34.316936@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 16:39:41.720762||error||collecting ads||Error||4||1
+2015-12-01 16:39:53.653560||measurement||price||2015-12-01 16:39:34.316936@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 16:39:55.386229||measurement||price||2015-12-01 16:39:48.924760@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:40:00.860582||measurement||loadtime||0:00:28.884195||3||1
+2015-12-01 16:40:00.860732||event||progress-marker||measurement-end||3||1
+2015-12-01 16:40:08.474139||measurement||price||2015-12-01 16:39:48.924760@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:40:15.656507||measurement||loadtime||0:00:28.930490||4||1
+2015-12-01 16:40:15.656649||event||progress-marker||measurement-end||4||1
+2015-12-01 16:40:16.071331||meta||block_id end||11
+2015-12-01 16:40:16.071727||meta||block_id start||12
+2015-12-01 16:40:16.071758||meta||assignment||3@|1@|0@|4@|2@|5
+2015-12-01 16:40:17.638007||event||progress-marker||training-start||3||0
+2015-12-01 16:40:17.638111||event||progress-marker||training-end||3||0
+2015-12-01 16:40:17.672708||event||progress-marker||training-start||1||0
+2015-12-01 16:40:17.674422||event||progress-marker||training-end||1||0
+2015-12-01 16:40:17.706231||event||progress-marker||training-start||0||0
+2015-12-01 16:40:17.706325||event||progress-marker||training-end||0||0
+2015-12-01 16:40:22.281163||event||progress-marker||training-start||2||1
+2015-12-01 16:40:22.281311||event||progress-marker||training-end||2||1
+2015-12-01 16:40:22.675006||event||progress-marker||measurement-start||3||0
+2015-12-01 16:40:22.708273||event||progress-marker||measurement-start||1||0
+2015-12-01 16:40:22.737657||event||progress-marker||measurement-start||0||0
+2015-12-01 16:40:25.733261||event||progress-marker||training-start||4||1
+2015-12-01 16:40:25.733362||event||progress-marker||training-end||4||1
+2015-12-01 16:40:27.319301||event||progress-marker||measurement-start||2||1
+2015-12-01 16:40:30.763710||event||progress-marker||measurement-start||4||1
+2015-12-01 16:40:35.585536||measurement||price||2015-12-01 16:40:30.156741@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 16:40:36.042038||measurement||price||2015-12-01 16:40:30.098802@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:40:36.102601||measurement||price||2015-12-01 16:40:29.867349@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 16:40:45.075284||measurement||price||2015-12-01 16:40:38.744329@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 16:40:47.932633||measurement||price||2015-12-01 16:40:30.156741@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 16:40:48.385116||measurement||price||2015-12-01 16:40:30.098802@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:40:48.453419||measurement||price||2015-12-01 16:40:29.867349@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 16:40:51.769768||error||collecting ads||Error||2||1
+2015-12-01 16:40:55.044084||measurement||loadtime||0:00:27.304898||0||0
+2015-12-01 16:40:55.498632||measurement||loadtime||0:00:27.818379||3||0
+2015-12-01 16:40:55.566015||measurement||loadtime||0:00:27.854884||1||0
+2015-12-01 16:40:57.931746||measurement||price||2015-12-01 16:40:38.744329@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 16:41:05.146493||measurement||loadtime||0:00:29.377567||4||1
+2015-12-01 16:41:07.434757||measurement||price||2015-12-01 16:41:01.804774@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:41:08.002482||measurement||price||2015-12-01 16:41:02.173787@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:41:08.151182||measurement||price||2015-12-01 16:41:02.329912@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:41:15.728521||error||collecting ads||Error||2||1
+2015-12-01 16:41:18.656790||measurement||price||2015-12-01 16:41:12.603625@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:41:19.754116||measurement||price||2015-12-01 16:41:01.804774@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:41:20.305881||measurement||price||2015-12-01 16:41:02.173787@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:41:20.484990||measurement||price||2015-12-01 16:41:02.329912@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:41:21.927627||event||progress-marker||training-start||5||1
+2015-12-01 16:41:21.927726||event||progress-marker||training-end||5||1
+2015-12-01 16:41:26.864450||measurement||loadtime||0:00:26.817301||0||0
+2015-12-01 16:41:26.959087||event||progress-marker||measurement-start||5||1
+2015-12-01 16:41:27.417502||measurement||loadtime||0:00:26.913650||3||0
+2015-12-01 16:41:27.604859||measurement||loadtime||0:00:27.033694||1||0
+2015-12-01 16:41:30.528620||measurement||price||2015-12-01 16:41:22.905839@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:41:31.578346||measurement||price||2015-12-01 16:41:12.603625@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:41:38.822579||measurement||loadtime||0:00:28.673009||4||1
+2015-12-01 16:41:39.883253||measurement||price||2015-12-01 16:41:34.241940@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:41:39.924483||measurement||price||2015-12-01 16:41:34.195986@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:41:40.032723||measurement||price||2015-12-01 16:41:34.198649@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:41:41.409845||measurement||price||2015-12-01 16:41:34.849659@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:41:43.404362||measurement||price||2015-12-01 16:41:22.905839@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:41:50.622927||measurement||loadtime||0:00:29.891759||2||1
+2015-12-01 16:41:52.193241||measurement||price||2015-12-01 16:41:34.241940@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:41:52.263044||measurement||price||2015-12-01 16:41:34.195986@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:41:52.414470||measurement||price||2015-12-01 16:41:34.198649@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:41:52.477334||measurement||price||2015-12-01 16:41:45.934168@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:41:54.335654||measurement||price||2015-12-01 16:41:34.849659@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:41:59.280602||measurement||loadtime||0:00:27.410880||0||0
+2015-12-01 16:41:59.374958||measurement||loadtime||0:00:26.955063||3||0
+2015-12-01 16:41:59.535048||measurement||loadtime||0:00:26.928760||1||0
+2015-12-01 16:42:01.580827||measurement||loadtime||0:00:29.617652||5||1
+2015-12-01 16:42:04.696875||measurement||price||2015-12-01 16:41:58.105827@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 16:42:05.314968||measurement||price||2015-12-01 16:41:45.934168@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:42:11.841224||measurement||price||2015-12-01 16:42:06.173755@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:42:11.895010||measurement||price||2015-12-01 16:42:06.262074@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:42:12.237122||measurement||price||2015-12-01 16:42:06.576618@|Coast@|$9.54@|Coast HP1 Focusing 220 Lumen LED Flashlight||0||0
+2015-12-01 16:42:12.574488||measurement||loadtime||0:00:28.746686||4||1
+2015-12-01 16:42:15.400665||measurement||price||2015-12-01 16:42:09.181589@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:42:17.635157||measurement||price||2015-12-01 16:41:58.105827@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 16:42:24.188103||measurement||price||2015-12-01 16:42:06.173755@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:42:24.205247||measurement||price||2015-12-01 16:42:06.262074@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:42:24.566162||measurement||price||2015-12-01 16:42:06.576618@|Coast@|$31.41@|Coast HL7 Focusing 285 Lumen LED Headlamp||0||0
+2015-12-01 16:42:24.836566||measurement||loadtime||0:00:29.208416||2||1
+2015-12-01 16:42:28.228461||measurement||price||2015-12-01 16:42:09.181589@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:42:31.291136||measurement||loadtime||0:00:26.750906||1||0
+2015-12-01 16:42:31.302349||measurement||loadtime||0:00:26.927087||3||0
+2015-12-01 16:42:31.670699||measurement||loadtime||0:00:27.384872||0||0
+2015-12-01 16:42:35.428503||measurement||loadtime||0:00:28.844695||5||1
+2015-12-01 16:42:36.294759||error||collecting ads||Error||4||1
+2015-12-01 16:42:38.735993||measurement||price||2015-12-01 16:42:32.134894@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 16:42:43.573855||measurement||price||2015-12-01 16:42:37.915496@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:42:43.634179||measurement||price||2015-12-01 16:42:37.967577@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:42:44.008111||measurement||price||2015-12-01 16:42:38.347753@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:42:49.141132||measurement||price||2015-12-01 16:42:42.565187@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 16:42:49.953932||measurement||price||2015-12-01 16:42:43.508097@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:42:51.640236||measurement||price||2015-12-01 16:42:32.134894@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 16:42:55.928186||measurement||price||2015-12-01 16:42:37.915496@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:42:55.971487||measurement||price||2015-12-01 16:42:37.967577@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:42:56.317341||measurement||price||2015-12-01 16:42:38.347753@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:42:58.842238||measurement||loadtime||0:00:29.000448||2||1
+2015-12-01 16:43:01.986450||measurement||price||2015-12-01 16:42:42.565187@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 16:43:03.003265||measurement||price||2015-12-01 16:42:43.508097@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:43:03.034351||measurement||loadtime||0:00:26.726799||3||0
+2015-12-01 16:43:03.085471||measurement||loadtime||0:00:26.790324||1||0
+2015-12-01 16:43:03.436453||measurement||loadtime||0:00:26.762385||0||0
+2015-12-01 16:43:09.207195||measurement||loadtime||0:00:28.773399||5||1
+2015-12-01 16:43:10.207156||measurement||loadtime||0:00:28.907192||4||1
+2015-12-01 16:43:12.969194||measurement||price||2015-12-01 16:43:06.114607@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:43:15.387447||measurement||price||2015-12-01 16:43:09.765914@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 16:43:15.803694||measurement||price||2015-12-01 16:43:10.091297@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:43:24.145616||measurement||price||2015-12-01 16:43:17.428866@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 16:43:25.908303||measurement||price||2015-12-01 16:43:06.114607@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:43:26.128357||error||collecting ads||Error||3||0
+2015-12-01 16:43:27.730368||measurement||price||2015-12-01 16:43:09.765914@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 16:43:28.124108||measurement||price||2015-12-01 16:43:10.091297@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:43:32.921727||error||collecting ads||Error||5||1
+2015-12-01 16:43:33.115194||measurement||loadtime||0:00:29.267726||2||1
+2015-12-01 16:43:34.840425||measurement||loadtime||0:00:26.750291||1||0
+2015-12-01 16:43:35.211246||measurement||loadtime||0:00:26.772029||0||0
+2015-12-01 16:43:37.187934||measurement||price||2015-12-01 16:43:17.428866@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 16:43:38.430041||measurement||price||2015-12-01 16:43:32.778960@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:43:44.402855||measurement||loadtime||0:00:29.195515||4||1
+2015-12-01 16:43:46.933043||measurement||price||2015-12-01 16:43:40.185159@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||5||1
+2015-12-01 16:43:47.421348||measurement||price||2015-12-01 16:43:41.751424@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 16:43:47.812357||measurement||price||2015-12-01 16:43:40.439986@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 16:43:50.762284||measurement||price||2015-12-01 16:43:32.778960@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:43:57.560448||error||collecting ads||Error||0||0
+2015-12-01 16:43:57.881333||measurement||loadtime||0:00:26.749572||3||0
+2015-12-01 16:43:58.073522||measurement||price||2015-12-01 16:43:51.608334@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:43:59.720018||measurement||price||2015-12-01 16:43:41.751424@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 16:43:59.781759||measurement||price||2015-12-01 16:43:40.185159@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||5||1
+2015-12-01 16:44:00.853946||measurement||price||2015-12-01 16:43:40.439986@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 16:44:06.802244||measurement||loadtime||0:00:26.956627||1||0
+2015-12-01 16:44:07.012466||measurement||loadtime||0:00:29.085540||5||1
+2015-12-01 16:44:08.172766||measurement||loadtime||0:00:30.052366||2||1
+2015-12-01 16:44:09.857246||measurement||price||2015-12-01 16:44:04.342850@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:44:11.133156||measurement||price||2015-12-01 16:43:51.608334@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:44:18.331264||measurement||loadtime||0:00:28.923100||4||1
+2015-12-01 16:44:19.082839||measurement||price||2015-12-01 16:44:13.393690@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 16:44:20.158833||error||collecting ads||Error||3||0
+2015-12-01 16:44:20.816361||measurement||price||2015-12-01 16:44:14.282194@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:44:22.189394||measurement||price||2015-12-01 16:44:04.342850@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:44:22.270198||measurement||price||2015-12-01 16:44:15.490563@|@|$274.95@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||2||1
+2015-12-01 16:44:29.295234||measurement||loadtime||0:00:26.729545||0||0
+2015-12-01 16:44:31.429361||measurement||price||2015-12-01 16:44:13.393690@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 16:44:32.039371||measurement||price||2015-12-01 16:44:25.597093@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 16:44:32.491016||measurement||price||2015-12-01 16:44:26.837598@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:44:33.648350||measurement||price||2015-12-01 16:44:14.282194@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:44:35.121839||measurement||price||2015-12-01 16:44:15.490563@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||2||1
+2015-12-01 16:44:38.542453||measurement||loadtime||0:00:26.735017||1||0
+2015-12-01 16:44:40.877137||measurement||loadtime||0:00:28.859478||5||1
+2015-12-01 16:44:42.328250||measurement||loadtime||0:00:29.153091||2||1
+2015-12-01 16:44:44.835491||measurement||price||2015-12-01 16:44:26.837598@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:44:45.089344||measurement||price||2015-12-01 16:44:25.597093@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 16:44:50.728073||measurement||price||2015-12-01 16:44:45.136788@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 16:44:51.959197||measurement||loadtime||0:00:26.796034||3||0
+2015-12-01 16:44:51.974715||error||collecting ads||Error||0||0
+2015-12-01 16:44:52.317064||measurement||loadtime||0:00:28.980577||4||1
+2015-12-01 16:44:54.389432||measurement||price||2015-12-01 16:44:48.018578@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:44:56.558751||measurement||price||2015-12-01 16:44:49.735061@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 16:45:03.066536||measurement||price||2015-12-01 16:44:45.136788@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 16:45:04.358239||measurement||price||2015-12-01 16:44:58.668561@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:45:04.936417||measurement||price||2015-12-01 16:44:59.213753@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 16:45:07.227274||measurement||price||2015-12-01 16:44:48.018578@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:45:09.472626||measurement||price||2015-12-01 16:44:49.735061@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 16:45:10.182016||measurement||loadtime||0:00:26.634322||1||0
+2015-12-01 16:45:14.443509||measurement||loadtime||0:00:28.561968||5||1
+2015-12-01 16:45:16.066983||error||collecting ads||Error||4||1
+2015-12-01 16:45:16.675195||measurement||loadtime||0:00:29.343981||2||1
+2015-12-01 16:45:16.676148||measurement||price||2015-12-01 16:44:58.668561@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:45:17.274575||measurement||price||2015-12-01 16:44:59.213753@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 16:45:22.794079||measurement||price||2015-12-01 16:45:17.214490@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 16:45:23.795147||measurement||loadtime||0:00:26.830757||3||0
+2015-12-01 16:45:24.375140||measurement||loadtime||0:00:27.395350||0||0
+2015-12-01 16:45:28.138547||measurement||price||2015-12-01 16:45:21.598915@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:45:29.899334||measurement||price||2015-12-01 16:45:23.255360@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 16:45:30.512640||measurement||price||2015-12-01 16:45:23.997028@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 16:45:35.143663||measurement||price||2015-12-01 16:45:17.214490@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 16:45:37.030081||measurement||price||2015-12-01 16:45:31.455321@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||0||0
+2015-12-01 16:45:40.977676||measurement||price||2015-12-01 16:45:21.598915@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:45:42.253458||measurement||loadtime||0:00:27.070444||1||0
+2015-12-01 16:45:42.783445||measurement||price||2015-12-01 16:45:23.255360@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 16:45:43.555677||measurement||price||2015-12-01 16:45:23.997028@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 16:45:46.032140||error||collecting ads||Error||3||0
+2015-12-01 16:45:48.176993||measurement||loadtime||0:00:28.728255||5||1
+2015-12-01 16:45:49.358963||measurement||price||2015-12-01 16:45:31.455321@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||0||0
+2015-12-01 16:45:50.016159||measurement||loadtime||0:00:28.944919||4||1
+2015-12-01 16:45:50.772101||measurement||loadtime||0:00:29.092971||2||1
+2015-12-01 16:45:56.468064||measurement||loadtime||0:00:27.088574||0||0
+2015-12-01 16:45:58.280626||measurement||price||2015-12-01 16:45:52.620744@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:46:01.847589||measurement||price||2015-12-01 16:45:55.489838@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:46:04.222050||measurement||price||2015-12-01 16:45:57.870954@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 16:46:04.369399||error||collecting ads||Error||1||0
+2015-12-01 16:46:08.715432||measurement||price||2015-12-01 16:46:03.071239@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:46:10.623629||measurement||price||2015-12-01 16:45:52.620744@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:46:13.934844||error||collecting ads||Error||4||1
+2015-12-01 16:46:14.659303||measurement||price||2015-12-01 16:45:55.489838@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:46:16.648235||measurement||price||2015-12-01 16:46:11.018371@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 16:46:17.049540||measurement||price||2015-12-01 16:45:57.870954@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 16:46:17.730357||measurement||loadtime||0:00:26.695646||3||0
+2015-12-01 16:46:21.051341||measurement||price||2015-12-01 16:46:03.071239@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:46:21.875166||measurement||loadtime||0:00:28.696468||5||1
+2015-12-01 16:46:24.263145||measurement||loadtime||0:00:28.487985||2||1
+2015-12-01 16:46:28.005018||measurement||price||2015-12-01 16:46:21.854601@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||4||1
+2015-12-01 16:46:28.158573||measurement||loadtime||0:00:26.685328||0||0
+2015-12-01 16:46:28.991812||measurement||price||2015-12-01 16:46:11.018371@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 16:46:29.983658||measurement||price||2015-12-01 16:46:24.336895@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:46:35.956630||measurement||price||2015-12-01 16:46:29.664367@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||5||1
+2015-12-01 16:46:36.107172||measurement||loadtime||0:00:26.732567||1||0
+2015-12-01 16:46:38.207638||measurement||price||2015-12-01 16:46:31.504095@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 16:46:40.843172||measurement||price||2015-12-01 16:46:21.854601@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||4||1
+2015-12-01 16:46:41.020532||measurement||price||2015-12-01 16:46:35.414198@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:46:42.341417||measurement||price||2015-12-01 16:46:24.336895@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:46:48.059614||measurement||loadtime||0:00:29.119554||4||1
+2015-12-01 16:46:48.370267||measurement||price||2015-12-01 16:46:42.730739@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 16:46:48.842682||measurement||price||2015-12-01 16:46:29.664367@|Warner Bros@|$23.99@|Jurassic World Team Pack - LEGO Dimensions||5||1
+2015-12-01 16:46:49.446714||measurement||loadtime||0:00:26.711139||3||0
+2015-12-01 16:46:51.112402||measurement||price||2015-12-01 16:46:31.504095@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 16:46:53.402012||measurement||price||2015-12-01 16:46:35.414198@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:46:56.067160||measurement||loadtime||0:00:29.186809||5||1
+2015-12-01 16:46:58.289305||measurement||loadtime||0:00:29.021735||2||1
+2015-12-01 16:47:00.509435||measurement||loadtime||0:00:27.346284||0||0
+2015-12-01 16:47:00.721150||measurement||price||2015-12-01 16:46:42.730739@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 16:47:07.831145||measurement||loadtime||0:00:26.720011||1||0
+2015-12-01 16:47:09.616864||measurement||price||2015-12-01 16:47:03.352306@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:47:11.759078||error||collecting ads||Error||4||1
+2015-12-01 16:47:11.814352||error||collecting ads||Error||3||0
+2015-12-01 16:47:12.116317||measurement||price||2015-12-01 16:47:05.592930@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||1
+2015-12-01 16:47:12.813830||measurement||price||2015-12-01 16:47:07.217886@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:47:20.023371||measurement||price||2015-12-01 16:47:14.427637@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||0
+2015-12-01 16:47:22.482874||measurement||price||2015-12-01 16:47:03.352306@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:47:25.154744||measurement||price||2015-12-01 16:47:07.217886@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:47:25.200092||measurement||price||2015-12-01 16:47:05.592930@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||1
+2015-12-01 16:47:25.483493||measurement||price||2015-12-01 16:47:19.044726@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:47:29.696901||measurement||loadtime||0:00:28.624528||5||1
+2015-12-01 16:47:32.268985||measurement||loadtime||0:00:26.756291||0||0
+2015-12-01 16:47:32.379811||measurement||price||2015-12-01 16:47:14.427637@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||0
+2015-12-01 16:47:32.405585||measurement||loadtime||0:00:29.110850||2||1
+2015-12-01 16:47:34.068305||error||collecting ads||Error||3||0
+2015-12-01 16:47:38.595500||measurement||price||2015-12-01 16:47:19.044726@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:47:39.491164||measurement||loadtime||0:00:26.654843||1||0
+2015-12-01 16:47:43.185193||measurement||price||2015-12-01 16:47:36.943287@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:47:44.676466||measurement||price||2015-12-01 16:47:39.042634@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:47:45.831170||measurement||loadtime||0:00:29.066868||4||1
+2015-12-01 16:47:46.347156||measurement||price||2015-12-01 16:47:40.730378@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:47:46.649642||measurement||price||2015-12-01 16:47:39.781525@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:47:55.998946||measurement||price||2015-12-01 16:47:36.943287@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:47:56.995591||measurement||price||2015-12-01 16:47:39.042634@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:47:58.678955||measurement||price||2015-12-01 16:47:40.730378@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:47:59.510156||measurement||price||2015-12-01 16:47:53.038503@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:47:59.744396||measurement||price||2015-12-01 16:47:39.781525@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:48:01.701442||error||collecting ads||Error||1||0
+2015-12-01 16:48:03.208352||measurement||loadtime||0:00:28.506210||5||1
+2015-12-01 16:48:04.089408||measurement||loadtime||0:00:26.818261||0||0
+2015-12-01 16:48:05.790768||measurement||loadtime||0:00:26.717160||3||0
+2015-12-01 16:48:06.968066||measurement||loadtime||0:00:29.560936||2||1
+2015-12-01 16:48:12.450883||measurement||price||2015-12-01 16:47:53.038503@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:48:13.929197||measurement||price||2015-12-01 16:48:08.321510@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:48:16.406757||measurement||price||2015-12-01 16:48:10.745531@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||0
+2015-12-01 16:48:18.106889||measurement||price||2015-12-01 16:48:12.521526@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:48:19.667489||measurement||loadtime||0:00:28.831082||4||1
+2015-12-01 16:48:20.806642||measurement||price||2015-12-01 16:48:14.515863@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 16:48:26.271837||measurement||price||2015-12-01 16:48:08.321510@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:48:26.979499||error||collecting ads||Error||5||1
+2015-12-01 16:48:28.742530||measurement||price||2015-12-01 16:48:10.745531@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||0
+2015-12-01 16:48:30.440693||measurement||price||2015-12-01 16:48:12.521526@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:48:33.375158||measurement||loadtime||0:00:26.668513||1||0
+2015-12-01 16:48:33.758529||measurement||price||2015-12-01 16:48:14.515863@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 16:48:35.839927||measurement||loadtime||0:00:26.748779||0||0
+2015-12-01 16:48:37.558185||measurement||loadtime||0:00:26.763034||3||0
+2015-12-01 16:48:40.629232||measurement||price||2015-12-01 16:48:34.292705@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:48:40.943179||measurement||loadtime||0:00:28.969896||2||1
+2015-12-01 16:48:43.205811||error||collecting ads||Error||4||1
+2015-12-01 16:48:45.564026||measurement||price||2015-12-01 16:48:39.991571@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 16:48:49.820006||measurement||price||2015-12-01 16:48:44.146255@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:48:53.484684||measurement||price||2015-12-01 16:48:34.292705@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:48:57.910920||measurement||price||2015-12-01 16:48:39.991571@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 16:48:58.022525||error||collecting ads||Error||0||0
+2015-12-01 16:49:00.719134||measurement||loadtime||0:00:28.734433||5||1
+2015-12-01 16:49:00.807234||measurement||price||2015-12-01 16:48:52.027669@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:49:02.164224||measurement||price||2015-12-01 16:48:44.146255@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:49:05.026603||measurement||loadtime||0:00:26.646234||1||0
+2015-12-01 16:49:05.880915||measurement||price||2015-12-01 16:48:59.706294@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:49:09.279153||measurement||loadtime||0:00:26.716008||3||0
+2015-12-01 16:49:10.282614||measurement||price||2015-12-01 16:49:04.670000@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 16:49:13.778067||measurement||price||2015-12-01 16:48:52.027669@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:49:14.499908||measurement||price||2015-12-01 16:49:07.844288@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:49:17.187274||measurement||price||2015-12-01 16:49:11.594193@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 16:49:18.819416||measurement||price||2015-12-01 16:48:59.706294@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:49:20.998192||measurement||loadtime||0:00:35.049751||2||1
+2015-12-01 16:49:21.475777||measurement||price||2015-12-01 16:49:15.866044@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||0
+2015-12-01 16:49:22.616674||measurement||price||2015-12-01 16:49:04.670000@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 16:49:26.046358||measurement||loadtime||0:00:37.835345||4||1
+2015-12-01 16:49:27.332765||measurement||price||2015-12-01 16:49:07.844288@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:49:29.529255||measurement||price||2015-12-01 16:49:11.594193@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 16:49:29.723177||measurement||loadtime||0:00:26.695424||0||0
+2015-12-01 16:49:33.800920||measurement||price||2015-12-01 16:49:15.866044@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||0
+2015-12-01 16:49:34.560781||measurement||loadtime||0:00:28.841206||5||1
+2015-12-01 16:49:35.297988||measurement||price||2015-12-01 16:49:28.908234@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||2||1
+2015-12-01 16:49:36.631153||measurement||loadtime||0:00:26.600006||1||0
+2015-12-01 16:49:40.924565||measurement||loadtime||0:00:26.643854||3||0
+2015-12-01 16:49:42.002288||measurement||price||2015-12-01 16:49:36.411254@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 16:49:48.243878||measurement||price||2015-12-01 16:49:28.908234@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||2||1
+2015-12-01 16:49:48.391521||measurement||price||2015-12-01 16:49:41.785626@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 16:49:48.998322||measurement||price||2015-12-01 16:49:43.294335@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 16:49:49.763705||error||collecting ads||Error||4||1
+2015-12-01 16:49:53.200140||measurement||price||2015-12-01 16:49:47.549976@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:49:54.344829||measurement||price||2015-12-01 16:49:36.411254@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 16:49:55.447174||measurement||loadtime||0:00:29.443733||2||1
+2015-12-01 16:50:01.161717||measurement||price||2015-12-01 16:49:41.785626@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 16:50:01.353220||measurement||price||2015-12-01 16:49:43.294335@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 16:50:01.455168||measurement||loadtime||0:00:26.726754||0||0
+2015-12-01 16:50:03.384178||measurement||price||2015-12-01 16:49:57.013477@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:50:05.556446||measurement||price||2015-12-01 16:49:47.549976@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:50:08.405375||measurement||loadtime||0:00:28.839378||5||1
+2015-12-01 16:50:08.467177||measurement||loadtime||0:00:26.832026||1||0
+2015-12-01 16:50:12.679198||measurement||loadtime||0:00:26.749411||3||0
+2015-12-01 16:50:12.679328||event||progress-marker||measurement-end||3||0
+2015-12-01 16:50:13.619633||measurement||price||2015-12-01 16:50:08.046741@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 16:50:16.392355||measurement||price||2015-12-01 16:49:57.013477@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:50:19.220040||error||collecting ads||Error||2||1
+2015-12-01 16:50:23.609918||measurement||loadtime||0:00:28.843113||4||1
+2015-12-01 16:50:25.966222||measurement||price||2015-12-01 16:50:08.046741@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 16:50:30.697829||error||collecting ads||Error||1||0
+2015-12-01 16:50:30.697923||event||progress-marker||measurement-end||1||0
+2015-12-01 16:50:32.116676||error||collecting ads||Error||5||1
+2015-12-01 16:50:32.987592||measurement||price||2015-12-01 16:50:26.428559@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 16:50:33.070740||measurement||loadtime||0:00:26.610321||0||0
+2015-12-01 16:50:33.070834||event||progress-marker||measurement-end||0||0
+2015-12-01 16:50:37.360981||measurement||price||2015-12-01 16:50:30.832601@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||4||1
+2015-12-01 16:50:45.758461||measurement||price||2015-12-01 16:50:39.235991@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:50:45.808421||measurement||price||2015-12-01 16:50:26.428559@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 16:50:50.267470||measurement||price||2015-12-01 16:50:30.832601@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||4||1
+2015-12-01 16:50:53.010147||measurement||loadtime||0:00:28.784880||2||1
+2015-12-01 16:50:57.483220||measurement||loadtime||0:00:28.872068||4||1
+2015-12-01 16:50:57.483350||event||progress-marker||measurement-end||4||1
+2015-12-01 16:50:58.609781||measurement||price||2015-12-01 16:50:39.235991@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:51:05.841094||measurement||loadtime||0:00:28.719147||5||1
+2015-12-01 16:51:06.965798||measurement||price||2015-12-01 16:51:00.339587@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 16:51:19.539413||measurement||price||2015-12-01 16:51:12.984382@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 16:51:19.777004||measurement||price||2015-12-01 16:51:00.339587@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 16:51:26.995528||measurement||loadtime||0:00:28.980171||2||1
+2015-12-01 16:51:26.995666||event||progress-marker||measurement-end||2||1
+2015-12-01 16:51:32.337776||measurement||price||2015-12-01 16:51:12.984382@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 16:51:39.569195||measurement||loadtime||0:00:28.722843||5||1
+2015-12-01 16:51:53.286969||measurement||price||2015-12-01 16:51:46.787851@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 16:52:06.126029||measurement||price||2015-12-01 16:51:46.787851@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 16:52:13.336411||measurement||loadtime||0:00:28.762023||5||1
+2015-12-01 16:52:13.336528||event||progress-marker||measurement-end||5||1
+2015-12-01 16:52:13.771376||meta||block_id end||12
+2015-12-01 16:52:13.771720||meta||block_id start||13
+2015-12-01 16:52:13.771754||meta||assignment||2@|3@|5@|1@|4@|0
+2015-12-01 16:52:15.361166||event||progress-marker||training-start||3||0
+2015-12-01 16:52:15.361259||event||progress-marker||training-end||3||0
+2015-12-01 16:52:15.372347||event||progress-marker||training-start||5||0
+2015-12-01 16:52:15.372447||event||progress-marker||training-end||5||0
+2015-12-01 16:52:15.388538||event||progress-marker||training-start||2||0
+2015-12-01 16:52:15.388641||event||progress-marker||training-end||2||0
+2015-12-01 16:52:20.398132||event||progress-marker||measurement-start||3||0
+2015-12-01 16:52:20.410278||event||progress-marker||measurement-start||5||0
+2015-12-01 16:52:20.426904||event||progress-marker||measurement-start||2||0
+2015-12-01 16:52:33.476677||measurement||price||2015-12-01 16:52:28.099914@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:52:34.503514||measurement||price||2015-12-01 16:52:27.460178@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:52:34.517358||measurement||price||2015-12-01 16:52:27.567541@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:52:45.819641||measurement||price||2015-12-01 16:52:28.099914@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:52:46.864965||measurement||price||2015-12-01 16:52:27.460178@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:52:46.865087||measurement||price||2015-12-01 16:52:27.567541@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:52:52.933137||measurement||loadtime||0:00:27.517976||5||0
+2015-12-01 16:52:53.969596||measurement||loadtime||0:00:28.538440||2||0
+2015-12-01 16:52:53.973009||measurement||loadtime||0:00:28.569676||3||0
+2015-12-01 16:53:05.959682||measurement||price||2015-12-01 16:53:00.086279@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:53:06.324126||measurement||price||2015-12-01 16:53:00.585511@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:53:06.518688||measurement||price||2015-12-01 16:53:00.680540@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:53:18.298722||measurement||price||2015-12-01 16:53:00.086279@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:53:18.630565||measurement||price||2015-12-01 16:53:00.585511@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:53:18.816727||measurement||price||2015-12-01 16:53:00.680540@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:53:25.408781||measurement||loadtime||0:00:27.470439||5||0
+2015-12-01 16:53:25.718006||measurement||loadtime||0:00:26.742871||3||0
+2015-12-01 16:53:25.910247||measurement||loadtime||0:00:26.935445||2||0
+2015-12-01 16:53:30.180143||event||progress-marker||training-start||1||1
+2015-12-01 16:53:30.180293||event||progress-marker||training-end||1||1
+2015-12-01 16:53:34.518165||event||progress-marker||training-start||4||1
+2015-12-01 16:53:34.518270||event||progress-marker||training-end||4||1
+2015-12-01 16:53:35.219056||event||progress-marker||measurement-start||1||1
+2015-12-01 16:53:37.989588||measurement||price||2015-12-01 16:53:32.574880@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:53:38.105965||measurement||price||2015-12-01 16:53:32.472883@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 16:53:38.141039||measurement||price||2015-12-01 16:53:32.530164@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:53:39.556243||event||progress-marker||measurement-start||4||1
+2015-12-01 16:53:47.208946||event||progress-marker||training-start||0||1
+2015-12-01 16:53:47.209056||event||progress-marker||training-end||0||1
+2015-12-01 16:53:49.387830||measurement||price||2015-12-01 16:53:43.163613@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:53:50.304833||measurement||price||2015-12-01 16:53:32.574880@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:53:50.445335||measurement||price||2015-12-01 16:53:32.530164@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:53:50.450628||measurement||price||2015-12-01 16:53:32.472883@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 16:53:52.246582||event||progress-marker||measurement-start||0||1
+2015-12-01 16:53:54.237725||measurement||price||2015-12-01 16:53:47.899399@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 16:53:57.401561||measurement||loadtime||0:00:26.987543||5||0
+2015-12-01 16:53:57.542082||measurement||loadtime||0:00:26.822361||3||0
+2015-12-01 16:53:57.571695||measurement||loadtime||0:00:26.656225||2||0
+2015-12-01 16:54:02.244834||measurement||price||2015-12-01 16:53:43.163613@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:54:07.777812||measurement||price||2015-12-01 16:53:47.899399@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 16:54:09.444401||measurement||loadtime||0:00:29.220134||1||1
+2015-12-01 16:54:14.996728||measurement||loadtime||0:00:30.437530||4||1
+2015-12-01 16:54:28.795123||measurement||price||2015-12-01 16:54:15.617794@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:54:29.789363||measurement||price||2015-12-01 16:54:16.616787@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:54:33.995720||measurement||price||2015-12-01 16:54:28.669203@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:54:41.154859||measurement||price||2015-12-01 16:54:15.617794@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:54:42.121710||measurement||price||2015-12-01 16:54:16.616787@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:54:44.594888||measurement||price||2015-12-01 16:54:34.708124@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||1||1
+2015-12-01 16:54:45.336549||measurement||price||2015-12-01 16:54:26.695871@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 16:54:45.352163||measurement||price||2015-12-01 16:54:36.814843@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:54:46.342946||measurement||price||2015-12-01 16:54:28.669203@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:54:48.251054||measurement||loadtime||0:00:45.703714||3||0
+2015-12-01 16:54:49.207176||measurement||loadtime||0:00:46.630246||2||0
+2015-12-01 16:54:53.438250||measurement||loadtime||0:00:51.033099||5||0
+2015-12-01 16:54:57.415690||measurement||price||2015-12-01 16:54:34.708124@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||1||1
+2015-12-01 16:54:58.145202||measurement||price||2015-12-01 16:54:26.695871@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 16:54:58.255961||measurement||price||2015-12-01 16:54:36.814843@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:55:02.301684||measurement||price||2015-12-01 16:54:56.904011@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:55:04.626794||measurement||loadtime||0:00:50.177176||1||1
+2015-12-01 16:55:05.345730||measurement||loadtime||0:01:08.096683||0||1
+2015-12-01 16:55:05.478697||measurement||loadtime||0:00:45.476733||4||1
+2015-12-01 16:55:12.124915||error||collecting ads||Error||2||0
+2015-12-01 16:55:14.618394||measurement||price||2015-12-01 16:54:56.904011@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:55:16.391525||error||collecting ads||Error||5||0
+2015-12-01 16:55:18.879767||measurement||price||2015-12-01 16:55:12.050903@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 16:55:19.171244||measurement||price||2015-12-01 16:55:12.753818@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 16:55:19.309969||measurement||price||2015-12-01 16:55:12.719578@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:55:21.737410||measurement||loadtime||0:00:28.481114||3||0
+2015-12-01 16:55:24.291542||measurement||price||2015-12-01 16:55:18.685092@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:55:28.859517||measurement||price||2015-12-01 16:55:23.450625@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:55:31.745632||measurement||price||2015-12-01 16:55:12.050903@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 16:55:32.107680||measurement||price||2015-12-01 16:55:12.753818@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 16:55:32.188084||measurement||price||2015-12-01 16:55:12.719578@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:55:33.985851||measurement||price||2015-12-01 16:55:28.350410@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:55:36.624772||measurement||price||2015-12-01 16:55:18.685092@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:55:38.979309||measurement||loadtime||0:00:29.347309||1||1
+2015-12-01 16:55:39.346929||measurement||loadtime||0:00:28.995974||0||1
+2015-12-01 16:55:39.412528||measurement||loadtime||0:00:28.928593||4||1
+2015-12-01 16:55:41.188903||measurement||price||2015-12-01 16:55:23.450625@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:55:43.743328||measurement||loadtime||0:00:26.613184||2||0
+2015-12-01 16:55:46.329580||measurement||price||2015-12-01 16:55:28.350410@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:55:48.287164||measurement||loadtime||0:00:26.890381||5||0
+2015-12-01 16:55:52.693019||measurement||price||2015-12-01 16:55:46.317044@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:55:53.249907||measurement||price||2015-12-01 16:55:46.699433@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:55:53.447158||measurement||loadtime||0:00:26.708012||3||0
+2015-12-01 16:55:53.508499||measurement||price||2015-12-01 16:55:46.643692@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:55:55.950564||measurement||price||2015-12-01 16:55:50.353715@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:56:05.689832||measurement||price||2015-12-01 16:56:00.116566@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:56:05.704093||measurement||price||2015-12-01 16:55:46.317044@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:56:06.353194||measurement||price||2015-12-01 16:55:46.699433@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:56:06.637855||measurement||price||2015-12-01 16:55:46.643692@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:56:08.283745||measurement||price||2015-12-01 16:55:50.353715@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:56:10.669819||error||collecting ads||Error||5||0
+2015-12-01 16:56:12.887179||measurement||loadtime||0:00:28.906396||1||1
+2015-12-01 16:56:13.585832||measurement||loadtime||0:00:29.170683||4||1
+2015-12-01 16:56:13.860981||measurement||loadtime||0:00:29.508788||0||1
+2015-12-01 16:56:15.398144||measurement||loadtime||0:00:26.651001||2||0
+2015-12-01 16:56:18.025323||measurement||price||2015-12-01 16:56:00.116566@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:56:25.138590||measurement||loadtime||0:00:26.686226||3||0
+2015-12-01 16:56:26.808194||measurement||price||2015-12-01 16:56:20.256789@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 16:56:27.397678||measurement||price||2015-12-01 16:56:20.766668@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 16:56:27.753843||measurement||price||2015-12-01 16:56:22.165165@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 16:56:28.066016||measurement||price||2015-12-01 16:56:21.340787@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:56:33.164434||error||collecting ads||Error||5||0
+2015-12-01 16:56:39.810503||measurement||price||2015-12-01 16:56:20.256789@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 16:56:40.098954||measurement||price||2015-12-01 16:56:22.165165@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 16:56:40.548067||measurement||price||2015-12-01 16:56:20.766668@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 16:56:40.990633||measurement||price||2015-12-01 16:56:21.340787@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:56:45.765620||measurement||price||2015-12-01 16:56:40.266655@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 16:56:47.023013||measurement||loadtime||0:00:29.130625||1||1
+2015-12-01 16:56:47.224955||measurement||loadtime||0:00:26.821604||2||0
+2015-12-01 16:56:47.444579||error||collecting ads||Error||3||0
+2015-12-01 16:56:47.933960||measurement||loadtime||0:00:29.343156||4||1
+2015-12-01 16:56:48.209832||measurement||loadtime||0:00:29.343651||0||1
+2015-12-01 16:56:58.115509||measurement||price||2015-12-01 16:56:40.266655@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 16:56:59.608859||measurement||price||2015-12-01 16:56:54.033728@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:56:59.915467||measurement||price||2015-12-01 16:56:54.246399@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:57:05.222485||measurement||loadtime||0:00:27.052794||5||0
+2015-12-01 16:57:11.222479||error||collecting ads||Error||1||1
+2015-12-01 16:57:11.919205||measurement||price||2015-12-01 16:56:54.033728@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:57:11.938221||error||collecting ads||Error||4||1
+2015-12-01 16:57:12.267498||measurement||price||2015-12-01 16:56:54.246399@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:57:12.374151||error||collecting ads||Error||0||1
+2015-12-01 16:57:17.736296||measurement||price||2015-12-01 16:57:12.334643@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:57:19.008358||measurement||loadtime||0:00:26.778261||2||0
+2015-12-01 16:57:19.381780||measurement||loadtime||0:00:26.934650||3||0
+2015-12-01 16:57:25.074678||measurement||price||2015-12-01 16:57:18.611492@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 16:57:26.512733||measurement||price||2015-12-01 16:57:19.595859@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:57:30.067158||measurement||price||2015-12-01 16:57:12.334643@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:57:31.545672||measurement||price||2015-12-01 16:57:25.996742@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 16:57:31.740833||measurement||price||2015-12-01 16:57:26.069620@|@|$274.95@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||2||0
+2015-12-01 16:57:36.142809||error||collecting ads||Error||4||1
+2015-12-01 16:57:37.191409||measurement||loadtime||0:00:26.963666||5||0
+2015-12-01 16:57:37.907983||measurement||price||2015-12-01 16:57:18.611492@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 16:57:39.481883||measurement||price||2015-12-01 16:57:19.595859@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:57:43.880239||measurement||price||2015-12-01 16:57:25.996742@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 16:57:44.079114||measurement||price||2015-12-01 16:57:26.069620@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||2||0
+2015-12-01 16:57:45.087148||measurement||loadtime||0:00:28.860370||1||1
+2015-12-01 16:57:46.696540||measurement||loadtime||0:00:29.317379||0||1
+2015-12-01 16:57:49.728196||measurement||price||2015-12-01 16:57:44.280994@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 16:57:50.992078||measurement||loadtime||0:00:26.608904||3||0
+2015-12-01 16:57:51.196069||measurement||loadtime||0:00:27.182503||2||0
+2015-12-01 16:57:58.716602||measurement||price||2015-12-01 16:57:52.376717@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:57:59.789948||error||collecting ads||Error||4||1
+2015-12-01 16:58:02.078093||measurement||price||2015-12-01 16:57:44.280994@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 16:58:03.290712||measurement||price||2015-12-01 16:57:57.637622@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:58:09.187179||measurement||loadtime||0:00:26.990548||5||0
+2015-12-01 16:58:10.422290||error||collecting ads||Error||0||1
+2015-12-01 16:58:11.560976||measurement||price||2015-12-01 16:57:52.376717@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:58:13.470258||error||collecting ads||Error||2||0
+2015-12-01 16:58:13.622393||measurement||price||2015-12-01 16:58:07.177998@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:58:15.643458||measurement||price||2015-12-01 16:57:57.637622@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:58:18.763349||measurement||loadtime||0:00:28.671015||1||1
+2015-12-01 16:58:22.752300||measurement||loadtime||0:00:26.754961||3||0
+2015-12-01 16:58:24.515766||measurement||price||2015-12-01 16:58:17.724883@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 16:58:25.651973||measurement||price||2015-12-01 16:58:20.019339@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 16:58:26.439624||measurement||price||2015-12-01 16:58:07.177998@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:58:31.801394||error||collecting ads||Error||5||0
+2015-12-01 16:58:32.684621||measurement||price||2015-12-01 16:58:26.136995@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 16:58:33.657884||measurement||loadtime||0:00:28.862703||4||1
+2015-12-01 16:58:34.976114||measurement||price||2015-12-01 16:58:29.348338@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 16:58:37.362855||measurement||price||2015-12-01 16:58:17.724883@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 16:58:37.996270||measurement||price||2015-12-01 16:58:20.019339@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 16:58:44.288182||measurement||price||2015-12-01 16:58:38.846341@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 16:58:44.585348||measurement||loadtime||0:00:29.157868||0||1
+2015-12-01 16:58:45.131831||measurement||loadtime||0:00:26.656679||2||0
+2015-12-01 16:58:45.626131||measurement||price||2015-12-01 16:58:26.136995@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 16:58:47.313531||measurement||price||2015-12-01 16:58:29.348338@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 16:58:47.520563||measurement||price||2015-12-01 16:58:40.901321@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 16:58:52.828611||measurement||loadtime||0:00:29.060054||1||1
+2015-12-01 16:58:54.420215||measurement||loadtime||0:00:26.662614||3||0
+2015-12-01 16:58:56.612686||measurement||price||2015-12-01 16:58:38.846341@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 16:58:57.400009||measurement||price||2015-12-01 16:58:51.728286@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 16:58:58.698709||measurement||price||2015-12-01 16:58:52.037646@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:59:00.335785||measurement||price||2015-12-01 16:58:40.901321@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 16:59:03.715175||measurement||loadtime||0:00:26.908584||5||0
+2015-12-01 16:59:07.207505||measurement||price||2015-12-01 16:59:01.581231@|@|$37.46@|OtterBox DEFENDER iPhone 6/6s Case - Retail Packaging - BLACK||3||0
+2015-12-01 16:59:07.585221||measurement||loadtime||0:00:28.926058||4||1
+2015-12-01 16:59:09.710260||measurement||price||2015-12-01 16:58:51.728286@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 16:59:11.805350||measurement||price||2015-12-01 16:58:52.037646@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:59:16.263417||measurement||price||2015-12-01 16:59:10.868313@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 16:59:16.817703||measurement||loadtime||0:00:26.682565||2||0
+2015-12-01 16:59:16.934498||error||collecting ads||Error||1||1
+2015-12-01 16:59:19.033709||measurement||loadtime||0:00:29.443117||0||1
+2015-12-01 16:59:19.551014||measurement||price||2015-12-01 16:59:01.581231@|@|$18.89@|OtterBox COMMUTER iPhone 6/6s Case - Frustration-Free Packag...||3||0
+2015-12-01 16:59:21.319084||measurement||price||2015-12-01 16:59:14.844692@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 16:59:26.663948||measurement||loadtime||0:00:27.240796||3||0
+2015-12-01 16:59:28.590725||measurement||price||2015-12-01 16:59:10.868313@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 16:59:29.515846||measurement||price||2015-12-01 16:59:23.870422@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||0
+2015-12-01 16:59:30.735247||measurement||price||2015-12-01 16:59:24.266807@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 16:59:32.805240||measurement||price||2015-12-01 16:59:26.284376@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 16:59:34.222191||measurement||price||2015-12-01 16:59:14.844692@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 16:59:35.703190||measurement||loadtime||0:00:26.983337||5||0
+2015-12-01 16:59:38.914595||measurement||price||2015-12-01 16:59:33.266321@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 16:59:41.442259||measurement||loadtime||0:00:28.851813||4||1
+2015-12-01 16:59:41.869155||measurement||price||2015-12-01 16:59:23.870422@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||0
+2015-12-01 16:59:43.613755||measurement||price||2015-12-01 16:59:24.266807@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 16:59:45.797322||measurement||price||2015-12-01 16:59:26.284376@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 16:59:48.978601||measurement||loadtime||0:00:27.155693||2||0
+2015-12-01 16:59:50.831185||measurement||loadtime||0:00:28.891483||1||1
+2015-12-01 16:59:51.263997||measurement||price||2015-12-01 16:59:33.266321@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 16:59:53.072797||measurement||loadtime||0:00:29.037635||0||1
+2015-12-01 16:59:55.190875||measurement||price||2015-12-01 16:59:48.716678@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 16:59:58.199954||error||collecting ads||Error||5||0
+2015-12-01 16:59:58.379132||measurement||loadtime||0:00:26.709930||3||0
+2015-12-01 17:00:01.213351||measurement||price||2015-12-01 16:59:55.589621@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:00:04.555284||measurement||price||2015-12-01 16:59:58.117978@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:00:07.186017||measurement||price||2015-12-01 17:00:00.297784@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:00:08.152485||measurement||price||2015-12-01 16:59:48.716678@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:00:10.629322||measurement||price||2015-12-01 17:00:05.027364@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 17:00:10.846369||measurement||price||2015-12-01 17:00:05.458125@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 17:00:13.558742||measurement||price||2015-12-01 16:59:55.589621@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:00:15.351182||measurement||loadtime||0:00:28.903575||4||1
+2015-12-01 17:00:17.382025||measurement||price||2015-12-01 16:59:58.117978@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:00:20.098924||measurement||price||2015-12-01 17:00:00.297784@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:00:20.680902||measurement||loadtime||0:00:26.697089||2||0
+2015-12-01 17:00:22.959898||measurement||price||2015-12-01 17:00:05.027364@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 17:00:23.176801||measurement||price||2015-12-01 17:00:05.458125@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 17:00:24.594266||measurement||loadtime||0:00:28.759110||1||1
+2015-12-01 17:00:27.311158||measurement||loadtime||0:00:29.233088||0||1
+2015-12-01 17:00:29.064362||measurement||price||2015-12-01 17:00:22.859232@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:00:30.072676||measurement||loadtime||0:00:26.690237||3||0
+2015-12-01 17:00:30.284852||measurement||loadtime||0:00:27.079597||5||0
+2015-12-01 17:00:32.896252||measurement||price||2015-12-01 17:00:27.237599@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:00:38.318984||measurement||price||2015-12-01 17:00:31.822687@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:00:41.249615||measurement||price||2015-12-01 17:00:34.565193@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:00:42.194924||measurement||price||2015-12-01 17:00:22.859232@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:00:42.359561||measurement||price||2015-12-01 17:00:36.705601@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 17:00:43.028820||measurement||price||2015-12-01 17:00:37.624654@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 17:00:45.242157||measurement||price||2015-12-01 17:00:27.237599@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:00:49.459191||measurement||loadtime||0:00:29.102781||4||1
+2015-12-01 17:00:51.163377||measurement||price||2015-12-01 17:00:31.822687@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:00:52.361658||measurement||loadtime||0:00:26.675537||2||0
+2015-12-01 17:00:54.135122||measurement||price||2015-12-01 17:00:34.565193@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:00:54.718401||measurement||price||2015-12-01 17:00:36.705601@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 17:00:55.386087||measurement||price||2015-12-01 17:00:37.624654@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 17:00:58.351188||measurement||loadtime||0:00:28.751683||1||1
+2015-12-01 17:01:01.344679||measurement||loadtime||0:00:29.028293||0||1
+2015-12-01 17:01:01.823079||measurement||loadtime||0:00:26.745159||3||0
+2015-12-01 17:01:02.514803||measurement||loadtime||0:00:27.226351||5||0
+2015-12-01 17:01:03.040871||measurement||price||2015-12-01 17:00:56.716327@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:01:04.548520||measurement||price||2015-12-01 17:00:58.942492@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:01:14.147126||measurement||price||2015-12-01 17:01:08.499546@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 17:01:15.077251||measurement||price||2015-12-01 17:01:09.662848@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 17:01:15.611667||measurement||price||2015-12-01 17:01:08.728919@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:01:15.883234||measurement||price||2015-12-01 17:00:56.716327@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:01:16.874804||measurement||price||2015-12-01 17:00:58.942492@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:01:22.065781||error||collecting ads||Error||1||1
+2015-12-01 17:01:23.076300||measurement||loadtime||0:00:28.611847||4||1
+2015-12-01 17:01:23.987860||measurement||loadtime||0:00:26.621009||2||0
+2015-12-01 17:01:26.483840||measurement||price||2015-12-01 17:01:08.499546@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 17:01:27.404430||measurement||price||2015-12-01 17:01:09.662848@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 17:01:28.633226||measurement||price||2015-12-01 17:01:08.728919@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:01:33.602106||measurement||loadtime||0:00:26.773802||3||0
+2015-12-01 17:01:34.512269||measurement||loadtime||0:00:26.993143||5||0
+2015-12-01 17:01:35.855924||measurement||loadtime||0:00:29.508773||0||1
+2015-12-01 17:01:36.328850||measurement||price||2015-12-01 17:01:30.756499@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:01:36.345763||measurement||price||2015-12-01 17:01:29.440654@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 17:01:46.869105||error||collecting ads||Error||4||1
+2015-12-01 17:01:47.051092||measurement||price||2015-12-01 17:01:41.607271@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 17:01:48.656125||measurement||price||2015-12-01 17:01:30.756499@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:01:49.234470||measurement||price||2015-12-01 17:01:29.440654@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 17:01:50.339853||measurement||price||2015-12-01 17:01:43.866648@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||0||1
+2015-12-01 17:01:55.767741||measurement||loadtime||0:00:26.776585||2||0
+2015-12-01 17:01:55.843431||error||collecting ads||Error||3||0
+2015-12-01 17:01:56.465345||measurement||loadtime||0:00:29.394324||1||1
+2015-12-01 17:01:59.393744||measurement||price||2015-12-01 17:01:41.607271@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 17:02:00.568241||measurement||price||2015-12-01 17:01:53.943146@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:02:03.371396||measurement||price||2015-12-01 17:01:43.866648@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||0||1
+2015-12-01 17:02:06.502443||measurement||loadtime||0:00:26.984992||5||0
+2015-12-01 17:02:08.105341||measurement||price||2015-12-01 17:02:02.439425@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:02:10.562124||measurement||price||2015-12-01 17:02:04.002685@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:02:10.770677||measurement||loadtime||0:00:29.909533||0||1
+2015-12-01 17:02:13.514688||measurement||price||2015-12-01 17:01:53.943146@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:02:18.052052||error||collecting ads||Error||3||0
+2015-12-01 17:02:19.106125||measurement||price||2015-12-01 17:02:13.688823@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 17:02:20.438545||measurement||price||2015-12-01 17:02:02.439425@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:02:20.748794||measurement||loadtime||0:00:28.874431||4||1
+2015-12-01 17:02:23.451522||measurement||price||2015-12-01 17:02:04.002685@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:02:24.862319||measurement||price||2015-12-01 17:02:18.005665@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:02:27.549598||measurement||loadtime||0:00:26.776635||2||0
+2015-12-01 17:02:30.659345||measurement||loadtime||0:00:29.192193||1||1
+2015-12-01 17:02:31.445920||measurement||price||2015-12-01 17:02:13.688823@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 17:02:34.493324||measurement||price||2015-12-01 17:02:27.922981@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:02:37.703771||measurement||price||2015-12-01 17:02:18.005665@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:02:38.564443||measurement||loadtime||0:00:27.056777||5||0
+2015-12-01 17:02:38.564577||event||progress-marker||measurement-end||5||0
+2015-12-01 17:02:40.251116||error||collecting ads||Error||3||0
+2015-12-01 17:02:40.251246||event||progress-marker||measurement-end||3||0
+2015-12-01 17:02:44.447645||measurement||price||2015-12-01 17:02:37.894880@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:02:44.904275||measurement||loadtime||0:00:29.129113||0||1
+2015-12-01 17:02:47.334588||measurement||price||2015-12-01 17:02:27.922981@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:02:49.787178||error||collecting ads||Error||2||0
+2015-12-01 17:02:49.787312||event||progress-marker||measurement-end||2||0
+2015-12-01 17:02:54.586779||measurement||loadtime||0:00:28.835621||4||1
+2015-12-01 17:02:57.487868||measurement||price||2015-12-01 17:02:37.894880@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:02:58.761833||measurement||price||2015-12-01 17:02:52.172278@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:03:04.687304||measurement||loadtime||0:00:29.024090||1||1
+2015-12-01 17:03:08.160047||measurement||price||2015-12-01 17:03:01.685680@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:03:11.629965||measurement||price||2015-12-01 17:02:52.172278@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:03:18.831158||measurement||loadtime||0:00:28.923976||0||1
+2015-12-01 17:03:21.036354||measurement||price||2015-12-01 17:03:01.685680@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:03:28.227056||measurement||loadtime||0:00:28.635005||4||1
+2015-12-01 17:03:28.570518||error||collecting ads||Error||1||1
+2015-12-01 17:03:32.726608||measurement||price||2015-12-01 17:03:26.137907@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:03:41.845394||measurement||price||2015-12-01 17:03:35.339158@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:03:45.537160||measurement||price||2015-12-01 17:03:26.137907@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:03:52.289846||error||collecting ads||Error||1||1
+2015-12-01 17:03:52.741304||measurement||loadtime||0:00:28.904904||0||1
+2015-12-01 17:03:54.858837||measurement||price||2015-12-01 17:03:35.339158@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:04:02.057683||measurement||loadtime||0:00:28.826543||4||1
+2015-12-01 17:04:05.967643||measurement||price||2015-12-01 17:03:59.368658@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:04:06.999415||measurement||price||2015-12-01 17:04:00.706143@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||0||1
+2015-12-01 17:04:15.680925||measurement||price||2015-12-01 17:04:09.172871@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:04:18.951878||measurement||price||2015-12-01 17:03:59.368658@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:04:20.065761||measurement||price||2015-12-01 17:04:00.706143@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||0||1
+2015-12-01 17:04:26.151334||measurement||loadtime||0:00:28.856249||1||1
+2015-12-01 17:04:26.151466||event||progress-marker||measurement-end||1||1
+2015-12-01 17:04:27.264394||measurement||loadtime||0:00:29.517878||0||1
+2015-12-01 17:04:28.545532||measurement||price||2015-12-01 17:04:09.172871@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:04:35.759165||measurement||loadtime||0:00:28.696271||4||1
+2015-12-01 17:04:35.759270||event||progress-marker||measurement-end||4||1
+2015-12-01 17:04:51.077144||error||collecting ads||Error||0||1
+2015-12-01 17:05:05.015904||measurement||price||2015-12-01 17:04:58.290196@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:05:17.888248||measurement||price||2015-12-01 17:04:58.290196@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:05:25.085081||measurement||loadtime||0:00:29.002706||0||1
+2015-12-01 17:05:25.085215||event||progress-marker||measurement-end||0||1
+2015-12-01 17:05:25.413263||meta||block_id end||13
+2015-12-01 17:05:25.413560||meta||block_id start||14
+2015-12-01 17:05:25.413591||meta||assignment||0@|2@|4@|3@|1@|5
+2015-12-01 17:05:26.982098||event||progress-marker||training-start||4||0
+2015-12-01 17:05:26.982193||event||progress-marker||training-end||4||0
+2015-12-01 17:05:27.044353||event||progress-marker||training-start||0||0
+2015-12-01 17:05:27.044971||event||progress-marker||training-end||0||0
+2015-12-01 17:05:27.059057||event||progress-marker||training-start||2||0
+2015-12-01 17:05:27.059193||event||progress-marker||training-end||2||0
+2015-12-01 17:05:32.039777||event||progress-marker||measurement-start||4||0
+2015-12-01 17:05:32.086156||event||progress-marker||measurement-start||0||0
+2015-12-01 17:05:32.101782||event||progress-marker||measurement-start||2||0
+2015-12-01 17:05:45.380825||measurement||price||2015-12-01 17:05:39.626417@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:05:47.322101||measurement||price||2015-12-01 17:05:39.399868@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:05:57.338874||error||collecting ads||Error||2||0
+2015-12-01 17:05:57.738220||measurement||price||2015-12-01 17:05:39.626417@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:05:59.669969||measurement||price||2015-12-01 17:05:39.399868@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:06:04.850737||measurement||loadtime||0:00:27.805729||4||0
+2015-12-01 17:06:06.789685||measurement||loadtime||0:00:29.698365||0||0
+2015-12-01 17:06:19.191732||measurement||price||2015-12-01 17:06:13.611304@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:06:19.806814||error||collecting ads||Error||2||0
+2015-12-01 17:06:27.609452||error||collecting ads||Error||4||0
+2015-12-01 17:06:31.512553||measurement||price||2015-12-01 17:06:13.611304@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:06:32.036220||measurement||price||2015-12-01 17:06:26.428476@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:06:38.631907||measurement||loadtime||0:00:26.837680||0||0
+2015-12-01 17:06:44.393717||measurement||price||2015-12-01 17:06:26.428476@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:06:49.758976||error||collecting ads||Error||4||0
+2015-12-01 17:06:50.848800||measurement||price||2015-12-01 17:06:45.225131@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:06:51.509426||measurement||loadtime||0:00:26.697394||2||0
+2015-12-01 17:07:02.341247||measurement||price||2015-12-01 17:06:56.722012@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:07:03.177933||measurement||price||2015-12-01 17:06:45.225131@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:07:03.776829||measurement||price||2015-12-01 17:06:58.136851@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:07:06.935857||event||progress-marker||training-start||5||1
+2015-12-01 17:07:06.936011||event||progress-marker||training-end||5||1
+2015-12-01 17:07:10.291877||measurement||loadtime||0:00:26.659625||0||0
+2015-12-01 17:07:11.970492||event||progress-marker||measurement-start||5||1
+2015-12-01 17:07:14.665401||measurement||price||2015-12-01 17:06:56.722012@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:07:16.072621||measurement||price||2015-12-01 17:06:58.136851@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:07:21.771147||measurement||loadtime||0:00:27.007583||4||0
+2015-12-01 17:07:23.165236||measurement||loadtime||0:00:26.650545||2||0
+2015-12-01 17:07:25.825689||measurement||price||2015-12-01 17:07:19.649116@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:07:32.547664||error||collecting ads||Error||0||0
+2015-12-01 17:07:33.976248||measurement||price||2015-12-01 17:07:28.379757@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:07:35.328458||measurement||price||2015-12-01 17:07:29.772010@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:07:38.743906||measurement||price||2015-12-01 17:07:19.649116@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:07:41.709526||event||progress-marker||training-start||3||1
+2015-12-01 17:07:41.709640||event||progress-marker||training-end||3||1
+2015-12-01 17:07:45.942021||measurement||loadtime||0:00:28.966859||5||1
+2015-12-01 17:07:46.284440||measurement||price||2015-12-01 17:07:28.379757@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:07:46.745706||event||progress-marker||measurement-start||3||1
+2015-12-01 17:07:47.657669||measurement||price||2015-12-01 17:07:29.772010@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:07:53.372134||measurement||loadtime||0:00:26.596978||4||0
+2015-12-01 17:07:54.772622||measurement||loadtime||0:00:26.602217||2||0
+2015-12-01 17:07:54.784602||error||collecting ads||Error||0||0
+2015-12-01 17:07:59.421601||measurement||price||2015-12-01 17:07:53.211938@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:08:01.997172||event||progress-marker||training-start||1||1
+2015-12-01 17:08:01.997291||event||progress-marker||training-end||1||1
+2015-12-01 17:08:05.625951||measurement||price||2015-12-01 17:07:59.985437@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:08:07.031327||event||progress-marker||measurement-start||1||1
+2015-12-01 17:08:07.112106||measurement||price||2015-12-01 17:08:01.398777@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:08:11.222730||error||collecting ads||Error||3||1
+2015-12-01 17:08:12.439740||measurement||price||2015-12-01 17:07:53.211938@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:08:17.080919||error||collecting ads||Error||2||0
+2015-12-01 17:08:17.924870||measurement||price||2015-12-01 17:07:59.985437@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:08:19.450615||measurement||price||2015-12-01 17:08:01.398777@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:08:19.667459||measurement||loadtime||0:00:28.720208||5||1
+2015-12-01 17:08:21.117135||measurement||price||2015-12-01 17:08:15.005512@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:08:24.984585||measurement||price||2015-12-01 17:08:18.488492@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:08:25.017850||measurement||loadtime||0:00:26.640530||4||0
+2015-12-01 17:08:26.551259||measurement||loadtime||0:00:26.764129||0||0
+2015-12-01 17:08:29.298285||measurement||price||2015-12-01 17:08:23.785776@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:08:33.190542||measurement||price||2015-12-01 17:08:26.975416@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:08:33.943204||measurement||price||2015-12-01 17:08:15.005512@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:08:37.288166||measurement||price||2015-12-01 17:08:31.689287@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:08:37.891260||measurement||price||2015-12-01 17:08:18.488492@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:08:38.809931||measurement||price||2015-12-01 17:08:33.164591@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:08:41.195598||measurement||loadtime||0:00:29.158959||1||1
+2015-12-01 17:08:41.642853||measurement||price||2015-12-01 17:08:23.785776@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:08:45.095189||measurement||loadtime||0:00:28.867226||3||1
+2015-12-01 17:08:46.003410||measurement||price||2015-12-01 17:08:26.975416@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:08:48.759148||measurement||loadtime||0:00:26.674859||2||0
+2015-12-01 17:08:49.631141||measurement||price||2015-12-01 17:08:31.689287@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:08:51.157185||measurement||price||2015-12-01 17:08:33.164591@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:08:53.237970||measurement||loadtime||0:00:28.566828||5||1
+2015-12-01 17:08:55.128872||measurement||price||2015-12-01 17:08:49.002852@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||1||1
+2015-12-01 17:08:56.744913||measurement||loadtime||0:00:26.721834||4||0
+2015-12-01 17:08:58.269883||measurement||loadtime||0:00:26.714874||0||0
+2015-12-01 17:08:58.994396||measurement||price||2015-12-01 17:08:52.448794@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:09:01.055259||measurement||price||2015-12-01 17:08:55.541194@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:09:06.953447||measurement||price||2015-12-01 17:09:00.568435@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:09:08.040539||measurement||price||2015-12-01 17:08:49.002852@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||1||1
+2015-12-01 17:09:08.933710||measurement||price||2015-12-01 17:09:03.337144@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:09:10.531055||measurement||price||2015-12-01 17:09:04.956639@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:09:11.931439||measurement||price||2015-12-01 17:08:52.448794@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:09:13.378738||measurement||price||2015-12-01 17:08:55.541194@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:09:15.272264||measurement||loadtime||0:00:29.071447||1||1
+2015-12-01 17:09:19.120139||measurement||loadtime||0:00:29.024297||3||1
+2015-12-01 17:09:19.806156||measurement||price||2015-12-01 17:09:00.568435@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:09:20.495146||measurement||loadtime||0:00:26.730798||2||0
+2015-12-01 17:09:21.281358||measurement||price||2015-12-01 17:09:03.337144@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:09:22.868840||measurement||price||2015-12-01 17:09:04.956639@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:09:27.039152||measurement||loadtime||0:00:28.795965||5||1
+2015-12-01 17:09:28.398770||measurement||loadtime||0:00:26.650970||4||0
+2015-12-01 17:09:28.955329||measurement||price||2015-12-01 17:09:22.843808@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 17:09:29.980977||measurement||loadtime||0:00:26.709799||0||0
+2015-12-01 17:09:32.746565||measurement||price||2015-12-01 17:09:27.170359@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:09:33.334087||measurement||price||2015-12-01 17:09:26.998463@|Coast@|$9.54@|Coast HP1 Focusing 220 Lumen LED Flashlight||3||1
+2015-12-01 17:09:40.605351||measurement||price||2015-12-01 17:09:34.972049@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:09:41.898271||measurement||price||2015-12-01 17:09:22.843808@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 17:09:42.291765||measurement||price||2015-12-01 17:09:36.614618@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:09:45.052142||measurement||price||2015-12-01 17:09:27.170359@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:09:46.260230||measurement||price||2015-12-01 17:09:26.998463@|Coast@|$31.41@|Coast HL7 Focusing 285 Lumen LED Headlamp||3||1
+2015-12-01 17:09:49.108693||measurement||loadtime||0:00:28.836085||1||1
+2015-12-01 17:09:50.398604||error||collecting ads||Error||5||1
+2015-12-01 17:09:52.142364||measurement||loadtime||0:00:26.641993||2||0
+2015-12-01 17:09:52.959252||measurement||price||2015-12-01 17:09:34.972049@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:09:53.444534||measurement||loadtime||0:00:29.319161||3||1
+2015-12-01 17:09:54.639665||measurement||price||2015-12-01 17:09:36.614618@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:10:00.074118||measurement||loadtime||0:00:26.670967||4||0
+2015-12-01 17:10:01.741034||measurement||loadtime||0:00:26.757903||0||0
+2015-12-01 17:10:02.671864||measurement||price||2015-12-01 17:09:56.517528@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:10:04.196136||measurement||price||2015-12-01 17:09:57.617040@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:10:04.410888||measurement||price||2015-12-01 17:09:58.761531@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:10:07.305294||measurement||price||2015-12-01 17:10:00.947327@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:10:14.126624||measurement||price||2015-12-01 17:10:08.471133@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:10:15.506708||measurement||price||2015-12-01 17:09:56.517528@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:10:16.720427||measurement||price||2015-12-01 17:09:58.761531@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:10:17.186461||measurement||price||2015-12-01 17:09:57.617040@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:10:20.243779||measurement||price||2015-12-01 17:10:00.947327@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:10:22.282384||error||collecting ads||Error||4||0
+2015-12-01 17:10:22.723527||measurement||loadtime||0:00:28.613806||1||1
+2015-12-01 17:10:23.811445||measurement||loadtime||0:00:26.664293||2||0
+2015-12-01 17:10:24.415605||measurement||loadtime||0:00:29.011775||5||1
+2015-12-01 17:10:26.470128||measurement||price||2015-12-01 17:10:08.471133@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:10:27.460301||measurement||loadtime||0:00:29.013156||3||1
+2015-12-01 17:10:33.583159||measurement||loadtime||0:00:26.836957||0||0
+2015-12-01 17:10:34.536141||measurement||price||2015-12-01 17:10:28.913986@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:10:36.155129||measurement||price||2015-12-01 17:10:30.529652@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:10:36.428441||measurement||price||2015-12-01 17:10:30.273838@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:10:41.583014||measurement||price||2015-12-01 17:10:34.869114@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:10:45.758627||measurement||price||2015-12-01 17:10:40.161980@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:10:46.866100||measurement||price||2015-12-01 17:10:28.913986@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:10:48.098145||error||collecting ads||Error||5||1
+2015-12-01 17:10:48.494800||measurement||price||2015-12-01 17:10:30.529652@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:10:49.241360||measurement||price||2015-12-01 17:10:30.273838@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:10:53.975171||measurement||loadtime||0:00:26.687579||4||0
+2015-12-01 17:10:54.715057||measurement||price||2015-12-01 17:10:34.869114@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:10:55.612902||measurement||loadtime||0:00:26.797768||2||0
+2015-12-01 17:10:56.459171||measurement||loadtime||0:00:28.730437||1||1
+2015-12-01 17:10:58.114828||measurement||price||2015-12-01 17:10:40.161980@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:11:01.647752||measurement||price||2015-12-01 17:10:55.229832@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:11:01.918512||measurement||loadtime||0:00:29.455359||3||1
+2015-12-01 17:11:05.219176||measurement||loadtime||0:00:26.630796||0||0
+2015-12-01 17:11:06.416750||measurement||price||2015-12-01 17:11:00.774045@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:11:07.906189||measurement||price||2015-12-01 17:11:02.333072@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:11:14.516835||measurement||price||2015-12-01 17:10:55.229832@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:11:15.727812||measurement||price||2015-12-01 17:11:09.312246@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:11:17.421521||measurement||price||2015-12-01 17:11:11.850179@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:11:18.741482||measurement||price||2015-12-01 17:11:00.774045@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:11:20.257646||measurement||price||2015-12-01 17:11:02.333072@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:11:20.323187||error||collecting ads||Error||1||1
+2015-12-01 17:11:21.733181||measurement||loadtime||0:00:28.629785||5||1
+2015-12-01 17:11:25.849470||measurement||loadtime||0:00:26.869055||4||0
+2015-12-01 17:11:27.365237||measurement||loadtime||0:00:26.747132||2||0
+2015-12-01 17:11:28.669450||measurement||price||2015-12-01 17:11:09.312246@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:11:29.786343||measurement||price||2015-12-01 17:11:11.850179@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:11:33.941157||measurement||price||2015-12-01 17:11:27.822757@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:11:35.887156||measurement||loadtime||0:00:28.963446||3||1
+2015-12-01 17:11:36.897060||measurement||loadtime||0:00:26.672979||0||0
+2015-12-01 17:11:38.020506||measurement||price||2015-12-01 17:11:32.399793@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:11:45.589254||error||collecting ads||Error||5||1
+2015-12-01 17:11:46.815345||measurement||price||2015-12-01 17:11:27.822757@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:11:50.130823||error||collecting ads||Error||2||0
+2015-12-01 17:11:50.205374||measurement||price||2015-12-01 17:11:43.857936@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||3||1
+2015-12-01 17:11:50.407129||measurement||price||2015-12-01 17:11:32.399793@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:11:54.028854||measurement||loadtime||0:00:28.700463||1||1
+2015-12-01 17:11:57.534639||measurement||loadtime||0:00:26.679945||4||0
+2015-12-01 17:11:59.205004||error||collecting ads||Error||0||0
+2015-12-01 17:12:02.373824||measurement||price||2015-12-01 17:11:56.728898@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:12:03.275971||measurement||price||2015-12-01 17:11:43.857936@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||3||1
+2015-12-01 17:12:07.586723||measurement||price||2015-12-01 17:12:01.475376@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 17:12:09.167252||error||collecting ads||Error||5||1
+2015-12-01 17:12:09.824133||measurement||price||2015-12-01 17:12:04.141912@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:12:10.494423||measurement||loadtime||0:00:29.605515||3||1
+2015-12-01 17:12:11.453404||measurement||price||2015-12-01 17:12:05.876217@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:12:14.729709||measurement||price||2015-12-01 17:11:56.728898@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:12:20.407826||measurement||price||2015-12-01 17:12:01.475376@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 17:12:21.830559||measurement||loadtime||0:00:26.694538||2||0
+2015-12-01 17:12:22.174299||measurement||price||2015-12-01 17:12:04.141912@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:12:22.805664||measurement||price||2015-12-01 17:12:16.385337@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:12:23.791931||measurement||price||2015-12-01 17:12:05.876217@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:12:24.408156||measurement||price||2015-12-01 17:12:17.841968@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:12:27.641044||measurement||loadtime||0:00:28.609898||1||1
+2015-12-01 17:12:29.283175||measurement||loadtime||0:00:26.743339||4||0
+2015-12-01 17:12:30.906586||measurement||loadtime||0:00:26.699426||0||0
+2015-12-01 17:12:35.682562||measurement||price||2015-12-01 17:12:16.385337@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:12:37.380369||measurement||price||2015-12-01 17:12:17.841968@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:12:41.207412||measurement||price||2015-12-01 17:12:35.090527@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 17:12:41.586814||measurement||price||2015-12-01 17:12:35.948705@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:12:42.916653||measurement||loadtime||0:00:28.744173||5||1
+2015-12-01 17:12:43.148439||measurement||price||2015-12-01 17:12:37.493124@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:12:44.076813||error||collecting ads||Error||2||0
+2015-12-01 17:12:44.597018||measurement||loadtime||0:00:29.097379||3||1
+2015-12-01 17:12:53.937098||measurement||price||2015-12-01 17:12:35.948705@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:12:54.030988||measurement||price||2015-12-01 17:12:35.090527@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 17:12:55.493673||measurement||price||2015-12-01 17:12:37.493124@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:12:56.767090||measurement||price||2015-12-01 17:12:51.152061@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 17:13:01.045294||measurement||loadtime||0:00:26.756905||4||0
+2015-12-01 17:13:01.250499||measurement||loadtime||0:00:28.607360||1||1
+2015-12-01 17:13:02.605334||measurement||loadtime||0:00:26.694179||0||0
+2015-12-01 17:13:06.814469||error||collecting ads||Error||5||1
+2015-12-01 17:13:08.525147||error||collecting ads||Error||3||1
+2015-12-01 17:13:13.724390||measurement||price||2015-12-01 17:13:08.076607@|Extech@|$17.75@|Extech MN35 Digital Mini MultiMeter||4||0
+2015-12-01 17:13:14.839273||measurement||price||2015-12-01 17:13:09.189876@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:13:19.096335||error||collecting ads||Error||2||0
+2015-12-01 17:13:22.234126||measurement||price||2015-12-01 17:13:15.865837@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:13:25.277991||error||collecting ads||Error||1||1
+2015-12-01 17:13:26.064278||measurement||price||2015-12-01 17:13:08.076607@|Extech@|$39.99@|Extech CB10 Circuit Breaker Finder locates fuses/breakers, t...||4||0
+2015-12-01 17:13:27.169918||measurement||price||2015-12-01 17:13:09.189876@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:13:30.406025||error||collecting ads||Error||5||1
+2015-12-01 17:13:33.172883||measurement||loadtime||0:00:27.125712||4||0
+2015-12-01 17:13:34.279527||measurement||loadtime||0:00:26.672372||0||0
+2015-12-01 17:13:35.088258||measurement||price||2015-12-01 17:13:15.865837@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:13:38.842111||measurement||price||2015-12-01 17:13:32.720948@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:13:41.287662||error||collecting ads||Error||2||0
+2015-12-01 17:13:42.315820||measurement||loadtime||0:00:28.788667||3||1
+2015-12-01 17:13:44.281648||measurement||price||2015-12-01 17:13:37.611478@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:13:45.485888||measurement||price||2015-12-01 17:13:39.801138@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:13:46.570917||measurement||price||2015-12-01 17:13:40.978479@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:13:51.697477||measurement||price||2015-12-01 17:13:32.720948@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:13:56.192794||measurement||price||2015-12-01 17:13:49.634793@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:13:57.121881||measurement||price||2015-12-01 17:13:37.611478@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:13:57.826133||measurement||price||2015-12-01 17:13:39.801138@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:13:58.909199||measurement||price||2015-12-01 17:13:40.978479@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:13:58.915148||measurement||loadtime||0:00:28.631875||1||1
+2015-12-01 17:14:03.591933||error||collecting ads||Error||2||0
+2015-12-01 17:14:04.339213||measurement||loadtime||0:00:28.927983||5||1
+2015-12-01 17:14:04.947116||measurement||loadtime||0:00:26.769017||4||0
+2015-12-01 17:14:06.031599||measurement||loadtime||0:00:26.748462||0||0
+2015-12-01 17:14:09.069884||measurement||price||2015-12-01 17:13:49.634793@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:14:12.617746||measurement||price||2015-12-01 17:14:06.499184@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:14:16.283209||measurement||loadtime||0:00:28.962151||3||1
+2015-12-01 17:14:17.423234||measurement||price||2015-12-01 17:14:11.772955@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:14:18.353218||measurement||price||2015-12-01 17:14:11.757501@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:14:25.452852||measurement||price||2015-12-01 17:14:06.499184@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:14:25.820134||error||collecting ads||Error||2||0
+2015-12-01 17:14:28.318855||error||collecting ads||Error||0||0
+2015-12-01 17:14:29.771828||measurement||price||2015-12-01 17:14:11.772955@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:14:30.444014||measurement||price||2015-12-01 17:14:23.589248@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:14:31.189996||measurement||price||2015-12-01 17:14:11.757501@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:14:32.680159||measurement||loadtime||0:00:28.760965||1||1
+2015-12-01 17:14:36.887183||measurement||loadtime||0:00:26.936023||4||0
+2015-12-01 17:14:38.074697||measurement||price||2015-12-01 17:14:32.465259@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:14:38.421505||measurement||loadtime||0:00:29.078197||5||1
+2015-12-01 17:14:43.398501||measurement||price||2015-12-01 17:14:23.589248@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:14:46.278166||measurement||price||2015-12-01 17:14:40.148929@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 17:14:49.541810||measurement||price||2015-12-01 17:14:43.935608@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:14:50.413693||measurement||price||2015-12-01 17:14:32.465259@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:14:50.586242||error||collecting ads||Error||0||0
+2015-12-01 17:14:50.599188||measurement||loadtime||0:00:29.310728||3||1
+2015-12-01 17:14:51.996579||measurement||price||2015-12-01 17:14:45.614428@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:14:57.522057||measurement||loadtime||0:00:26.701506||2||0
+2015-12-01 17:14:57.522153||event||progress-marker||measurement-end||2||0
+2015-12-01 17:14:59.090804||measurement||price||2015-12-01 17:14:40.148929@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 17:15:01.847613||measurement||price||2015-12-01 17:14:43.935608@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:15:02.850224||measurement||price||2015-12-01 17:14:57.236019@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:15:04.838417||measurement||price||2015-12-01 17:14:57.973525@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:15:04.924903||measurement||price||2015-12-01 17:14:45.614428@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:15:06.302769||measurement||loadtime||0:00:28.617375||1||1
+2015-12-01 17:15:08.928733||measurement||loadtime||0:00:27.037581||4||0
+2015-12-01 17:15:12.139155||measurement||loadtime||0:00:28.715427||5||1
+2015-12-01 17:15:15.207125||measurement||price||2015-12-01 17:14:57.236019@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:15:17.760253||measurement||price||2015-12-01 17:14:57.973525@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:15:22.327555||measurement||loadtime||0:00:26.736105||0||0
+2015-12-01 17:15:22.327658||event||progress-marker||measurement-end||0||0
+2015-12-01 17:15:24.973242||measurement||loadtime||0:00:29.370067||3||1
+2015-12-01 17:15:25.796982||measurement||price||2015-12-01 17:15:19.363147@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:15:29.972534||error||collecting ads||Error||1||1
+2015-12-01 17:15:31.235059||error||collecting ads||Error||4||0
+2015-12-01 17:15:31.235162||event||progress-marker||measurement-end||4||0
+2015-12-01 17:15:38.632422||measurement||price||2015-12-01 17:15:19.363147@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:15:43.369184||measurement||price||2015-12-01 17:15:37.409591@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:15:45.863533||measurement||loadtime||0:00:28.720379||5||1
+2015-12-01 17:15:48.586662||error||collecting ads||Error||3||1
+2015-12-01 17:15:56.300900||measurement||price||2015-12-01 17:15:37.409591@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:15:59.388573||measurement||price||2015-12-01 17:15:53.050405@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:16:02.177748||measurement||price||2015-12-01 17:15:55.822412@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:16:03.499079||measurement||loadtime||0:00:28.521284||1||1
+2015-12-01 17:16:12.231178||measurement||price||2015-12-01 17:15:53.050405@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:16:15.002317||measurement||price||2015-12-01 17:15:55.822412@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:16:19.460265||measurement||loadtime||0:00:28.593083||5||1
+2015-12-01 17:16:22.232865||measurement||loadtime||0:00:28.640956||3||1
+2015-12-01 17:16:26.983709||error||collecting ads||Error||1||1
+2015-12-01 17:16:33.028219||measurement||price||2015-12-01 17:16:26.719085@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:16:40.497258||measurement||price||2015-12-01 17:16:34.376027@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 17:16:45.814473||measurement||price||2015-12-01 17:16:26.719085@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:16:46.107476||error||collecting ads||Error||3||1
+2015-12-01 17:16:53.043250||measurement||loadtime||0:00:28.577736||5||1
+2015-12-01 17:16:53.332214||measurement||price||2015-12-01 17:16:34.376027@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 17:17:00.125819||measurement||price||2015-12-01 17:16:53.279552@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:17:00.563187||measurement||loadtime||0:00:28.574152||1||1
+2015-12-01 17:17:06.722011||measurement||price||2015-12-01 17:17:00.312569@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:17:13.331788||measurement||price||2015-12-01 17:16:53.279552@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:17:14.566495||measurement||price||2015-12-01 17:17:08.541349@|Irwin Tools@|$129.95@|Irwin Tools 1868997 Multiple Tool Set, 13-Piece||1||1
+2015-12-01 17:17:19.523368||measurement||price||2015-12-01 17:17:00.312569@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:17:20.550400||measurement||loadtime||0:00:29.437697||3||1
+2015-12-01 17:17:26.752055||measurement||loadtime||0:00:28.703578||5||1
+2015-12-01 17:17:26.752188||event||progress-marker||measurement-end||5||1
+2015-12-01 17:17:27.362291||measurement||price||2015-12-01 17:17:08.541349@|Irwin Tools@|$11.07@|IRWIN Tools VISE-GRIP Locking Pliers, Fast Release, Curved J...||1||1
+2015-12-01 17:17:34.349074||measurement||price||2015-12-01 17:17:27.797906@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:17:34.581966||measurement||loadtime||0:00:29.017520||1||1
+2015-12-01 17:17:47.330581||measurement||price||2015-12-01 17:17:27.797906@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:17:48.104544||measurement||price||2015-12-01 17:17:41.950950@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 17:17:54.528292||measurement||loadtime||0:00:28.972651||3||1
+2015-12-01 17:18:00.897208||measurement||price||2015-12-01 17:17:41.950950@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 17:18:08.098683||measurement||loadtime||0:00:28.511527||1||1
+2015-12-01 17:18:08.326459||measurement||price||2015-12-01 17:18:01.875634@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:18:21.170070||measurement||price||2015-12-01 17:18:01.875634@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:18:22.028134||measurement||price||2015-12-01 17:18:16.070441@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||1
+2015-12-01 17:18:28.371976||measurement||loadtime||0:00:28.838454||3||1
+2015-12-01 17:18:28.372105||event||progress-marker||measurement-end||3||1
+2015-12-01 17:18:34.960807||measurement||price||2015-12-01 17:18:16.070441@|Warner Bros@|$46.33@|Jurassic World Team Pack - LEGO Dimensions||1||1
+2015-12-01 17:18:42.173951||measurement||loadtime||0:00:29.069945||1||1
+2015-12-01 17:18:42.174134||event||progress-marker||measurement-end||1||1
+2015-12-01 17:18:42.738366||meta||block_id end||14
+2015-12-01 17:18:42.738744||meta||block_id start||15
+2015-12-01 17:18:42.738778||meta||assignment||4@|2@|1@|3@|0@|5
+2015-12-01 17:18:44.357669||event||progress-marker||training-start||4||0
+2015-12-01 17:18:44.357778||event||progress-marker||training-end||4||0
+2015-12-01 17:18:44.367098||event||progress-marker||training-start||1||0
+2015-12-01 17:18:44.369645||event||progress-marker||training-end||1||0
+2015-12-01 17:18:44.379984||event||progress-marker||training-start||2||0
+2015-12-01 17:18:44.380074||event||progress-marker||training-end||2||0
+2015-12-01 17:18:48.559377||event||progress-marker||training-start||0||1
+2015-12-01 17:18:48.559478||event||progress-marker||training-end||0||1
+2015-12-01 17:18:49.400140||event||progress-marker||measurement-start||4||0
+2015-12-01 17:18:49.408561||event||progress-marker||measurement-start||1||0
+2015-12-01 17:18:49.416652||event||progress-marker||measurement-start||2||0
+2015-12-01 17:18:53.599746||event||progress-marker||measurement-start||0||1
+2015-12-01 17:19:03.035709||measurement||price||2015-12-01 17:18:56.914391@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:19:03.050874||measurement||price||2015-12-01 17:18:56.977345@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:19:05.401597||measurement||price||2015-12-01 17:18:57.539472@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:19:15.370478||measurement||price||2015-12-01 17:18:56.914391@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:19:15.380498||measurement||price||2015-12-01 17:18:56.977345@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:19:17.750161||measurement||price||2015-12-01 17:18:57.539472@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:19:18.648154||error||collecting ads||Error||0||1
+2015-12-01 17:19:22.477613||measurement||loadtime||0:00:28.066436||1||0
+2015-12-01 17:19:22.487201||measurement||loadtime||0:00:28.068035||2||0
+2015-12-01 17:19:24.847178||measurement||loadtime||0:00:30.441811||4||0
+2015-12-01 17:19:32.312673||measurement||price||2015-12-01 17:19:25.902213@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:19:34.992892||measurement||price||2015-12-01 17:19:29.217286@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:19:37.745284||measurement||price||2015-12-01 17:19:31.993933@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:19:44.917218||error||collecting ads||Error||2||0
+2015-12-01 17:19:45.187428||measurement||price||2015-12-01 17:19:25.902213@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:19:47.315606||measurement||price||2015-12-01 17:19:29.217286@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:19:50.047646||measurement||price||2015-12-01 17:19:31.993933@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:19:52.403159||measurement||loadtime||0:00:28.749798||0||1
+2015-12-01 17:19:54.427169||measurement||loadtime||0:00:26.944345||1||0
+2015-12-01 17:19:57.151188||measurement||loadtime||0:00:27.299956||4||0
+2015-12-01 17:19:57.803305||measurement||price||2015-12-01 17:19:52.515279@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:20:06.860843||measurement||price||2015-12-01 17:20:01.244642@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:20:09.521955||measurement||price||2015-12-01 17:20:03.964583@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:20:10.126898||measurement||price||2015-12-01 17:19:52.515279@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:20:16.191803||error||collecting ads||Error||0||1
+2015-12-01 17:20:17.235313||measurement||loadtime||0:00:27.312852||2||0
+2015-12-01 17:20:19.208384||measurement||price||2015-12-01 17:20:01.244642@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:20:21.839227||measurement||price||2015-12-01 17:20:03.964583@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:20:26.327948||measurement||loadtime||0:00:26.896814||1||0
+2015-12-01 17:20:28.946694||measurement||loadtime||0:00:26.790264||4||0
+2015-12-01 17:20:29.503042||measurement||price||2015-12-01 17:20:23.917071@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:20:30.297866||measurement||price||2015-12-01 17:20:23.518478@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:20:38.666218||measurement||price||2015-12-01 17:20:33.083894@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:20:41.806175||measurement||price||2015-12-01 17:20:23.917071@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:20:43.248992||measurement||price||2015-12-01 17:20:23.518478@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:20:48.893334||measurement||loadtime||0:00:26.654075||2||0
+2015-12-01 17:20:50.514064||measurement||loadtime||0:00:29.317059||0||1
+2015-12-01 17:20:51.001839||measurement||price||2015-12-01 17:20:33.083894@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:20:51.278764||error||collecting ads||Error||4||0
+2015-12-01 17:20:52.168133||event||progress-marker||training-start||3||1
+2015-12-01 17:20:52.168276||event||progress-marker||training-end||3||1
+2015-12-01 17:20:57.205428||event||progress-marker||measurement-start||3||1
+2015-12-01 17:20:58.111159||measurement||loadtime||0:00:26.778988||1||0
+2015-12-01 17:21:01.653728||measurement||price||2015-12-01 17:20:55.996372@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 17:21:04.005997||measurement||price||2015-12-01 17:20:58.425706@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||4||0
+2015-12-01 17:21:04.300751||measurement||price||2015-12-01 17:20:57.871322@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:21:07.209945||event||progress-marker||training-start||5||1
+2015-12-01 17:21:07.210051||event||progress-marker||training-end||5||1
+2015-12-01 17:21:10.628790||measurement||price||2015-12-01 17:21:05.034159@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:21:11.807367||measurement||price||2015-12-01 17:21:05.165028@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:21:12.247516||event||progress-marker||measurement-start||5||1
+2015-12-01 17:21:17.331444||measurement||price||2015-12-01 17:20:57.871322@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:21:22.972438||measurement||price||2015-12-01 17:21:05.034159@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:21:23.969118||error||collecting ads||Error||2||0
+2015-12-01 17:21:24.547137||measurement||loadtime||0:00:29.032036||0||1
+2015-12-01 17:21:24.667202||measurement||price||2015-12-01 17:21:05.165028@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:21:26.343554||error||collecting ads||Error||4||0
+2015-12-01 17:21:26.613083||measurement||price||2015-12-01 17:21:20.145817@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:21:30.087454||measurement||loadtime||0:00:26.973916||1||0
+2015-12-01 17:21:31.880411||measurement||loadtime||0:00:29.669693||3||1
+2015-12-01 17:21:36.564406||measurement||price||2015-12-01 17:21:30.970712@|Extech@|$17.75@|Extech MN35 Digital Mini MultiMeter||2||0
+2015-12-01 17:21:38.358520||measurement||price||2015-12-01 17:21:31.899958@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:21:38.706511||measurement||price||2015-12-01 17:21:33.138608@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:21:39.497811||measurement||price||2015-12-01 17:21:20.145817@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:21:42.339681||measurement||price||2015-12-01 17:21:36.712102@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:21:46.052298||measurement||price||2015-12-01 17:21:39.425342@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:21:46.696773||measurement||loadtime||0:00:29.444035||5||1
+2015-12-01 17:21:48.905073||measurement||price||2015-12-01 17:21:30.970712@|Extech@|$39.99@|Extech CB10 Circuit Breaker Finder locates fuses/breakers, t...||2||0
+2015-12-01 17:21:51.055490||measurement||price||2015-12-01 17:21:33.138608@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:21:51.512674||measurement||price||2015-12-01 17:21:31.899958@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:21:54.684951||measurement||price||2015-12-01 17:21:36.712102@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:21:56.017803||measurement||loadtime||0:00:27.043460||2||0
+2015-12-01 17:21:58.168907||measurement||loadtime||0:00:26.821311||4||0
+2015-12-01 17:21:58.745553||measurement||loadtime||0:00:29.194343||0||1
+2015-12-01 17:21:58.900020||measurement||price||2015-12-01 17:21:39.425342@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:22:00.622442||measurement||price||2015-12-01 17:21:54.221657@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:22:01.795529||measurement||loadtime||0:00:26.704388||1||0
+2015-12-01 17:22:06.121948||measurement||loadtime||0:00:29.240429||3||1
+2015-12-01 17:22:08.250789||measurement||price||2015-12-01 17:22:02.689659@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:22:10.444807||measurement||price||2015-12-01 17:22:04.851543@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:22:12.501227||measurement||price||2015-12-01 17:22:06.048434@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:22:13.597706||measurement||price||2015-12-01 17:21:54.221657@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:22:14.179313||measurement||price||2015-12-01 17:22:08.607176@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:22:20.115074||measurement||price||2015-12-01 17:22:13.650996@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:22:20.593950||measurement||price||2015-12-01 17:22:02.689659@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:22:20.785418||measurement||loadtime||0:00:29.086232||5||1
+2015-12-01 17:22:22.732381||measurement||price||2015-12-01 17:22:04.851543@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:22:25.548840||measurement||price||2015-12-01 17:22:06.048434@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:22:26.520953||measurement||price||2015-12-01 17:22:08.607176@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:22:27.711148||measurement||loadtime||0:00:26.688141||2||0
+2015-12-01 17:22:29.826702||measurement||loadtime||0:00:26.656425||4||0
+2015-12-01 17:22:32.747170||measurement||loadtime||0:00:28.999998||0||1
+2015-12-01 17:22:32.954699||measurement||price||2015-12-01 17:22:13.650996@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:22:33.634233||measurement||loadtime||0:00:26.834917||1||0
+2015-12-01 17:22:40.151150||measurement||loadtime||0:00:29.023983||3||1
+2015-12-01 17:22:42.098202||measurement||price||2015-12-01 17:22:36.518293@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:22:44.601348||error||collecting ads||Error||5||1
+2015-12-01 17:22:45.878004||measurement||price||2015-12-01 17:22:40.319116@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:22:46.509301||measurement||price||2015-12-01 17:22:40.062215@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:22:49.893307||error||collecting ads||Error||2||0
+2015-12-01 17:22:54.124948||measurement||price||2015-12-01 17:22:47.506174@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:22:54.438141||measurement||price||2015-12-01 17:22:36.518293@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:22:58.213261||measurement||price||2015-12-01 17:22:40.319116@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:22:59.401336||measurement||price||2015-12-01 17:22:40.062215@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:23:01.552592||measurement||loadtime||0:00:26.721451||4||0
+2015-12-01 17:23:02.134936||measurement||price||2015-12-01 17:22:56.571517@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:23:05.320891||measurement||loadtime||0:00:26.681438||1||0
+2015-12-01 17:23:06.611173||measurement||loadtime||0:00:28.858773||0||1
+2015-12-01 17:23:07.242394||measurement||price||2015-12-01 17:22:47.506174@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:23:08.494663||error||collecting ads||Error||5||1
+2015-12-01 17:23:13.820359||measurement||price||2015-12-01 17:23:08.217791@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:23:14.458066||measurement||loadtime||0:00:29.301713||3||1
+2015-12-01 17:23:14.478895||measurement||price||2015-12-01 17:22:56.571517@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:23:17.578743||measurement||price||2015-12-01 17:23:11.989566@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:23:20.066173||measurement||price||2015-12-01 17:23:13.675999@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:23:21.595179||measurement||loadtime||0:00:26.696568||2||0
+2015-12-01 17:23:26.152304||measurement||price||2015-12-01 17:23:08.217791@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:23:28.348907||measurement||price||2015-12-01 17:23:21.722465@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:23:29.914439||measurement||price||2015-12-01 17:23:11.989566@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:23:32.312510||error||collecting ads||Error||5||1
+2015-12-01 17:23:33.112679||measurement||price||2015-12-01 17:23:13.675999@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:23:33.244669||measurement||loadtime||0:00:26.688898||4||0
+2015-12-01 17:23:33.933965||measurement||price||2015-12-01 17:23:28.302194@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:23:37.022660||measurement||loadtime||0:00:26.696520||1||0
+2015-12-01 17:23:40.312682||measurement||loadtime||0:00:28.697525||0||1
+2015-12-01 17:23:41.345411||measurement||price||2015-12-01 17:23:21.722465@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:23:45.975614||measurement||price||2015-12-01 17:23:39.522825@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:23:46.220809||measurement||price||2015-12-01 17:23:40.642685@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||4||0
+2015-12-01 17:23:46.285697||measurement||price||2015-12-01 17:23:28.302194@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:23:48.580321||measurement||loadtime||0:00:29.117015||3||1
+2015-12-01 17:23:49.722331||measurement||price||2015-12-01 17:23:44.197068@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:23:53.407768||measurement||loadtime||0:00:26.811363||2||0
+2015-12-01 17:23:53.848230||measurement||price||2015-12-01 17:23:47.436493@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:23:58.552988||measurement||price||2015-12-01 17:23:40.642685@|@|$79.95@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||4||0
+2015-12-01 17:23:58.901303||measurement||price||2015-12-01 17:23:39.522825@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:24:02.070394||measurement||price||2015-12-01 17:23:44.197068@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:24:02.953661||measurement||price||2015-12-01 17:23:56.375236@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||3||1
+2015-12-01 17:24:05.659988||measurement||price||2015-12-01 17:24:00.057880@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:24:05.667137||measurement||loadtime||0:00:27.417276||4||0
+2015-12-01 17:24:06.120038||measurement||loadtime||0:00:28.802295||5||1
+2015-12-01 17:24:06.773533||measurement||price||2015-12-01 17:23:47.436493@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:24:09.186094||measurement||loadtime||0:00:27.158204||1||0
+2015-12-01 17:24:13.992190||measurement||loadtime||0:00:28.674294||0||1
+2015-12-01 17:24:15.848727||measurement||price||2015-12-01 17:23:56.375236@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||3||1
+2015-12-01 17:24:17.883289||measurement||price||2015-12-01 17:24:12.290130@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 17:24:17.993448||measurement||price||2015-12-01 17:24:00.057880@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:24:20.248635||measurement||price||2015-12-01 17:24:13.730056@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:24:23.051617||measurement||loadtime||0:00:29.466097||3||1
+2015-12-01 17:24:25.112915||measurement||loadtime||0:00:26.700511||2||0
+2015-12-01 17:24:30.227937||measurement||price||2015-12-01 17:24:12.290130@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 17:24:31.439455||error||collecting ads||Error||1||0
+2015-12-01 17:24:33.052354||measurement||price||2015-12-01 17:24:13.730056@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:24:36.829475||measurement||price||2015-12-01 17:24:30.241748@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:24:37.338360||measurement||price||2015-12-01 17:24:31.704283@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:24:37.349239||measurement||loadtime||0:00:26.675229||4||0
+2015-12-01 17:24:37.605143||error||collecting ads||Error||0||1
+2015-12-01 17:24:40.255186||measurement||loadtime||0:00:29.129942||5||1
+2015-12-01 17:24:49.652291||measurement||price||2015-12-01 17:24:43.932260@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:24:49.694224||measurement||price||2015-12-01 17:24:31.704283@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:24:49.705867||measurement||price||2015-12-01 17:24:30.241748@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:24:51.967295||measurement||price||2015-12-01 17:24:45.425339@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:24:53.730817||error||collecting ads||Error||1||0
+2015-12-01 17:24:54.260127||measurement||price||2015-12-01 17:24:47.633566@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:24:56.819150||measurement||loadtime||0:00:26.703443||2||0
+2015-12-01 17:24:56.963212||measurement||loadtime||0:00:28.906364||3||1
+2015-12-01 17:25:02.007588||measurement||price||2015-12-01 17:24:43.932260@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:25:04.859274||measurement||price||2015-12-01 17:24:45.425339@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:25:07.254847||measurement||price||2015-12-01 17:24:47.633566@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:25:09.130941||measurement||loadtime||0:00:26.776465||4||0
+2015-12-01 17:25:10.933024||measurement||price||2015-12-01 17:25:04.273655@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:25:12.104599||measurement||loadtime||0:00:29.494236||0||1
+2015-12-01 17:25:14.437890||measurement||loadtime||0:00:29.176832||5||1
+2015-12-01 17:25:15.955453||error||collecting ads||Error||1||0
+2015-12-01 17:25:19.087677||error||collecting ads||Error||2||0
+2015-12-01 17:25:21.425072||measurement||price||2015-12-01 17:25:15.803564@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:25:23.768706||measurement||price||2015-12-01 17:25:04.273655@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:25:25.844742||measurement||price||2015-12-01 17:25:19.389553@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:25:28.259360||measurement||price||2015-12-01 17:25:22.623338@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:25:28.912152||measurement||price||2015-12-01 17:25:22.045790@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:25:30.982366||measurement||loadtime||0:00:29.015226||3||1
+2015-12-01 17:25:31.280259||measurement||price||2015-12-01 17:25:25.629949@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:25:33.788829||measurement||price||2015-12-01 17:25:15.803564@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:25:38.632236||measurement||price||2015-12-01 17:25:19.389553@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:25:40.570216||measurement||price||2015-12-01 17:25:22.623338@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:25:40.899734||measurement||loadtime||0:00:26.763538||4||0
+2015-12-01 17:25:42.020405||measurement||price||2015-12-01 17:25:22.045790@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:25:43.610045||measurement||price||2015-12-01 17:25:25.629949@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:25:44.582588||measurement||price||2015-12-01 17:25:38.303250@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:25:45.871758||measurement||loadtime||0:00:28.766862||0||1
+2015-12-01 17:25:47.656614||measurement||loadtime||0:00:26.695952||1||0
+2015-12-01 17:25:49.323893||measurement||loadtime||0:00:29.884758||5||1
+2015-12-01 17:25:50.727629||measurement||loadtime||0:00:26.634708||2||0
+2015-12-01 17:25:57.519094||measurement||price||2015-12-01 17:25:38.303250@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:25:59.828284||measurement||price||2015-12-01 17:25:53.458754@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:26:00.684072||measurement||price||2015-12-01 17:25:53.934390@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:26:03.126200||error||collecting ads||Error||4||0
+2015-12-01 17:26:03.127689||measurement||price||2015-12-01 17:25:56.696431@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:26:03.414766||measurement||price||2015-12-01 17:25:57.799786@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:26:04.723962||measurement||loadtime||0:00:28.736381||3||1
+2015-12-01 17:26:12.642576||measurement||price||2015-12-01 17:25:53.458754@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:26:13.036297||measurement||price||2015-12-01 17:25:53.934390@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:26:15.754055||measurement||price||2015-12-01 17:25:57.799786@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:26:16.178640||measurement||price||2015-12-01 17:25:56.696431@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:26:18.654272||measurement||price||2015-12-01 17:26:12.206309@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:26:19.878366||measurement||loadtime||0:00:29.001349||0||1
+2015-12-01 17:26:20.141921||measurement||loadtime||0:00:27.482769||1||0
+2015-12-01 17:26:22.872472||measurement||loadtime||0:00:27.141300||2||0
+2015-12-01 17:26:23.375217||measurement||loadtime||0:00:29.049259||5||1
+2015-12-01 17:26:25.701712||error||collecting ads||Error||4||0
+2015-12-01 17:26:31.593931||measurement||price||2015-12-01 17:26:12.206309@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:26:32.365431||measurement||price||2015-12-01 17:26:26.795144@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:26:33.790032||measurement||price||2015-12-01 17:26:27.101370@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 17:26:35.151410||measurement||price||2015-12-01 17:26:29.539056@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:26:37.470189||measurement||price||2015-12-01 17:26:30.762161@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:26:38.000172||measurement||price||2015-12-01 17:26:32.444727@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:26:38.800474||measurement||loadtime||0:00:29.071274||3||1
+2015-12-01 17:26:44.711764||measurement||price||2015-12-01 17:26:26.795144@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:26:46.641018||measurement||price||2015-12-01 17:26:27.101370@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 17:26:47.486955||measurement||price||2015-12-01 17:26:29.539056@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:26:50.361307||measurement||price||2015-12-01 17:26:32.444727@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:26:50.505408||measurement||price||2015-12-01 17:26:30.762161@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:26:51.828363||measurement||loadtime||0:00:26.681150||1||0
+2015-12-01 17:26:52.828535||measurement||price||2015-12-01 17:26:46.128742@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:26:53.857703||measurement||loadtime||0:00:28.974117||0||1
+2015-12-01 17:26:54.609347||measurement||loadtime||0:00:26.733797||2||0
+2015-12-01 17:26:57.471150||measurement||loadtime||0:00:26.764254||4||0
+2015-12-01 17:26:57.723210||measurement||loadtime||0:00:29.344068||5||1
+2015-12-01 17:27:04.051891||measurement||price||2015-12-01 17:26:58.458312@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:27:05.793984||measurement||price||2015-12-01 17:26:46.128742@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:27:09.734792||measurement||price||2015-12-01 17:27:04.175778@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:27:11.674509||measurement||price||2015-12-01 17:27:05.091696@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:27:13.009225||measurement||loadtime||0:00:29.203509||3||1
+2015-12-01 17:27:16.408734||measurement||price||2015-12-01 17:26:58.458312@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:27:17.537994||error||collecting ads||Error||2||0
+2015-12-01 17:27:17.838703||error||collecting ads||Error||0||1
+2015-12-01 17:27:22.066522||measurement||price||2015-12-01 17:27:04.175778@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:27:23.523146||measurement||loadtime||0:00:26.689561||1||0
+2015-12-01 17:27:24.705612||measurement||price||2015-12-01 17:27:05.091696@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:27:27.152109||measurement||price||2015-12-01 17:27:21.041880@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||3||1
+2015-12-01 17:27:29.183162||measurement||loadtime||0:00:26.708019||4||0
+2015-12-01 17:27:29.870399||measurement||price||2015-12-01 17:27:24.243231@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:27:31.646235||measurement||price||2015-12-01 17:27:25.091507@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 17:27:31.939167||measurement||loadtime||0:00:29.210741||5||1
+2015-12-01 17:27:40.155958||measurement||price||2015-12-01 17:27:21.041880@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||3||1
+2015-12-01 17:27:41.479413||measurement||price||2015-12-01 17:27:35.927130@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 17:27:42.208894||measurement||price||2015-12-01 17:27:24.243231@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:27:44.464986||measurement||price||2015-12-01 17:27:25.091507@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 17:27:45.856101||error||collecting ads||Error||1||0
+2015-12-01 17:27:47.350434||measurement||loadtime||0:00:29.335956||3||1
+2015-12-01 17:27:49.324460||measurement||loadtime||0:00:26.781222||2||0
+2015-12-01 17:27:51.669313||measurement||loadtime||0:00:28.825329||0||1
+2015-12-01 17:27:53.808860||measurement||price||2015-12-01 17:27:35.927130@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 17:27:55.907770||error||collecting ads||Error||5||1
+2015-12-01 17:27:58.077095||measurement||price||2015-12-01 17:27:52.469840@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:28:00.919155||measurement||loadtime||0:00:26.730779||4||0
+2015-12-01 17:28:01.246476||measurement||price||2015-12-01 17:27:54.713645@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:28:01.678652||measurement||price||2015-12-01 17:27:56.076631@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:28:05.197176||measurement||price||2015-12-01 17:27:58.778526@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:28:10.030313||measurement||price||2015-12-01 17:28:03.237037@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:28:10.417351||measurement||price||2015-12-01 17:27:52.469840@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:28:13.973104||measurement||price||2015-12-01 17:27:56.076631@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:28:14.161464||measurement||price||2015-12-01 17:27:54.713645@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:28:17.537358||measurement||loadtime||0:00:26.676023||1||0
+2015-12-01 17:28:18.065461||measurement||price||2015-12-01 17:27:58.778526@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:28:21.084542||measurement||loadtime||0:00:26.754839||2||0
+2015-12-01 17:28:21.347104||measurement||loadtime||0:00:28.991910||3||1
+2015-12-01 17:28:22.897600||measurement||price||2015-12-01 17:28:03.237037@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:28:23.298492||error||collecting ads||Error||4||0
+2015-12-01 17:28:25.266455||measurement||loadtime||0:00:28.591950||0||1
+2015-12-01 17:28:30.096257||measurement||loadtime||0:00:29.183283||5||1
+2015-12-01 17:28:33.274651||measurement||price||2015-12-01 17:28:27.699606@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:28:35.562897||measurement||price||2015-12-01 17:28:28.761477@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:28:35.644599||measurement||price||2015-12-01 17:28:29.991130@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 17:28:38.818136||measurement||price||2015-12-01 17:28:32.461607@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:28:39.763712||error||collecting ads||Error||1||0
+2015-12-01 17:28:39.763848||event||progress-marker||measurement-end||1||0
+2015-12-01 17:28:45.621052||measurement||price||2015-12-01 17:28:27.699606@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:28:47.971079||measurement||price||2015-12-01 17:28:29.991130@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 17:28:48.778279||measurement||price||2015-12-01 17:28:28.761477@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:28:51.678851||measurement||price||2015-12-01 17:28:32.461607@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:28:52.730121||measurement||loadtime||0:00:26.640326||2||0
+2015-12-01 17:28:52.730277||event||progress-marker||measurement-end||2||0
+2015-12-01 17:28:53.850193||error||collecting ads||Error||5||1
+2015-12-01 17:28:55.088699||measurement||loadtime||0:00:26.785536||4||0
+2015-12-01 17:28:55.089017||event||progress-marker||measurement-end||4||0
+2015-12-01 17:28:55.985482||measurement||loadtime||0:00:29.634260||3||1
+2015-12-01 17:28:58.893999||measurement||loadtime||0:00:28.622845||0||1
+2015-12-01 17:29:07.465253||measurement||price||2015-12-01 17:29:01.090973@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:29:09.674811||measurement||price||2015-12-01 17:29:03.252585@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:29:12.565855||measurement||price||2015-12-01 17:29:06.130934@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 17:29:20.312563||measurement||price||2015-12-01 17:29:01.090973@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:29:22.586044||measurement||price||2015-12-01 17:29:03.252585@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:29:25.425801||measurement||price||2015-12-01 17:29:06.130934@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 17:29:27.511304||measurement||loadtime||0:00:28.655862||5||1
+2015-12-01 17:29:29.789148||measurement||loadtime||0:00:28.801984||3||1
+2015-12-01 17:29:32.637277||measurement||loadtime||0:00:28.738048||0||1
+2015-12-01 17:29:32.637406||event||progress-marker||measurement-end||0||1
+2015-12-01 17:29:41.397496||measurement||price||2015-12-01 17:29:34.920914@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:29:53.420406||error||collecting ads||Error||3||1
+2015-12-01 17:29:54.188148||measurement||price||2015-12-01 17:29:34.920914@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:30:01.395457||measurement||loadtime||0:00:28.878942||5||1
+2015-12-01 17:30:07.128871||measurement||price||2015-12-01 17:30:00.675649@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:30:15.318701||measurement||price||2015-12-01 17:30:08.846634@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:30:19.975617||measurement||price||2015-12-01 17:30:00.675649@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:30:27.207430||measurement||loadtime||0:00:28.781763||3||1
+2015-12-01 17:30:28.098944||measurement||price||2015-12-01 17:30:08.846634@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:30:35.281400||measurement||loadtime||0:00:28.880725||5||1
+2015-12-01 17:30:49.283001||measurement||price||2015-12-01 17:30:42.473100@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:30:50.907197||error||collecting ads||Error||3||1
+2015-12-01 17:31:02.238459||measurement||price||2015-12-01 17:30:42.473100@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:31:04.673674||measurement||price||2015-12-01 17:30:58.091686@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:31:09.451656||measurement||loadtime||0:00:29.165028||5||1
+2015-12-01 17:31:17.777923||measurement||price||2015-12-01 17:30:58.091686@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:31:23.362289||measurement||price||2015-12-01 17:31:16.754236@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:31:24.987688||measurement||loadtime||0:00:29.075233||3||1
+2015-12-01 17:31:36.398462||measurement||price||2015-12-01 17:31:16.754236@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:31:38.824639||measurement||price||2015-12-01 17:31:32.193835@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:31:43.598042||measurement||loadtime||0:00:29.141152||5||1
+2015-12-01 17:31:43.598165||event||progress-marker||measurement-end||5||1
+2015-12-01 17:31:51.658825||measurement||price||2015-12-01 17:31:32.193835@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:31:58.871662||measurement||loadtime||0:00:28.878640||3||1
+2015-12-01 17:31:58.871800||event||progress-marker||measurement-end||3||1
+2015-12-01 17:31:59.369698||meta||block_id end||15
+2015-12-01 17:31:59.370057||meta||block_id start||16
+2015-12-01 17:31:59.370088||meta||assignment||0@|1@|2@|3@|4@|5
+2015-12-01 17:32:00.950866||event||progress-marker||training-start||2||0
+2015-12-01 17:32:00.950962||event||progress-marker||training-end||2||0
+2015-12-01 17:32:00.989918||event||progress-marker||training-start||0||0
+2015-12-01 17:32:00.990017||event||progress-marker||training-end||0||0
+2015-12-01 17:32:00.999932||event||progress-marker||training-start||1||0
+2015-12-01 17:32:01.000028||event||progress-marker||training-end||1||0
+2015-12-01 17:32:05.094612||event||progress-marker||training-start||5||1
+2015-12-01 17:32:05.094719||event||progress-marker||training-end||5||1
+2015-12-01 17:32:05.996965||event||progress-marker||measurement-start||2||0
+2015-12-01 17:32:06.037321||event||progress-marker||measurement-start||0||0
+2015-12-01 17:32:06.046934||event||progress-marker||measurement-start||1||0
+2015-12-01 17:32:10.138400||event||progress-marker||measurement-start||5||1
+2015-12-01 17:32:20.047453||measurement||price||2015-12-01 17:32:13.276167@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:32:21.162918||measurement||price||2015-12-01 17:32:13.674117@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:32:24.142950||measurement||price||2015-12-01 17:32:17.886067@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:32:30.061094||error||collecting ads||Error||1||0
+2015-12-01 17:32:32.397154||measurement||price||2015-12-01 17:32:13.276167@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:32:33.551315||measurement||price||2015-12-01 17:32:13.674117@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:32:36.973985||measurement||price||2015-12-01 17:32:17.886067@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:32:39.493418||measurement||loadtime||0:00:28.491255||2||0
+2015-12-01 17:32:40.662980||measurement||loadtime||0:00:29.623791||0||0
+2015-12-01 17:32:42.470382||measurement||price||2015-12-01 17:32:36.676309@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:32:44.225318||measurement||loadtime||0:00:29.082154||5||1
+2015-12-01 17:32:51.742591||measurement||price||2015-12-01 17:32:46.067273@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:32:54.809153||measurement||price||2015-12-01 17:32:36.676309@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:32:58.056228||measurement||price||2015-12-01 17:32:51.618146@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:33:01.921982||measurement||loadtime||0:00:26.855648||1||0
+2015-12-01 17:33:03.244798||error||collecting ads||Error||0||0
+2015-12-01 17:33:04.088753||measurement||price||2015-12-01 17:32:46.067273@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:33:10.880521||measurement||price||2015-12-01 17:32:51.618146@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:33:11.185484||measurement||loadtime||0:00:26.686875||2||0
+2015-12-01 17:33:15.757000||measurement||price||2015-12-01 17:33:10.353012@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:33:18.107154||measurement||loadtime||0:00:28.876624||5||1
+2015-12-01 17:33:24.214823||error||collecting ads||Error||1||0
+2015-12-01 17:33:26.764956||event||progress-marker||training-start||4||1
+2015-12-01 17:33:26.765058||event||progress-marker||training-end||4||1
+2015-12-01 17:33:28.111545||measurement||price||2015-12-01 17:33:10.353012@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:33:31.804679||event||progress-marker||measurement-start||4||1
+2015-12-01 17:33:33.314075||error||collecting ads||Error||2||0
+2015-12-01 17:33:35.225074||measurement||loadtime||0:00:26.977894||0||0
+2015-12-01 17:33:36.359092||measurement||price||2015-12-01 17:33:30.777350@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:33:41.848514||error||collecting ads||Error||5||1
+2015-12-01 17:33:46.038244||measurement||price||2015-12-01 17:33:39.654788@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:33:48.691303||measurement||price||2015-12-01 17:33:30.777350@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:33:55.192915||event||progress-marker||training-start||3||1
+2015-12-01 17:33:55.193078||event||progress-marker||training-end||3||1
+2015-12-01 17:33:55.615332||measurement||price||2015-12-01 17:33:49.067147@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:33:55.656713||error||collecting ads||Error||2||0
+2015-12-01 17:33:55.804913||measurement||loadtime||0:00:26.584881||1||0
+2015-12-01 17:33:57.855154||error||collecting ads||Error||0||0
+2015-12-01 17:33:58.827774||measurement||price||2015-12-01 17:33:39.654788@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:34:00.238331||event||progress-marker||measurement-start||3||1
+2015-12-01 17:34:06.039164||measurement||loadtime||0:00:29.232015||4||1
+2015-12-01 17:34:07.915909||measurement||price||2015-12-01 17:34:02.423054@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:34:08.383766||measurement||price||2015-12-01 17:34:02.854717@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||0
+2015-12-01 17:34:08.521646||measurement||price||2015-12-01 17:33:49.067147@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:34:10.349240||measurement||price||2015-12-01 17:34:04.985797@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:34:15.759178||measurement||loadtime||0:00:28.907997||5||1
+2015-12-01 17:34:19.615284||measurement||price||2015-12-01 17:34:13.337379@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:34:20.252517||measurement||price||2015-12-01 17:34:02.423054@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:34:20.718935||measurement||price||2015-12-01 17:34:02.854717@|Warner Bros@|$46.49@|Jurassic World Team Pack - LEGO Dimensions||1||0
+2015-12-01 17:34:22.693109||measurement||price||2015-12-01 17:34:04.985797@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:34:24.284910||error||collecting ads||Error||3||1
+2015-12-01 17:34:27.363239||measurement||loadtime||0:00:26.701309||2||0
+2015-12-01 17:34:27.831197||measurement||loadtime||0:00:27.024038||1||0
+2015-12-01 17:34:29.804226||measurement||loadtime||0:00:26.945055||0||0
+2015-12-01 17:34:32.481231||measurement||price||2015-12-01 17:34:13.337379@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:34:37.724694||measurement||price||2015-12-01 17:34:31.496111@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:34:39.317784||error||collecting ads||Error||5||1
+2015-12-01 17:34:39.699155||measurement||loadtime||0:00:28.655926||4||1
+2015-12-01 17:34:39.709889||measurement||price||2015-12-01 17:34:34.152538@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:34:40.468759||measurement||price||2015-12-01 17:34:34.828038@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||1||0
+2015-12-01 17:34:42.353477||measurement||price||2015-12-01 17:34:37.000127@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:34:50.580484||measurement||price||2015-12-01 17:34:31.496111@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:34:52.058843||measurement||price||2015-12-01 17:34:34.152538@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:34:52.810841||measurement||price||2015-12-01 17:34:34.828038@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||1||0
+2015-12-01 17:34:53.098610||measurement||price||2015-12-01 17:34:46.520444@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:34:54.693104||measurement||price||2015-12-01 17:34:37.000127@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:34:57.795165||measurement||loadtime||0:00:28.505016||3||1
+2015-12-01 17:34:59.162809||measurement||loadtime||0:00:26.798794||2||0
+2015-12-01 17:34:59.914428||measurement||loadtime||0:00:27.078000||1||0
+2015-12-01 17:35:01.807154||measurement||loadtime||0:00:26.997648||0||0
+2015-12-01 17:35:03.422554||error||collecting ads||Error||4||1
+2015-12-01 17:35:06.061227||measurement||price||2015-12-01 17:34:46.520444@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:35:11.675138||measurement||price||2015-12-01 17:35:05.955350@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:35:12.372582||measurement||price||2015-12-01 17:35:06.661713@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:35:13.279150||measurement||loadtime||0:00:28.956168||5||1
+2015-12-01 17:35:14.409906||measurement||price||2015-12-01 17:35:08.974125@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:35:16.912277||measurement||price||2015-12-01 17:35:10.544522@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:35:21.535552||error||collecting ads||Error||3||1
+2015-12-01 17:35:24.032092||measurement||price||2015-12-01 17:35:05.955350@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:35:24.708687||measurement||price||2015-12-01 17:35:06.661713@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:35:26.717036||measurement||price||2015-12-01 17:35:08.974125@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:35:30.000532||measurement||price||2015-12-01 17:35:10.544522@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:35:31.146445||measurement||loadtime||0:00:26.978408||2||0
+2015-12-01 17:35:31.830547||measurement||loadtime||0:00:26.911361||1||0
+2015-12-01 17:35:33.808077||measurement||loadtime||0:00:26.995711||0||0
+2015-12-01 17:35:36.860842||error||collecting ads||Error||5||1
+2015-12-01 17:35:37.223171||measurement||loadtime||0:00:28.796924||4||1
+2015-12-01 17:35:43.381493||measurement||price||2015-12-01 17:35:37.721557@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:35:45.033598||error||collecting ads||Error||3||1
+2015-12-01 17:35:46.267992||measurement||price||2015-12-01 17:35:40.928712@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:35:50.811545||measurement||price||2015-12-01 17:35:44.489796@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||5||1
+2015-12-01 17:35:50.946977||measurement||price||2015-12-01 17:35:44.485553@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:35:54.060874||error||collecting ads||Error||1||0
+2015-12-01 17:35:55.738221||measurement||price||2015-12-01 17:35:37.721557@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:35:58.597815||measurement||price||2015-12-01 17:35:40.928712@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:35:58.746790||measurement||price||2015-12-01 17:35:52.153863@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:36:02.846734||measurement||loadtime||0:00:26.695017||2||0
+2015-12-01 17:36:03.615805||measurement||price||2015-12-01 17:35:44.489796@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||5||1
+2015-12-01 17:36:03.851789||measurement||price||2015-12-01 17:35:44.485553@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:36:05.714629||measurement||loadtime||0:00:26.901743||0||0
+2015-12-01 17:36:10.851168||measurement||loadtime||0:00:28.985445||5||1
+2015-12-01 17:36:11.059155||measurement||loadtime||0:00:28.830804||4||1
+2015-12-01 17:36:11.602242||measurement||price||2015-12-01 17:35:52.153863@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:36:15.106431||measurement||price||2015-12-01 17:36:09.512151@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:36:16.809660||error||collecting ads||Error||1||0
+2015-12-01 17:36:18.322486||measurement||price||2015-12-01 17:36:12.913311@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:36:18.827156||measurement||loadtime||0:00:28.788342||3||1
+2015-12-01 17:36:27.444876||measurement||price||2015-12-01 17:36:09.512151@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:36:28.858479||measurement||price||2015-12-01 17:36:23.329012@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:36:30.625299||measurement||price||2015-12-01 17:36:12.913311@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:36:34.547870||error||collecting ads||Error||5||1
+2015-12-01 17:36:34.555181||measurement||loadtime||0:00:26.706310||2||0
+2015-12-01 17:36:34.614467||error||collecting ads||Error||4||1
+2015-12-01 17:36:37.710154||measurement||loadtime||0:00:26.990295||0||0
+2015-12-01 17:36:41.144076||measurement||price||2015-12-01 17:36:23.329012@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:36:42.403320||error||collecting ads||Error||3||1
+2015-12-01 17:36:46.820699||measurement||price||2015-12-01 17:36:41.253721@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:36:48.150981||measurement||price||2015-12-01 17:36:42.022423@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:36:48.246277||measurement||loadtime||0:00:26.431399||1||0
+2015-12-01 17:36:48.342276||measurement||price||2015-12-01 17:36:41.961962@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:36:50.126127||measurement||price||2015-12-01 17:36:44.782761@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:36:59.146643||measurement||price||2015-12-01 17:36:41.253721@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:37:01.221299||measurement||price||2015-12-01 17:36:42.022423@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:37:01.390797||measurement||price||2015-12-01 17:36:41.961962@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:37:02.472907||measurement||price||2015-12-01 17:36:44.782761@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:37:05.930192||error||collecting ads||Error||3||1
+2015-12-01 17:37:06.255200||measurement||loadtime||0:00:26.694814||2||0
+2015-12-01 17:37:08.435186||measurement||loadtime||0:00:28.882056||5||1
+2015-12-01 17:37:08.617998||measurement||loadtime||0:00:28.998850||4||1
+2015-12-01 17:37:09.587167||measurement||loadtime||0:00:26.871787||0||0
+2015-12-01 17:37:10.406914||error||collecting ads||Error||1||0
+2015-12-01 17:37:18.600672||measurement||price||2015-12-01 17:37:12.944449@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:37:19.602937||measurement||price||2015-12-01 17:37:13.141113@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:37:22.184996||measurement||price||2015-12-01 17:37:16.787057@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:37:22.333758||measurement||price||2015-12-01 17:37:15.638655@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:37:22.797229||measurement||price||2015-12-01 17:37:17.076683@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:37:25.763662||measurement||price||2015-12-01 17:37:19.236454@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:37:30.937869||measurement||price||2015-12-01 17:37:12.944449@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:37:32.400387||measurement||price||2015-12-01 17:37:13.141113@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:37:34.536879||measurement||price||2015-12-01 17:37:16.787057@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:37:35.154967||measurement||price||2015-12-01 17:37:17.076683@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:37:35.287282||measurement||price||2015-12-01 17:37:15.638655@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:37:38.051295||measurement||loadtime||0:00:26.790867||2||0
+2015-12-01 17:37:38.627224||measurement||price||2015-12-01 17:37:19.236454@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:37:39.626840||measurement||loadtime||0:00:28.691420||3||1
+2015-12-01 17:37:41.651937||measurement||loadtime||0:00:27.059550||0||0
+2015-12-01 17:37:42.268764||measurement||loadtime||0:00:26.856633||1||0
+2015-12-01 17:37:42.500616||measurement||loadtime||0:00:29.061466||5||1
+2015-12-01 17:37:45.851139||measurement||loadtime||0:00:32.227973||4||1
+2015-12-01 17:37:50.310224||measurement||price||2015-12-01 17:37:44.652013@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:37:53.794040||measurement||price||2015-12-01 17:37:47.333752@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||1
+2015-12-01 17:37:54.356094||measurement||price||2015-12-01 17:37:48.884292@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:37:54.801258||measurement||price||2015-12-01 17:37:49.084607@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:37:56.456470||measurement||price||2015-12-01 17:37:49.811273@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:37:59.463091||measurement||price||2015-12-01 17:37:53.000583@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:38:02.662902||measurement||price||2015-12-01 17:37:44.652013@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:38:06.647225||measurement||price||2015-12-01 17:37:48.884292@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:38:06.716698||measurement||price||2015-12-01 17:37:47.333752@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||1
+2015-12-01 17:38:07.122745||measurement||price||2015-12-01 17:37:49.084607@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:38:09.480158||measurement||price||2015-12-01 17:37:49.811273@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:38:09.786521||measurement||loadtime||0:00:26.730004||2||0
+2015-12-01 17:38:12.299561||measurement||price||2015-12-01 17:37:53.000583@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:38:13.724596||measurement||loadtime||0:00:27.068743||0||0
+2015-12-01 17:38:13.977494||measurement||loadtime||0:00:29.345444||3||1
+2015-12-01 17:38:14.236955||measurement||loadtime||0:00:26.962966||1||0
+2015-12-01 17:38:16.690096||measurement||loadtime||0:00:29.185130||5||1
+2015-12-01 17:38:19.515168||measurement||loadtime||0:00:28.659005||4||1
+2015-12-01 17:38:21.967718||measurement||price||2015-12-01 17:38:16.331757@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:38:27.817139||measurement||price||2015-12-01 17:38:21.237402@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:38:30.235674||measurement||price||2015-12-01 17:38:23.839412@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:38:34.303174||measurement||price||2015-12-01 17:38:16.331757@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:38:36.387663||error||collecting ads||Error||0||0
+2015-12-01 17:38:36.504030||error||collecting ads||Error||1||0
+2015-12-01 17:38:40.827175||measurement||price||2015-12-01 17:38:21.237402@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:38:41.411730||measurement||loadtime||0:00:26.620582||2||0
+2015-12-01 17:38:43.081208||error||collecting ads||Error||4||1
+2015-12-01 17:38:43.215902||measurement||price||2015-12-01 17:38:23.839412@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:38:48.059192||measurement||loadtime||0:00:29.076501||3||1
+2015-12-01 17:38:48.729694||measurement||price||2015-12-01 17:38:43.114118@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:38:48.900902||measurement||price||2015-12-01 17:38:43.510654@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:38:50.469102||measurement||loadtime||0:00:28.773943||5||1
+2015-12-01 17:38:53.614168||measurement||price||2015-12-01 17:38:48.025942@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:39:01.116608||measurement||price||2015-12-01 17:38:43.114118@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:39:01.252018||measurement||price||2015-12-01 17:38:43.510654@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:39:01.734780||measurement||price||2015-12-01 17:38:55.178595@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:39:05.964139||measurement||price||2015-12-01 17:38:48.025942@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:39:06.709441||error||collecting ads||Error||4||1
+2015-12-01 17:39:08.225281||measurement||loadtime||0:00:26.718133||1||0
+2015-12-01 17:39:08.380430||measurement||loadtime||0:00:26.991690||0||0
+2015-12-01 17:39:13.071183||measurement||loadtime||0:00:26.654239||2||0
+2015-12-01 17:39:13.896341||error||collecting ads||Error||5||1
+2015-12-01 17:39:14.655173||measurement||price||2015-12-01 17:38:55.178595@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:39:21.145041||measurement||price||2015-12-01 17:39:15.768740@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:39:21.925811||measurement||loadtime||0:00:28.861446||3||1
+2015-12-01 17:39:25.713343||measurement||price||2015-12-01 17:39:20.074290@|Lexmark@|$519.99@|Lexmark MS810n Mono Laser Printer||2||0
+2015-12-01 17:39:30.555752||error||collecting ads||Error||1||0
+2015-12-01 17:39:30.569019||error||collecting ads||Error||4||1
+2015-12-01 17:39:33.426822||measurement||price||2015-12-01 17:39:15.768740@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:39:35.619400||measurement||price||2015-12-01 17:39:29.328507@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:39:37.759068||error||collecting ads||Error||5||1
+2015-12-01 17:39:38.059510||measurement||price||2015-12-01 17:39:20.074290@|Lexmark@|$460.99@|Lexmark MS610dn Mono Laser Printer||2||0
+2015-12-01 17:39:40.523126||measurement||loadtime||0:00:27.139049||0||0
+2015-12-01 17:39:43.357272||measurement||price||2015-12-01 17:39:37.832969@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:39:44.770688||measurement||price||2015-12-01 17:39:38.722606@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||4||1
+2015-12-01 17:39:45.177679||measurement||loadtime||0:00:27.101282||2||0
+2015-12-01 17:39:48.570162||measurement||price||2015-12-01 17:39:29.328507@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:39:51.320331||measurement||price||2015-12-01 17:39:44.909203@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:39:52.952254||measurement||price||2015-12-01 17:39:47.550903@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:39:55.695327||measurement||price||2015-12-01 17:39:37.832969@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:39:55.787238||measurement||loadtime||0:00:28.856169||3||1
+2015-12-01 17:39:57.538880||measurement||price||2015-12-01 17:39:51.882274@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:39:57.733301||measurement||price||2015-12-01 17:39:38.722606@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||4||1
+2015-12-01 17:40:02.811185||measurement||loadtime||0:00:27.252041||1||0
+2015-12-01 17:40:04.255277||measurement||price||2015-12-01 17:39:44.909203@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:40:05.103808||measurement||loadtime||0:00:29.529541||4||1
+2015-12-01 17:40:05.313972||measurement||price||2015-12-01 17:39:47.550903@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:40:09.859139||measurement||price||2015-12-01 17:40:03.742786@|Mira@|$118.30@|Mira Wellness and Activity Bracelet||3||1
+2015-12-01 17:40:09.882655||measurement||price||2015-12-01 17:39:51.882274@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:40:11.451612||measurement||loadtime||0:00:28.687328||5||1
+2015-12-01 17:40:12.415176||measurement||loadtime||0:00:26.888024||0||0
+2015-12-01 17:40:16.994613||measurement||loadtime||0:00:26.811639||2||0
+2015-12-01 17:40:19.096144||measurement||price||2015-12-01 17:40:12.623711@|Mr Beams@|$23.99@|Mr. Beams MB723 Battery-Powered Motion-Sensing LED Stick-Any...||4||1
+2015-12-01 17:40:22.920298||measurement||price||2015-12-01 17:40:03.742786@|Tile@|$25.00@|Tile (Gen 2) - Phone Finder. Key Finder. Item Finder  - 1 Pack||3||1
+2015-12-01 17:40:25.044196||measurement||price||2015-12-01 17:40:19.623635@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:40:25.593211||error||collecting ads||Error||1||0
+2015-12-01 17:40:29.238992||measurement||price||2015-12-01 17:40:23.696968@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:40:30.151207||measurement||loadtime||0:00:29.358734||3||1
+2015-12-01 17:40:31.932951||measurement||price||2015-12-01 17:40:12.623711@|Mr. Beams@|$29.99@|Mr Beams MB390 300-Lumen Weatherproof Wireless Battery Power...||4||1
+2015-12-01 17:40:35.199510||error||collecting ads||Error||5||1
+2015-12-01 17:40:37.399092||measurement||price||2015-12-01 17:40:19.623635@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:40:37.813633||measurement||price||2015-12-01 17:40:32.196852@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:40:39.160938||measurement||loadtime||0:00:29.051909||4||1
+2015-12-01 17:40:41.587675||measurement||price||2015-12-01 17:40:23.696968@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:40:43.844901||measurement||price||2015-12-01 17:40:37.452436@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:40:44.512090||measurement||loadtime||0:00:27.095337||0||0
+2015-12-01 17:40:48.705610||measurement||loadtime||0:00:26.705729||2||0
+2015-12-01 17:40:50.136557||measurement||price||2015-12-01 17:40:32.196852@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:40:52.926980||measurement||price||2015-12-01 17:40:46.614839@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:40:56.714113||measurement||price||2015-12-01 17:40:37.452436@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:40:57.248997||measurement||loadtime||0:00:26.650554||1||0
+2015-12-01 17:40:58.969860||error||collecting ads||Error||5||1
+2015-12-01 17:41:00.864373||measurement||price||2015-12-01 17:40:55.282612@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:41:03.927214||measurement||loadtime||0:00:28.770713||3||1
+2015-12-01 17:41:05.732090||measurement||price||2015-12-01 17:40:46.614839@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:41:06.968845||error||collecting ads||Error||0||0
+2015-12-01 17:41:09.381333||measurement||price||2015-12-01 17:41:03.781026@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:41:12.946390||measurement||loadtime||0:00:28.783246||4||1
+2015-12-01 17:41:13.207262||measurement||price||2015-12-01 17:40:55.282612@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:41:17.504852||measurement||price||2015-12-01 17:41:11.144506@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:41:20.315197||measurement||loadtime||0:00:26.604342||2||0
+2015-12-01 17:41:21.712148||measurement||price||2015-12-01 17:41:03.781026@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:41:22.686499||error||collecting ads||Error||5||1
+2015-12-01 17:41:26.404162||measurement||price||2015-12-01 17:41:20.210125@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:41:28.825417||measurement||loadtime||0:00:26.574239||1||0
+2015-12-01 17:41:28.825506||event||progress-marker||measurement-end||1||0
+2015-12-01 17:41:29.586803||error||collecting ads||Error||0||0
+2015-12-01 17:41:30.299517||measurement||price||2015-12-01 17:41:11.144506@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:41:36.401886||measurement||price||2015-12-01 17:41:29.867245@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:41:37.507270||measurement||loadtime||0:00:28.574758||3||1
+2015-12-01 17:41:39.160762||measurement||price||2015-12-01 17:41:20.210125@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:41:42.045782||measurement||price||2015-12-01 17:41:36.711185@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:41:42.546773||error||collecting ads||Error||2||0
+2015-12-01 17:41:46.387932||measurement||loadtime||0:00:28.440788||4||1
+2015-12-01 17:41:49.251884||measurement||price||2015-12-01 17:41:29.867245@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:41:51.088095||measurement||price||2015-12-01 17:41:44.666541@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:41:54.392386||measurement||price||2015-12-01 17:41:36.711185@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:41:56.487272||measurement||loadtime||0:00:28.795554||5||1
+2015-12-01 17:41:56.487394||event||progress-marker||measurement-end||5||1
+2015-12-01 17:41:59.954223||measurement||price||2015-12-01 17:41:53.552353@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:42:01.502763||measurement||loadtime||0:00:26.910740||0||0
+2015-12-01 17:42:01.502880||event||progress-marker||measurement-end||0||0
+2015-12-01 17:42:03.914848||measurement||price||2015-12-01 17:41:44.666541@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:42:04.776802||error||collecting ads||Error||2||0
+2015-12-01 17:42:04.776942||event||progress-marker||measurement-end||2||0
+2015-12-01 17:42:11.143667||measurement||loadtime||0:00:28.631152||3||1
+2015-12-01 17:42:12.745364||measurement||price||2015-12-01 17:41:53.552353@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:42:19.945310||measurement||loadtime||0:00:28.552123||4||1
+2015-12-01 17:42:24.747767||measurement||price||2015-12-01 17:42:18.236614@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:42:37.561053||measurement||price||2015-12-01 17:42:18.236614@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:42:43.587147||error||collecting ads||Error||4||1
+2015-12-01 17:42:44.758664||measurement||loadtime||0:00:28.609765||3||1
+2015-12-01 17:42:57.267235||measurement||price||2015-12-01 17:42:50.769933@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:43:08.536852||error||collecting ads||Error||3||1
+2015-12-01 17:43:10.118800||measurement||price||2015-12-01 17:42:50.769933@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:43:17.334466||measurement||loadtime||0:00:28.742078||4||1
+2015-12-01 17:43:31.036055||measurement||price||2015-12-01 17:43:24.521667@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:43:32.228629||error||collecting ads||Error||3||1
+2015-12-01 17:43:43.808320||measurement||price||2015-12-01 17:43:24.521667@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:43:45.812253||measurement||price||2015-12-01 17:43:39.448122@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:43:51.006782||measurement||loadtime||0:00:28.667055||4||1
+2015-12-01 17:43:51.007022||event||progress-marker||measurement-end||4||1
+2015-12-01 17:43:58.614783||measurement||price||2015-12-01 17:43:39.448122@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:44:05.836332||measurement||loadtime||0:00:28.602482||3||1
+2015-12-01 17:44:05.836470||event||progress-marker||measurement-end||3||1
+2015-12-01 17:44:06.285754||meta||block_id end||16
+2015-12-01 17:44:06.286091||meta||block_id start||17
+2015-12-01 17:44:06.286122||meta||assignment||2@|1@|0@|3@|5@|4
+2015-12-01 17:44:07.878373||event||progress-marker||training-start||0||0
+2015-12-01 17:44:07.878481||event||progress-marker||training-end||0||0
+2015-12-01 17:44:07.892329||event||progress-marker||training-start||1||0
+2015-12-01 17:44:07.892451||event||progress-marker||training-end||1||0
+2015-12-01 17:44:07.919172||event||progress-marker||training-start||2||0
+2015-12-01 17:44:07.919564||event||progress-marker||training-end||2||0
+2015-12-01 17:44:12.927873||event||progress-marker||measurement-start||0||0
+2015-12-01 17:44:12.938355||event||progress-marker||measurement-start||1||0
+2015-12-01 17:44:12.968641||event||progress-marker||measurement-start||2||0
+2015-12-01 17:44:27.024289||measurement||price||2015-12-01 17:44:20.106639@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:44:27.097246||measurement||price||2015-12-01 17:44:20.502345@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||0||0
+2015-12-01 17:44:37.007325||error||collecting ads||Error||1||0
+2015-12-01 17:44:39.367594||measurement||price||2015-12-01 17:44:20.106639@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:44:39.427948||measurement||price||2015-12-01 17:44:20.502345@|@|$79.95@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||0||0
+2015-12-01 17:44:46.470889||measurement||loadtime||0:00:28.500348||2||0
+2015-12-01 17:44:46.545705||measurement||loadtime||0:00:28.614548||0||0
+2015-12-01 17:44:59.143093||error||collecting ads||Error||1||0
+2015-12-01 17:45:08.823691||error||collecting ads||Error||2||0
+2015-12-01 17:45:09.101082||error||collecting ads||Error||0||0
+2015-12-01 17:45:11.256687||measurement||price||2015-12-01 17:45:05.643791@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:45:21.171915||measurement||price||2015-12-01 17:45:15.494133@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:45:21.320496||measurement||price||2015-12-01 17:45:15.734634@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:45:23.576284||measurement||price||2015-12-01 17:45:05.643791@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:45:30.671620||measurement||loadtime||0:00:26.523274||1||0
+2015-12-01 17:45:33.516115||measurement||price||2015-12-01 17:45:15.494133@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:45:33.657919||measurement||price||2015-12-01 17:45:15.734634@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:45:40.627174||measurement||loadtime||0:00:26.798530||2||0
+2015-12-01 17:45:40.772533||measurement||loadtime||0:00:26.666220||0||0
+2015-12-01 17:45:40.781096||event||progress-marker||training-start||4||1
+2015-12-01 17:45:40.781227||event||progress-marker||training-end||4||1
+2015-12-01 17:45:45.828047||event||progress-marker||measurement-start||4||1
+2015-12-01 17:45:52.795612||error||collecting ads||Error||1||0
+2015-12-01 17:45:52.942904||measurement||price||2015-12-01 17:45:47.398163@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:45:55.052968||event||progress-marker||training-start||5||1
+2015-12-01 17:45:55.053133||event||progress-marker||training-end||5||1
+2015-12-01 17:46:00.093227||event||progress-marker||measurement-start||5||1
+2015-12-01 17:46:00.148620||measurement||price||2015-12-01 17:45:53.596173@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:46:02.932364||error||collecting ads||Error||2||0
+2015-12-01 17:46:04.953704||measurement||price||2015-12-01 17:45:59.361875@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:46:05.290786||measurement||price||2015-12-01 17:45:47.398163@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:46:12.404285||measurement||loadtime||0:00:26.629130||0||0
+2015-12-01 17:46:13.059104||measurement||price||2015-12-01 17:45:53.596173@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:46:14.430122||measurement||price||2015-12-01 17:46:08.063903@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:46:15.204143||measurement||price||2015-12-01 17:46:09.619683@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:46:17.282693||measurement||price||2015-12-01 17:45:59.361875@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:46:20.254585||measurement||loadtime||0:00:29.421251||4||1
+2015-12-01 17:46:24.387061||measurement||loadtime||0:00:26.586160||1||0
+2015-12-01 17:46:24.678180||measurement||price||2015-12-01 17:46:19.068134@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:46:27.309003||measurement||price||2015-12-01 17:46:08.063903@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:46:27.561278||measurement||price||2015-12-01 17:46:09.619683@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:46:34.022865||measurement||price||2015-12-01 17:46:27.660144@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:46:34.537900||measurement||loadtime||0:00:29.439464||5||1
+2015-12-01 17:46:34.672477||measurement||loadtime||0:00:26.737325||2||0
+2015-12-01 17:46:37.026104||measurement||price||2015-12-01 17:46:19.068134@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:46:44.136814||measurement||loadtime||0:00:26.729650||0||0
+2015-12-01 17:46:46.530244||error||collecting ads||Error||1||0
+2015-12-01 17:46:47.042082||measurement||price||2015-12-01 17:46:27.660144@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:46:48.430200||measurement||price||2015-12-01 17:46:42.023119@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:46:49.880202||event||progress-marker||training-start||3||1
+2015-12-01 17:46:49.880318||event||progress-marker||training-end||3||1
+2015-12-01 17:46:54.239141||measurement||loadtime||0:00:28.979262||4||1
+2015-12-01 17:46:54.921802||event||progress-marker||measurement-start||3||1
+2015-12-01 17:46:56.318179||measurement||price||2015-12-01 17:46:50.712608@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:46:57.004681||error||collecting ads||Error||2||0
+2015-12-01 17:46:58.785868||measurement||price||2015-12-01 17:46:53.098302@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:47:01.299972||measurement||price||2015-12-01 17:46:42.023119@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:47:08.055416||measurement||price||2015-12-01 17:47:01.597193@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:47:08.511173||measurement||loadtime||0:00:28.968072||5||1
+2015-12-01 17:47:08.657288||measurement||price||2015-12-01 17:46:50.712608@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:47:09.250022||measurement||price||2015-12-01 17:47:02.826469@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:47:09.446358||measurement||price||2015-12-01 17:47:03.752685@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:47:11.113056||measurement||price||2015-12-01 17:46:53.098302@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:47:15.767161||measurement||loadtime||0:00:26.625149||0||0
+2015-12-01 17:47:18.224553||measurement||loadtime||0:00:26.689835||1||0
+2015-12-01 17:47:20.943720||measurement||price||2015-12-01 17:47:01.597193@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:47:21.760423||measurement||price||2015-12-01 17:47:03.752685@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:47:22.116357||measurement||price||2015-12-01 17:47:02.826469@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:47:22.385659||measurement||price||2015-12-01 17:47:15.700165@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:47:27.997322||measurement||price||2015-12-01 17:47:22.415154@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:47:28.158557||measurement||loadtime||0:00:28.914161||4||1
+2015-12-01 17:47:28.850902||measurement||loadtime||0:00:26.841022||2||0
+2015-12-01 17:47:29.321914||measurement||loadtime||0:00:29.394895||3||1
+2015-12-01 17:47:30.428737||measurement||price||2015-12-01 17:47:24.811447@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 17:47:35.473814||measurement||price||2015-12-01 17:47:15.700165@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:47:40.357054||measurement||price||2015-12-01 17:47:22.415154@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:47:42.695372||measurement||loadtime||0:00:29.178950||5||1
+2015-12-01 17:47:42.757858||measurement||price||2015-12-01 17:47:24.811447@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 17:47:43.248471||measurement||price||2015-12-01 17:47:36.725155@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:47:47.468160||measurement||loadtime||0:00:26.695776||0||0
+2015-12-01 17:47:49.868694||measurement||loadtime||0:00:26.641553||1||0
+2015-12-01 17:47:51.288206||error||collecting ads||Error||2||0
+2015-12-01 17:47:52.195970||error||collecting ads||Error||4||1
+2015-12-01 17:47:56.230764||measurement||price||2015-12-01 17:47:36.725155@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:47:56.474895||measurement||price||2015-12-01 17:47:49.889822@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:47:59.732101||measurement||price||2015-12-01 17:47:54.173732@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:48:02.086524||measurement||price||2015-12-01 17:47:56.489591@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:48:03.434996||measurement||loadtime||0:00:29.107845||3||1
+2015-12-01 17:48:09.347252||measurement||price||2015-12-01 17:47:49.889822@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:48:12.081612||measurement||price||2015-12-01 17:47:54.173732@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:48:13.625679||error||collecting ads||Error||2||0
+2015-12-01 17:48:14.415451||measurement||price||2015-12-01 17:47:56.489591@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:48:16.018070||error||collecting ads||Error||4||1
+2015-12-01 17:48:16.546092||measurement||loadtime||0:00:28.846944||5||1
+2015-12-01 17:48:17.294999||measurement||price||2015-12-01 17:48:10.783601@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:48:19.207379||measurement||loadtime||0:00:26.733970||0||0
+2015-12-01 17:48:21.534824||measurement||loadtime||0:00:26.660926||1||0
+2015-12-01 17:48:25.837968||measurement||price||2015-12-01 17:48:20.257657@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:48:29.731302||measurement||price||2015-12-01 17:48:23.246875@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:48:30.353954||measurement||price||2015-12-01 17:48:10.783601@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:48:30.492041||measurement||price||2015-12-01 17:48:23.832290@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:48:33.708724||measurement||price||2015-12-01 17:48:28.148281@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:48:37.541055||measurement||loadtime||0:00:29.100834||3||1
+2015-12-01 17:48:38.194127||measurement||price||2015-12-01 17:48:20.257657@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:48:41.622050||error||collecting ads||Error||0||0
+2015-12-01 17:48:42.702831||measurement||price||2015-12-01 17:48:23.246875@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:48:43.359507||measurement||price||2015-12-01 17:48:23.832290@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:48:45.302254||measurement||loadtime||0:00:26.671359||2||0
+2015-12-01 17:48:46.063529||measurement||price||2015-12-01 17:48:28.148281@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:48:49.889817||measurement||loadtime||0:00:28.866557||4||1
+2015-12-01 17:48:50.569906||measurement||loadtime||0:00:29.018497||5||1
+2015-12-01 17:48:51.384017||measurement||price||2015-12-01 17:48:45.027044@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:48:53.171200||measurement||loadtime||0:00:26.632076||1||0
+2015-12-01 17:49:03.586312||measurement||price||2015-12-01 17:48:57.153169@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:49:03.783944||error||collecting ads||Error||0||0
+2015-12-01 17:49:04.385589||measurement||price||2015-12-01 17:48:45.027044@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:49:04.524980||measurement||price||2015-12-01 17:48:58.027448@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:49:05.469634||measurement||price||2015-12-01 17:48:59.851941@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:49:08.687610||error||collecting ads||Error||2||0
+2015-12-01 17:49:11.575723||measurement||loadtime||0:00:29.029464||3||1
+2015-12-01 17:49:15.985982||measurement||price||2015-12-01 17:49:10.372993@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:49:16.541396||measurement||price||2015-12-01 17:48:57.153169@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:49:17.375153||measurement||price||2015-12-01 17:48:58.027448@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:49:17.808813||measurement||price||2015-12-01 17:48:59.851941@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:49:20.822495||measurement||price||2015-12-01 17:49:15.266778@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 17:49:23.742079||measurement||loadtime||0:00:28.846999||4||1
+2015-12-01 17:49:24.571687||measurement||loadtime||0:00:29.000528||5||1
+2015-12-01 17:49:24.919980||measurement||loadtime||0:00:26.744817||1||0
+2015-12-01 17:49:25.497375||measurement||price||2015-12-01 17:49:18.901251@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:49:28.298732||measurement||price||2015-12-01 17:49:10.372993@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:49:33.184869||measurement||price||2015-12-01 17:49:15.266778@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 17:49:35.414094||measurement||loadtime||0:00:26.626571||0||0
+2015-12-01 17:49:37.175760||measurement||price||2015-12-01 17:49:31.604895@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:49:38.079060||measurement||price||2015-12-01 17:49:31.938418@|Makita@|$549.00@|Makita XT601 18-volt LXT Lithium-Ion Cordless Combo Kit, 6-P...||4||1
+2015-12-01 17:49:38.398006||measurement||price||2015-12-01 17:49:18.901251@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:49:38.448304||measurement||price||2015-12-01 17:49:31.793961@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:49:40.303191||measurement||loadtime||0:00:26.610318||2||0
+2015-12-01 17:49:45.591190||measurement||loadtime||0:00:29.010252||3||1
+2015-12-01 17:49:47.634772||measurement||price||2015-12-01 17:49:42.085892@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:49:49.531288||measurement||price||2015-12-01 17:49:31.604895@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:49:50.917517||measurement||price||2015-12-01 17:49:31.938418@|Makita@|$469.00@|Makita BBX7600N 75.6 CC 4-Stroke Backpack Blower||4||1
+2015-12-01 17:49:51.417470||measurement||price||2015-12-01 17:49:31.793961@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:49:52.620008||measurement||price||2015-12-01 17:49:47.044964@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:49:56.655183||measurement||loadtime||0:00:26.729991||1||0
+2015-12-01 17:49:58.102434||measurement||loadtime||0:00:29.358400||4||1
+2015-12-01 17:49:58.632520||measurement||loadtime||0:00:29.055598||5||1
+2015-12-01 17:49:59.415878||measurement||price||2015-12-01 17:49:52.918136@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:49:59.958693||measurement||price||2015-12-01 17:49:42.085892@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:50:04.957498||measurement||price||2015-12-01 17:49:47.044964@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:50:07.082758||measurement||loadtime||0:00:26.663589||0||0
+2015-12-01 17:50:12.004659||measurement||price||2015-12-01 17:50:05.402379@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:50:12.068361||measurement||loadtime||0:00:26.761213||2||0
+2015-12-01 17:50:12.364532||measurement||price||2015-12-01 17:49:52.918136@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:50:12.947245||measurement||price||2015-12-01 17:50:06.729221@|Makita@|$549.00@|Makita XT601 18-volt LXT Lithium-Ion Cordless Combo Kit, 6-P...||5||1
+2015-12-01 17:50:19.265006||measurement||price||2015-12-01 17:50:13.657565@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:50:19.555304||error||collecting ads||Error||1||0
+2015-12-01 17:50:19.565659||measurement||loadtime||0:00:28.969253||3||1
+2015-12-01 17:50:24.279835||measurement||price||2015-12-01 17:50:18.685933@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:50:24.933817||measurement||price||2015-12-01 17:50:05.402379@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:50:26.073071||measurement||price||2015-12-01 17:50:06.729221@|Makita@|$469.00@|Makita BBX7600N 75.6 CC 4-Stroke Backpack Blower||5||1
+2015-12-01 17:50:31.648348||measurement||price||2015-12-01 17:50:13.657565@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:50:31.759075||measurement||price||2015-12-01 17:50:26.084709@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:50:32.137953||measurement||loadtime||0:00:29.030313||4||1
+2015-12-01 17:50:33.270655||measurement||loadtime||0:00:29.635504||5||1
+2015-12-01 17:50:33.598027||measurement||price||2015-12-01 17:50:26.800499@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 17:50:36.614903||measurement||price||2015-12-01 17:50:18.685933@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:50:38.764438||measurement||loadtime||0:00:26.677283||0||0
+2015-12-01 17:50:43.724458||measurement||loadtime||0:00:26.652513||2||0
+2015-12-01 17:50:44.060082||measurement||price||2015-12-01 17:50:26.084709@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:50:46.041476||measurement||price||2015-12-01 17:50:39.475859@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:50:46.432671||measurement||price||2015-12-01 17:50:26.800499@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 17:50:47.788163||measurement||price||2015-12-01 17:50:40.945690@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||5||1
+2015-12-01 17:50:51.147155||measurement||loadtime||0:00:26.586637||1||0
+2015-12-01 17:50:53.649623||measurement||loadtime||0:00:29.078752||3||1
+2015-12-01 17:50:59.014766||measurement||price||2015-12-01 17:50:39.475859@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:51:00.847980||measurement||price||2015-12-01 17:50:40.945690@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||5||1
+2015-12-01 17:51:01.010381||error||collecting ads||Error||0||0
+2015-12-01 17:51:03.262520||measurement||price||2015-12-01 17:50:57.671378@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 17:51:05.892050||error||collecting ads||Error||2||0
+2015-12-01 17:51:06.207170||measurement||loadtime||0:00:29.064005||4||1
+2015-12-01 17:51:07.724784||measurement||price||2015-12-01 17:51:01.003998@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:51:08.075169||measurement||loadtime||0:00:29.799988||5||1
+2015-12-01 17:51:13.233277||measurement||price||2015-12-01 17:51:07.590038@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:51:15.606748||measurement||price||2015-12-01 17:50:57.671378@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 17:51:20.790246||measurement||price||2015-12-01 17:51:01.003998@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:51:21.897329||measurement||price||2015-12-01 17:51:15.604801@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:51:22.717503||measurement||loadtime||0:00:26.565164||1||0
+2015-12-01 17:51:25.567193||measurement||price||2015-12-01 17:51:07.590038@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:51:28.017374||measurement||loadtime||0:00:29.366212||3||1
+2015-12-01 17:51:28.128371||error||collecting ads||Error||2||0
+2015-12-01 17:51:30.018132||error||collecting ads||Error||4||1
+2015-12-01 17:51:32.674673||measurement||loadtime||0:00:26.659972||0||0
+2015-12-01 17:51:34.873593||measurement||price||2015-12-01 17:51:15.604801@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:51:34.923880||measurement||price||2015-12-01 17:51:29.322796@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 17:51:40.475270||measurement||price||2015-12-01 17:51:34.708536@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 17:51:42.095136||measurement||loadtime||0:00:29.015997||5||1
+2015-12-01 17:51:42.204916||measurement||price||2015-12-01 17:51:35.334158@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:51:47.277893||measurement||price||2015-12-01 17:51:29.322796@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 17:51:52.832255||measurement||price||2015-12-01 17:51:34.708536@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 17:51:53.955462||error||collecting ads||Error||4||1
+2015-12-01 17:51:54.397649||measurement||loadtime||0:00:26.674942||1||0
+2015-12-01 17:51:54.906608||error||collecting ads||Error||0||0
+2015-12-01 17:51:55.137571||measurement||price||2015-12-01 17:51:35.334158@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:51:59.943176||measurement||loadtime||0:00:26.812026||2||0
+2015-12-01 17:52:02.311989||measurement||loadtime||0:00:29.289386||3||1
+2015-12-01 17:52:06.104881||error||collecting ads||Error||5||1
+2015-12-01 17:52:07.217986||measurement||price||2015-12-01 17:52:01.562688@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:52:07.870222||measurement||price||2015-12-01 17:52:01.250199@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:52:12.209001||measurement||price||2015-12-01 17:52:06.587398@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:52:16.192115||measurement||price||2015-12-01 17:52:09.584785@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:52:16.775195||error||collecting ads||Error||1||0
+2015-12-01 17:52:19.508183||measurement||price||2015-12-01 17:52:13.360790@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:52:19.548569||measurement||price||2015-12-01 17:52:01.562688@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:52:20.920343||measurement||price||2015-12-01 17:52:01.250199@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 17:52:24.548396||measurement||price||2015-12-01 17:52:06.587398@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:52:26.664110||measurement||loadtime||0:00:26.752313||0||0
+2015-12-01 17:52:28.163509||measurement||loadtime||0:00:29.202826||4||1
+2015-12-01 17:52:29.072258||measurement||price||2015-12-01 17:52:09.584785@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:52:31.668233||measurement||loadtime||0:00:26.719847||2||0
+2015-12-01 17:52:32.416158||measurement||price||2015-12-01 17:52:13.360790@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:52:36.263420||measurement||loadtime||0:00:28.946230||3||1
+2015-12-01 17:52:38.910421||measurement||price||2015-12-01 17:52:33.438515@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 17:52:39.030330||error||collecting ads||Error||1||0
+2015-12-01 17:52:39.624098||measurement||loadtime||0:00:28.513970||5||1
+2015-12-01 17:52:50.811399||measurement||price||2015-12-01 17:52:44.046588@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||3||1
+2015-12-01 17:52:51.248992||measurement||price||2015-12-01 17:52:33.438515@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 17:52:51.931372||error||collecting ads||Error||4||1
+2015-12-01 17:52:53.508312||measurement||price||2015-12-01 17:52:47.156415@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:52:53.963600||error||collecting ads||Error||2||0
+2015-12-01 17:52:58.363154||measurement||loadtime||0:00:26.693822||0||0
+2015-12-01 17:53:01.434114||error||collecting ads||Error||1||0
+2015-12-01 17:53:03.689697||measurement||price||2015-12-01 17:52:44.046588@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||3||1
+2015-12-01 17:53:05.786403||measurement||price||2015-12-01 17:52:59.292852@|@|$349.99@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||4||1
+2015-12-01 17:53:06.366678||measurement||price||2015-12-01 17:52:47.156415@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:53:10.566150||measurement||price||2015-12-01 17:53:04.987418@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:53:10.904361||measurement||loadtime||0:00:29.635710||3||1
+2015-12-01 17:53:13.567191||measurement||loadtime||0:00:28.937900||5||1
+2015-12-01 17:53:16.177236||error||collecting ads||Error||2||0
+2015-12-01 17:53:16.177331||event||progress-marker||measurement-end||2||0
+2015-12-01 17:53:22.912020||measurement||price||2015-12-01 17:53:04.987418@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:53:23.661337||error||collecting ads||Error||1||0
+2015-12-01 17:53:23.661454||event||progress-marker||measurement-end||1||0
+2015-12-01 17:53:24.687908||measurement||price||2015-12-01 17:53:18.328882@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:53:27.322546||measurement||price||2015-12-01 17:53:20.860288@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:53:28.743675||error||collecting ads||Error||4||1
+2015-12-01 17:53:30.030357||measurement||loadtime||0:00:26.663186||0||0
+2015-12-01 17:53:37.523717||measurement||price||2015-12-01 17:53:18.328882@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:53:40.208995||measurement||price||2015-12-01 17:53:20.860288@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:53:42.605189||measurement||price||2015-12-01 17:53:36.165054@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:53:44.736674||measurement||loadtime||0:00:28.827086||3||1
+2015-12-01 17:53:47.410303||measurement||loadtime||0:00:28.837900||5||1
+2015-12-01 17:53:52.318744||error||collecting ads||Error||0||0
+2015-12-01 17:53:52.318884||event||progress-marker||measurement-end||0||0
+2015-12-01 17:53:55.405767||measurement||price||2015-12-01 17:53:36.165054@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:53:58.608002||measurement||price||2015-12-01 17:53:52.276721@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:54:01.111664||measurement||price||2015-12-01 17:53:54.717519@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:54:02.604655||measurement||loadtime||0:00:28.855728||4||1
+2015-12-01 17:54:11.410887||measurement||price||2015-12-01 17:53:52.276721@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:54:14.001997||measurement||price||2015-12-01 17:53:54.717519@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:54:16.517560||measurement||price||2015-12-01 17:54:10.014566@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:54:18.610466||measurement||loadtime||0:00:28.868554||3||1
+2015-12-01 17:54:21.185888||measurement||loadtime||0:00:28.770724||5||1
+2015-12-01 17:54:29.356053||measurement||price||2015-12-01 17:54:10.014566@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:54:36.551156||measurement||loadtime||0:00:28.941287||4||1
+2015-12-01 17:54:42.369002||error||collecting ads||Error||3||1
+2015-12-01 17:54:45.025065||error||collecting ads||Error||5||1
+2015-12-01 17:54:56.034748||measurement||price||2015-12-01 17:54:49.539420@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:54:58.793545||measurement||price||2015-12-01 17:54:52.215318@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:55:00.125201||error||collecting ads||Error||4||1
+2015-12-01 17:55:09.083891||measurement||price||2015-12-01 17:54:49.539420@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:55:11.643777||measurement||price||2015-12-01 17:54:52.215318@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:55:13.948555||measurement||price||2015-12-01 17:55:07.364612@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:55:16.315176||measurement||loadtime||0:00:28.940941||3||1
+2015-12-01 17:55:18.875159||measurement||loadtime||0:00:28.848012||5||1
+2015-12-01 17:55:26.811249||measurement||price||2015-12-01 17:55:07.364612@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:55:33.991147||measurement||loadtime||0:00:28.864425||4||1
+2015-12-01 17:55:40.177778||error||collecting ads||Error||3||1
+2015-12-01 17:55:42.596747||error||collecting ads||Error||5||1
+2015-12-01 17:55:47.686343||measurement||price||2015-12-01 17:55:41.190714@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 17:55:56.233614||measurement||price||2015-12-01 17:55:49.757924@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:56:00.537389||measurement||price||2015-12-01 17:55:41.190714@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 17:56:03.809253||error||collecting ads||Error||3||1
+2015-12-01 17:56:07.735134||measurement||loadtime||0:00:28.738741||4||1
+2015-12-01 17:56:07.735266||event||progress-marker||measurement-end||4||1
+2015-12-01 17:56:09.269131||measurement||price||2015-12-01 17:55:49.757924@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:56:16.492419||measurement||loadtime||0:00:28.893241||5||1
+2015-12-01 17:56:18.463675||measurement||price||2015-12-01 17:56:11.796677@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 17:56:30.175813||measurement||price||2015-12-01 17:56:23.713613@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 17:56:31.359225||measurement||price||2015-12-01 17:56:11.796677@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 17:56:38.562920||measurement||loadtime||0:00:29.748447||3||1
+2015-12-01 17:56:43.189759||measurement||price||2015-12-01 17:56:23.713613@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 17:56:50.405910||measurement||loadtime||0:00:28.908240||5||1
+2015-12-01 17:56:50.406122||event||progress-marker||measurement-end||5||1
+2015-12-01 17:56:52.137186||measurement||price||2015-12-01 17:56:45.730160@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:57:04.895256||measurement||price||2015-12-01 17:56:45.730160@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:57:12.090797||measurement||loadtime||0:00:28.522640||3||1
+2015-12-01 17:57:25.861277||measurement||price||2015-12-01 17:57:19.399446@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 17:57:38.692911||measurement||price||2015-12-01 17:57:19.399446@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 17:57:45.877531||measurement||loadtime||0:00:28.781529||3||1
+2015-12-01 17:57:45.877685||event||progress-marker||measurement-end||3||1
+2015-12-01 17:57:46.320653||meta||block_id end||17
+2015-12-01 17:57:46.320952||meta||block_id start||18
+2015-12-01 17:57:46.320982||meta||assignment||3@|2@|0@|4@|5@|1
+2015-12-01 17:57:47.909812||event||progress-marker||training-start||2||0
+2015-12-01 17:57:47.909918||event||progress-marker||training-end||2||0
+2015-12-01 17:57:47.931675||event||progress-marker||training-start||0||0
+2015-12-01 17:57:47.931778||event||progress-marker||training-end||0||0
+2015-12-01 17:57:47.989031||event||progress-marker||training-start||3||0
+2015-12-01 17:57:47.990182||event||progress-marker||training-end||3||0
+2015-12-01 17:57:52.958407||event||progress-marker||measurement-start||2||0
+2015-12-01 17:57:52.980384||event||progress-marker||measurement-start||0||0
+2015-12-01 17:57:53.039060||event||progress-marker||measurement-start||3||0
+2015-12-01 17:57:59.081666||event||progress-marker||training-start||1||1
+2015-12-01 17:57:59.081832||event||progress-marker||training-end||1||1
+2015-12-01 17:58:04.136448||event||progress-marker||measurement-start||1||1
+2015-12-01 17:58:18.186667||measurement||price||2015-12-01 17:58:11.931242@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 17:58:21.244713||measurement||price||2015-12-01 17:58:15.277235@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 17:58:21.343353||measurement||price||2015-12-01 17:58:15.449798@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 17:58:23.364684||event||progress-marker||training-start||5||1
+2015-12-01 17:58:23.364827||event||progress-marker||training-end||5||1
+2015-12-01 17:58:28.408621||event||progress-marker||measurement-start||5||1
+2015-12-01 17:58:31.033090||measurement||price||2015-12-01 17:58:11.931242@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 17:58:31.396271||error||collecting ads||Error||3||0
+2015-12-01 17:58:33.600294||measurement||price||2015-12-01 17:58:15.277235@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 17:58:33.697593||measurement||price||2015-12-01 17:58:15.449798@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 17:58:38.263578||measurement||loadtime||0:00:29.121902||1||1
+2015-12-01 17:58:40.715222||measurement||loadtime||0:00:42.751603||2||0
+2015-12-01 17:58:40.828309||measurement||loadtime||0:00:42.845171||0||0
+2015-12-01 17:58:42.461617||measurement||price||2015-12-01 17:58:36.356876@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 17:58:53.310057||measurement||price||2015-12-01 17:58:47.574772@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:58:53.666973||error||collecting ads||Error||3||0
+2015-12-01 17:58:53.720595||event||progress-marker||training-start||4||1
+2015-12-01 17:58:53.720695||event||progress-marker||training-end||4||1
+2015-12-01 17:58:55.263500||measurement||price||2015-12-01 17:58:36.356876@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 17:58:58.763334||event||progress-marker||measurement-start||4||1
+2015-12-01 17:59:01.857296||error||collecting ads||Error||1||1
+2015-12-01 17:59:02.481287||measurement||loadtime||0:00:29.071118||5||1
+2015-12-01 17:59:03.069023||error||collecting ads||Error||2||0
+2015-12-01 17:59:05.638433||measurement||price||2015-12-01 17:58:47.574772@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:59:05.939377||measurement||price||2015-12-01 17:59:00.298975@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 17:59:12.739639||measurement||loadtime||0:00:26.907954||0||0
+2015-12-01 17:59:13.310494||measurement||price||2015-12-01 17:59:06.583773@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 17:59:16.008737||measurement||price||2015-12-01 17:59:09.653167@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||1
+2015-12-01 17:59:16.320106||measurement||price||2015-12-01 17:59:09.813085@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:59:18.287368||measurement||price||2015-12-01 17:59:00.298975@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 17:59:25.283907||error||collecting ads||Error||2||0
+2015-12-01 17:59:25.403520||measurement||loadtime||0:00:26.731295||3||0
+2015-12-01 17:59:26.219961||measurement||price||2015-12-01 17:59:06.583773@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 17:59:28.094271||measurement||price||2015-12-01 17:59:19.339784@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 17:59:28.896079||measurement||price||2015-12-01 17:59:09.653167@|Warner Bros@|$46.17@|Jurassic World Team Pack - LEGO Dimensions||1||1
+2015-12-01 17:59:29.354056||measurement||price||2015-12-01 17:59:09.813085@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 17:59:33.400839||measurement||loadtime||0:00:29.632251||4||1
+2015-12-01 17:59:36.132322||measurement||loadtime||0:00:29.273159||1||1
+2015-12-01 17:59:36.588682||measurement||loadtime||0:00:29.102164||5||1
+2015-12-01 17:59:37.582809||measurement||price||2015-12-01 17:59:31.976538@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 17:59:37.837659||measurement||price||2015-12-01 17:59:32.248877@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||0
+2015-12-01 17:59:40.455215||measurement||price||2015-12-01 17:59:19.339784@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 17:59:47.041741||measurement||price||2015-12-01 17:59:40.633480@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 17:59:47.569198||measurement||loadtime||0:00:29.826033||0||0
+2015-12-01 17:59:49.922662||measurement||price||2015-12-01 17:59:31.976538@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 17:59:50.169986||measurement||price||2015-12-01 17:59:32.248877@|Black  Decker@|$69.68@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||0
+2015-12-01 17:59:50.206246||measurement||price||2015-12-01 17:59:43.727916@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 17:59:57.033705||measurement||loadtime||0:00:26.624953||3||0
+2015-12-01 17:59:57.285391||measurement||loadtime||0:00:26.996263||2||0
+2015-12-01 17:59:59.790517||error||collecting ads||Error||1||1
+2015-12-01 17:59:59.944632||measurement||price||2015-12-01 17:59:40.633480@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:00:03.134530||measurement||price||2015-12-01 17:59:43.727916@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:00:07.143868||measurement||loadtime||0:00:28.742256||4||1
+2015-12-01 18:00:09.427270||measurement||price||2015-12-01 18:00:03.741739@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:00:09.559730||measurement||price||2015-12-01 18:00:03.918349@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:00:09.800577||error||collecting ads||Error||0||0
+2015-12-01 18:00:10.379916||measurement||loadtime||0:00:28.788775||5||1
+2015-12-01 18:00:13.363932||measurement||price||2015-12-01 18:00:06.908106@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:00:20.739644||measurement||price||2015-12-01 18:00:14.547679@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:00:21.758630||measurement||price||2015-12-01 18:00:03.741739@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:00:21.888713||measurement||price||2015-12-01 18:00:03.918349@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:00:22.101857||measurement||price||2015-12-01 18:00:16.428368@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 18:00:24.086478||measurement||price||2015-12-01 18:00:17.653059@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:00:26.284272||measurement||price||2015-12-01 18:00:06.908106@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:00:28.837590||measurement||loadtime||0:00:26.798656||3||0
+2015-12-01 18:00:28.992035||measurement||loadtime||0:00:26.701424||2||0
+2015-12-01 18:00:33.499132||measurement||loadtime||0:00:28.703959||1||1
+2015-12-01 18:00:33.504185||measurement||price||2015-12-01 18:00:14.547679@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:00:34.465821||measurement||price||2015-12-01 18:00:16.428368@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 18:00:36.965435||measurement||price||2015-12-01 18:00:17.653059@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:00:40.731131||measurement||loadtime||0:00:28.584413||4||1
+2015-12-01 18:00:41.218995||measurement||price||2015-12-01 18:00:35.575558@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:00:41.451572||measurement||price||2015-12-01 18:00:35.882583@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 18:00:41.583162||measurement||loadtime||0:00:26.777388||0||0
+2015-12-01 18:00:44.214877||measurement||loadtime||0:00:28.829735||5||1
+2015-12-01 18:00:47.147578||measurement||price||2015-12-01 18:00:40.695415@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:00:53.582199||measurement||price||2015-12-01 18:00:35.575558@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:00:53.816651||measurement||price||2015-12-01 18:00:35.882583@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 18:00:53.855327||measurement||price||2015-12-01 18:00:48.280103@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 18:00:55.108212||measurement||price||2015-12-01 18:00:48.108930@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:00:57.839809||measurement||price||2015-12-01 18:00:51.612422@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:01:00.028027||measurement||price||2015-12-01 18:00:40.695415@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:01:00.691777||measurement||loadtime||0:00:26.694528||2||0
+2015-12-01 18:01:00.935287||measurement||loadtime||0:00:27.092488||3||0
+2015-12-01 18:01:06.195453||measurement||price||2015-12-01 18:00:48.280103@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 18:01:07.235059||measurement||loadtime||0:00:28.730704||1||1
+2015-12-01 18:01:08.243146||measurement||price||2015-12-01 18:00:48.108930@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:01:10.714120||measurement||price||2015-12-01 18:00:51.612422@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:01:12.896088||measurement||price||2015-12-01 18:01:07.243325@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:01:13.201200||measurement||price||2015-12-01 18:01:07.610865@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 18:01:13.311150||measurement||loadtime||0:00:26.722796||0||0
+2015-12-01 18:01:15.468289||measurement||loadtime||0:00:29.731964||4||1
+2015-12-01 18:01:17.927815||measurement||loadtime||0:00:28.708359||5||1
+2015-12-01 18:01:25.235587||measurement||price||2015-12-01 18:01:07.243325@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:01:25.547975||measurement||price||2015-12-01 18:01:07.610865@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 18:01:25.552529||measurement||price||2015-12-01 18:01:19.979346@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 18:01:29.229598||measurement||price||2015-12-01 18:01:22.809537@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:01:30.764954||error||collecting ads||Error||1||1
+2015-12-01 18:01:31.396223||measurement||price||2015-12-01 18:01:25.038948@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:01:32.354672||measurement||loadtime||0:00:26.660478||2||0
+2015-12-01 18:01:32.667372||measurement||loadtime||0:00:26.728014||3||0
+2015-12-01 18:01:37.899738||measurement||price||2015-12-01 18:01:19.979346@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 18:01:42.099579||measurement||price||2015-12-01 18:01:22.809537@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:01:44.266089||measurement||price||2015-12-01 18:01:25.038948@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:01:45.015142||measurement||loadtime||0:00:26.703306||0||0
+2015-12-01 18:01:45.085788||measurement||price||2015-12-01 18:01:39.345409@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:01:49.327186||measurement||loadtime||0:00:28.852645||4||1
+2015-12-01 18:01:51.483144||measurement||loadtime||0:00:28.550108||5||1
+2015-12-01 18:01:54.798005||error||collecting ads||Error||2||0
+2015-12-01 18:01:55.217957||error||collecting ads||Error||1||1
+2015-12-01 18:01:57.392991||measurement||price||2015-12-01 18:01:39.345409@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:02:03.006349||measurement||price||2015-12-01 18:01:56.444120@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:02:04.478712||measurement||loadtime||0:00:26.807579||3||0
+2015-12-01 18:02:05.254812||measurement||price||2015-12-01 18:01:58.811371@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:02:07.117614||measurement||price||2015-12-01 18:02:01.526479@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:02:07.251746||error||collecting ads||Error||0||0
+2015-12-01 18:02:15.942311||measurement||price||2015-12-01 18:01:56.444120@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:02:16.806077||measurement||price||2015-12-01 18:02:11.244706@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:02:18.026545||measurement||price||2015-12-01 18:01:58.811371@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:02:18.737288||error||collecting ads||Error||1||1
+2015-12-01 18:02:19.458933||measurement||price||2015-12-01 18:02:01.526479@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:02:19.840530||measurement||price||2015-12-01 18:02:14.259506@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||0||0
+2015-12-01 18:02:23.144427||measurement||loadtime||0:00:28.812018||4||1
+2015-12-01 18:02:25.227149||measurement||loadtime||0:00:28.738811||5||1
+2015-12-01 18:02:26.568031||measurement||loadtime||0:00:26.764882||2||0
+2015-12-01 18:02:29.155934||measurement||price||2015-12-01 18:02:11.244706@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:02:32.183727||measurement||price||2015-12-01 18:02:14.259506@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||0||0
+2015-12-01 18:02:32.259613||measurement||price||2015-12-01 18:02:25.784022@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:02:36.260265||measurement||loadtime||0:00:26.776368||3||0
+2015-12-01 18:02:37.282925||measurement||price||2015-12-01 18:02:30.404274@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:02:38.897702||measurement||price||2015-12-01 18:02:32.456928@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:02:39.219502||measurement||price||2015-12-01 18:02:33.572493@|At-A-Glance@|$24.40@|At-A-Glance Weekly and Monthly Planner 2016, Collection, Wir...||2||0
+2015-12-01 18:02:39.307190||measurement||loadtime||0:00:27.052019||0||0
+2015-12-01 18:02:45.135400||measurement||price||2015-12-01 18:02:25.784022@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:02:48.478415||measurement||price||2015-12-01 18:02:42.894475@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:02:50.284997||measurement||price||2015-12-01 18:02:30.404274@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:02:51.517845||measurement||price||2015-12-01 18:02:33.572493@|At-A-Glance@|$18.58@|At-A-Glance Monthly Wall Pocket Calendar 2016, Collection, W...||2||0
+2015-12-01 18:02:51.628931||measurement||price||2015-12-01 18:02:46.016023@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 18:02:51.733984||measurement||price||2015-12-01 18:02:32.456928@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:02:52.352420||measurement||loadtime||0:00:28.609890||1||1
+2015-12-01 18:02:57.466301||measurement||loadtime||0:00:29.317256||4||1
+2015-12-01 18:02:58.619155||measurement||loadtime||0:00:27.045929||2||0
+2015-12-01 18:02:58.947242||measurement||loadtime||0:00:28.716302||5||1
+2015-12-01 18:03:00.804972||measurement||price||2015-12-01 18:02:42.894475@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:03:03.954574||measurement||price||2015-12-01 18:02:46.016023@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 18:03:06.132163||measurement||price||2015-12-01 18:02:59.516447@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:03:07.911693||measurement||loadtime||0:00:26.646222||3||0
+2015-12-01 18:03:10.912846||measurement||price||2015-12-01 18:03:05.341115@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:03:11.075209||measurement||loadtime||0:00:26.762771||0||0
+2015-12-01 18:03:11.285123||measurement||price||2015-12-01 18:03:04.782704@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:03:12.774546||measurement||price||2015-12-01 18:03:06.270046@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:03:19.020733||measurement||price||2015-12-01 18:02:59.516447@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:03:20.186274||measurement||price||2015-12-01 18:03:14.621076@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:03:23.212795||measurement||price||2015-12-01 18:03:05.341115@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:03:23.306018||measurement||price||2015-12-01 18:03:17.738887@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 18:03:24.286523||measurement||price||2015-12-01 18:03:04.782704@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:03:25.766645||measurement||price||2015-12-01 18:03:06.270046@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:03:26.256609||measurement||loadtime||0:00:28.898964||1||1
+2015-12-01 18:03:30.300915||measurement||loadtime||0:00:26.677753||2||0
+2015-12-01 18:03:31.482974||measurement||loadtime||0:00:29.014817||4||1
+2015-12-01 18:03:32.527420||measurement||price||2015-12-01 18:03:14.621076@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:03:32.971166||measurement||loadtime||0:00:29.020029||5||1
+2015-12-01 18:03:35.659876||measurement||price||2015-12-01 18:03:17.738887@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 18:03:39.635403||measurement||loadtime||0:00:26.720257||3||0
+2015-12-01 18:03:39.890494||measurement||price||2015-12-01 18:03:33.439861@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:03:42.462850||measurement||price||2015-12-01 18:03:36.896004@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:03:42.771170||measurement||loadtime||0:00:26.690730||0||0
+2015-12-01 18:03:46.598087||measurement||price||2015-12-01 18:03:40.195319@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:03:52.678918||measurement||price||2015-12-01 18:03:33.439861@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:03:54.811162||measurement||price||2015-12-01 18:03:36.896004@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:03:55.184326||measurement||price||2015-12-01 18:03:49.452702@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 18:03:55.489417||error||collecting ads||Error||4||1
+2015-12-01 18:03:59.503633||measurement||price||2015-12-01 18:03:40.195319@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:03:59.897622||measurement||loadtime||0:00:28.635771||1||1
+2015-12-01 18:04:01.911481||error||collecting ads||Error||3||0
+2015-12-01 18:04:01.921518||measurement||loadtime||0:00:26.615404||2||0
+2015-12-01 18:04:06.727147||measurement||loadtime||0:00:28.751373||5||1
+2015-12-01 18:04:07.561256||measurement||price||2015-12-01 18:03:49.452702@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 18:04:09.217233||measurement||price||2015-12-01 18:04:02.681045@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:04:13.676762||measurement||price||2015-12-01 18:04:07.113182@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:04:14.675149||measurement||loadtime||0:00:26.898797||0||0
+2015-12-01 18:04:20.497583||measurement||price||2015-12-01 18:04:13.885935@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:04:22.097140||measurement||price||2015-12-01 18:04:02.681045@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:04:24.230051||error||collecting ads||Error||3||0
+2015-12-01 18:04:24.404318||error||collecting ads||Error||2||0
+2015-12-01 18:04:26.495453||measurement||price||2015-12-01 18:04:07.113182@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:04:27.068102||measurement||price||2015-12-01 18:04:21.507744@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 18:04:29.315147||measurement||loadtime||0:00:28.820503||4||1
+2015-12-01 18:04:33.387500||measurement||price||2015-12-01 18:04:13.885935@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:04:33.708203||measurement||loadtime||0:00:28.805971||1||1
+2015-12-01 18:04:36.556364||measurement||price||2015-12-01 18:04:31.026073@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:04:36.573273||measurement||price||2015-12-01 18:04:30.946319@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:04:39.408761||measurement||price||2015-12-01 18:04:21.507744@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 18:04:40.606969||measurement||loadtime||0:00:28.874641||5||1
+2015-12-01 18:04:43.317485||measurement||price||2015-12-01 18:04:36.599215@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:04:46.519805||measurement||loadtime||0:00:26.839448||0||0
+2015-12-01 18:04:47.453460||measurement||price||2015-12-01 18:04:40.983596@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:04:48.894020||measurement||price||2015-12-01 18:04:31.026073@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:04:48.924424||measurement||price||2015-12-01 18:04:30.946319@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:04:54.333705||measurement||price||2015-12-01 18:04:47.946181@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:04:56.016789||measurement||loadtime||0:00:26.608003||2||0
+2015-12-01 18:04:56.047983||measurement||loadtime||0:00:26.812707||3||0
+2015-12-01 18:04:56.168208||measurement||price||2015-12-01 18:04:36.599215@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:04:58.751857||measurement||price||2015-12-01 18:04:53.174759@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 18:05:00.310367||measurement||price||2015-12-01 18:04:40.983596@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:05:03.367558||measurement||loadtime||0:00:29.047190||4||1
+2015-12-01 18:05:07.212485||measurement||price||2015-12-01 18:04:47.946181@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:05:07.539194||measurement||loadtime||0:00:28.828050||1||1
+2015-12-01 18:05:08.290167||measurement||price||2015-12-01 18:05:02.655523@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 18:05:08.293389||measurement||price||2015-12-01 18:05:02.655126@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:05:11.096264||measurement||price||2015-12-01 18:04:53.174759@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 18:05:14.426844||measurement||loadtime||0:00:28.814602||5||1
+2015-12-01 18:05:17.237074||measurement||price||2015-12-01 18:05:10.709903@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:05:18.227282||measurement||loadtime||0:00:26.702203||0||0
+2015-12-01 18:05:20.639666||measurement||price||2015-12-01 18:05:02.655126@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:05:20.646156||measurement||price||2015-12-01 18:05:02.655523@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 18:05:21.034168||measurement||price||2015-12-01 18:05:14.721099@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:05:27.753159||measurement||loadtime||0:00:26.731135||2||0
+2015-12-01 18:05:27.758816||measurement||loadtime||0:00:26.705675||3||0
+2015-12-01 18:05:28.135376||measurement||price||2015-12-01 18:05:21.630283@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 18:05:30.308484||measurement||price||2015-12-01 18:05:10.709903@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:05:33.858310||measurement||price||2015-12-01 18:05:14.721099@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:05:37.490312||measurement||loadtime||0:00:29.119177||4||1
+2015-12-01 18:05:40.001237||measurement||price||2015-12-01 18:05:34.433906@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:05:40.653745||error||collecting ads||Error||0||0
+2015-12-01 18:05:41.006543||measurement||price||2015-12-01 18:05:21.630283@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 18:05:41.106996||measurement||loadtime||0:00:28.563857||1||1
+2015-12-01 18:05:48.203185||measurement||loadtime||0:00:28.771123||5||1
+2015-12-01 18:05:50.257995||error||collecting ads||Error||3||0
+2015-12-01 18:05:52.363150||measurement||price||2015-12-01 18:05:34.433906@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:05:54.870456||measurement||price||2015-12-01 18:05:48.457743@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:05:59.478042||measurement||loadtime||0:00:26.719664||2||0
+2015-12-01 18:06:01.148564||error||collecting ads||Error||4||1
+2015-12-01 18:06:02.490359||measurement||price||2015-12-01 18:05:56.915887@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:06:02.968609||error||collecting ads||Error||0||0
+2015-12-01 18:06:07.685093||measurement||price||2015-12-01 18:05:48.457743@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:06:11.666187||measurement||price||2015-12-01 18:06:06.119178@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:06:12.354708||error||collecting ads||Error||5||1
+2015-12-01 18:06:14.828652||measurement||price||2015-12-01 18:05:56.915887@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:06:14.883223||measurement||loadtime||0:00:28.772047||1||1
+2015-12-01 18:06:15.179880||measurement||price||2015-12-01 18:06:09.631204@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 18:06:15.321498||measurement||price||2015-12-01 18:06:08.412455@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:06:21.943157||measurement||loadtime||0:00:26.681797||3||0
+2015-12-01 18:06:23.995161||measurement||price||2015-12-01 18:06:06.119178@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:06:26.119013||measurement||price||2015-12-01 18:06:19.676759@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 18:06:27.526097||measurement||price||2015-12-01 18:06:09.631204@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 18:06:28.333664||measurement||price||2015-12-01 18:06:08.412455@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:06:29.101495||measurement||price||2015-12-01 18:06:22.773353@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||1
+2015-12-01 18:06:31.110032||measurement||loadtime||0:00:26.626753||2||0
+2015-12-01 18:06:34.259440||measurement||price||2015-12-01 18:06:28.672559@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:06:34.660788||measurement||loadtime||0:00:26.688352||0||0
+2015-12-01 18:06:35.543956||measurement||loadtime||0:00:29.392799||4||1
+2015-12-01 18:06:38.997773||measurement||price||2015-12-01 18:06:19.676759@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 18:06:42.080458||measurement||price||2015-12-01 18:06:22.773353@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||1
+2015-12-01 18:06:43.294376||measurement||price||2015-12-01 18:06:37.772225@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:06:46.224337||measurement||loadtime||0:00:28.864434||5||1
+2015-12-01 18:06:46.588383||measurement||price||2015-12-01 18:06:28.672559@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:06:47.081016||measurement||price||2015-12-01 18:06:41.457085@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 18:06:49.311198||measurement||loadtime||0:00:29.424037||1||1
+2015-12-01 18:06:49.414852||measurement||price||2015-12-01 18:06:42.908266@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:06:53.705517||measurement||loadtime||0:00:26.762137||3||0
+2015-12-01 18:06:55.626041||measurement||price||2015-12-01 18:06:37.772225@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:06:59.426255||measurement||price||2015-12-01 18:06:41.457085@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 18:06:59.869521||measurement||price||2015-12-01 18:06:53.465472@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:07:02.232757||measurement||price||2015-12-01 18:06:42.908266@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:07:02.748391||measurement||loadtime||0:00:26.633130||2||0
+2015-12-01 18:07:03.023442||measurement||price||2015-12-01 18:06:56.558659@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:07:06.389278||measurement||price||2015-12-01 18:07:00.768825@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||3||0
+2015-12-01 18:07:06.537994||measurement||loadtime||0:00:26.871968||0||0
+2015-12-01 18:07:09.459427||measurement||loadtime||0:00:28.912279||4||1
+2015-12-01 18:07:12.666309||measurement||price||2015-12-01 18:06:53.465472@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:07:14.941531||measurement||price||2015-12-01 18:07:09.355071@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:07:16.057577||measurement||price||2015-12-01 18:06:56.558659@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:07:18.726230||measurement||price||2015-12-01 18:07:13.008790@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 18:07:18.730087||measurement||price||2015-12-01 18:07:00.768825@|@|$79.95@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||3||0
+2015-12-01 18:07:19.864975||measurement||loadtime||0:00:28.637802||5||1
+2015-12-01 18:07:23.040222||measurement||price||2015-12-01 18:07:16.821684@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:07:23.271182||measurement||loadtime||0:00:28.956020||1||1
+2015-12-01 18:07:25.842509||measurement||loadtime||0:00:27.131758||3||0
+2015-12-01 18:07:27.274683||measurement||price||2015-12-01 18:07:09.355071@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:07:31.088155||measurement||price||2015-12-01 18:07:13.008790@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 18:07:33.501096||measurement||price||2015-12-01 18:07:27.040606@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:07:34.389010||measurement||loadtime||0:00:26.640073||2||0
+2015-12-01 18:07:35.822526||measurement||price||2015-12-01 18:07:16.821684@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:07:36.855428||measurement||price||2015-12-01 18:07:30.609950@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:07:38.132527||measurement||price||2015-12-01 18:07:32.550123@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 18:07:38.212317||measurement||loadtime||0:00:26.670413||0||0
+2015-12-01 18:07:43.054053||measurement||loadtime||0:00:28.589438||4||1
+2015-12-01 18:07:46.338050||measurement||price||2015-12-01 18:07:27.040606@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:07:46.613188||measurement||price||2015-12-01 18:07:41.047286@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:07:49.727337||measurement||price||2015-12-01 18:07:30.609950@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:07:50.494568||measurement||price||2015-12-01 18:07:32.550123@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 18:07:50.877963||measurement||price||2015-12-01 18:07:45.280856@|Disney Software@|$9.00@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||0||0
+2015-12-01 18:07:53.547870||measurement||loadtime||0:00:28.677654||5||1
+2015-12-01 18:07:56.947226||measurement||price||2015-12-01 18:07:50.381969@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:07:56.956981||measurement||loadtime||0:00:28.680588||1||1
+2015-12-01 18:07:57.608053||measurement||loadtime||0:00:26.760893||3||0
+2015-12-01 18:07:57.608202||event||progress-marker||measurement-end||3||0
+2015-12-01 18:07:58.948539||measurement||price||2015-12-01 18:07:41.047286@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:08:03.223809||measurement||price||2015-12-01 18:07:45.280856@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||0
+2015-12-01 18:08:06.063915||measurement||loadtime||0:00:26.671893||2||0
+2015-12-01 18:08:06.064038||event||progress-marker||measurement-end||2||0
+2015-12-01 18:08:07.057793||measurement||price||2015-12-01 18:08:00.832476@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:08:09.863590||measurement||price||2015-12-01 18:07:50.381969@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:08:10.327181||measurement||loadtime||0:00:27.109605||0||0
+2015-12-01 18:08:10.327321||event||progress-marker||measurement-end||0||0
+2015-12-01 18:08:10.602175||measurement||price||2015-12-01 18:08:04.228102@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:08:17.066566||measurement||loadtime||0:00:29.007608||4||1
+2015-12-01 18:08:19.853882||measurement||price||2015-12-01 18:08:00.832476@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:08:23.427945||measurement||price||2015-12-01 18:08:04.228102@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:08:27.067097||measurement||loadtime||0:00:28.516310||5||1
+2015-12-01 18:08:30.629043||measurement||loadtime||0:00:28.666859||1||1
+2015-12-01 18:08:30.629190||event||progress-marker||measurement-end||1||1
+2015-12-01 18:08:30.981146||measurement||price||2015-12-01 18:08:24.489725@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:08:40.536988||measurement||price||2015-12-01 18:08:34.232317@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:08:43.977425||measurement||price||2015-12-01 18:08:24.489725@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:08:51.174007||measurement||loadtime||0:00:29.099787||4||1
+2015-12-01 18:08:53.312956||measurement||price||2015-12-01 18:08:34.232317@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:09:00.525395||measurement||loadtime||0:00:28.453058||5||1
+2015-12-01 18:09:14.748298||error||collecting ads||Error||4||1
+2015-12-01 18:09:24.112834||error||collecting ads||Error||5||1
+2015-12-01 18:09:24.112980||event||progress-marker||measurement-end||5||1
+2015-12-01 18:09:38.372295||error||collecting ads||Error||4||1
+2015-12-01 18:09:38.372451||event||progress-marker||measurement-end||4||1
+2015-12-01 18:09:38.813961||meta||block_id end||18
+2015-12-01 18:09:38.814288||meta||block_id start||19
+2015-12-01 18:09:38.814319||meta||assignment||1@|5@|2@|3@|0@|4
+2015-12-01 18:09:40.397405||event||progress-marker||training-start||2||0
+2015-12-01 18:09:40.397508||event||progress-marker||training-end||2||0
+2015-12-01 18:09:40.425702||event||progress-marker||training-start||1||0
+2015-12-01 18:09:40.425813||event||progress-marker||training-end||1||0
+2015-12-01 18:09:40.432056||event||progress-marker||training-start||5||0
+2015-12-01 18:09:40.432313||event||progress-marker||training-end||5||0
+2015-12-01 18:09:45.457901||event||progress-marker||measurement-start||2||0
+2015-12-01 18:09:45.476803||event||progress-marker||measurement-start||1||0
+2015-12-01 18:09:45.478548||event||progress-marker||measurement-start||5||0
+2015-12-01 18:09:59.479526||measurement||price||2015-12-01 18:09:52.888578@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:09:59.531787||measurement||price||2015-12-01 18:09:52.685402@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:10:00.431575||measurement||price||2015-12-01 18:09:52.669558@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:10:11.821604||measurement||price||2015-12-01 18:09:52.888578@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:10:11.872441||measurement||price||2015-12-01 18:09:52.685402@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:10:12.785407||measurement||price||2015-12-01 18:09:52.669558@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:10:18.928756||measurement||loadtime||0:00:28.445607||5||0
+2015-12-01 18:10:18.980923||measurement||loadtime||0:00:28.517808||2||0
+2015-12-01 18:10:19.890622||measurement||loadtime||0:00:29.411452||1||0
+2015-12-01 18:10:31.345329||measurement||price||2015-12-01 18:10:25.656518@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:10:32.154383||measurement||price||2015-12-01 18:10:26.597680@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:10:41.282041||error||collecting ads||Error||5||0
+2015-12-01 18:10:43.651136||measurement||price||2015-12-01 18:10:25.656518@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:10:44.476942||measurement||price||2015-12-01 18:10:26.597680@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:10:50.767178||measurement||loadtime||0:00:26.784004||2||0
+2015-12-01 18:10:51.594049||measurement||loadtime||0:00:26.698834||1||0
+2015-12-01 18:10:53.452422||measurement||price||2015-12-01 18:10:47.854854@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:11:02.981165||measurement||price||2015-12-01 18:10:57.390094@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:11:04.824075||measurement||price||2015-12-01 18:10:59.529773@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||1||0
+2015-12-01 18:11:05.781488||measurement||price||2015-12-01 18:10:47.854854@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:11:12.891445||measurement||loadtime||0:00:26.605864||5||0
+2015-12-01 18:11:15.307813||measurement||price||2015-12-01 18:10:57.390094@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:11:16.942720||event||progress-marker||training-start||3||1
+2015-12-01 18:11:16.942825||event||progress-marker||training-end||3||1
+2015-12-01 18:11:17.137827||measurement||price||2015-12-01 18:10:59.529773@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||1||0
+2015-12-01 18:11:19.343874||event||progress-marker||training-start||0||1
+2015-12-01 18:11:19.343970||event||progress-marker||training-end||0||1
+2015-12-01 18:11:21.990879||event||progress-marker||measurement-start||3||1
+2015-12-01 18:11:22.414040||measurement||loadtime||0:00:26.641642||2||0
+2015-12-01 18:11:24.223816||measurement||loadtime||0:00:27.624661||1||0
+2015-12-01 18:11:24.396106||event||progress-marker||measurement-start||0||1
+2015-12-01 18:11:25.106345||measurement||price||2015-12-01 18:11:19.546599@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:11:34.628141||measurement||price||2015-12-01 18:11:28.978334@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:11:36.318298||measurement||price||2015-12-01 18:11:29.973952@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:11:36.450630||measurement||price||2015-12-01 18:11:30.849158@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:11:37.423984||measurement||price||2015-12-01 18:11:19.546599@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:11:39.226490||measurement||price||2015-12-01 18:11:33.057598@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:11:44.533785||measurement||loadtime||0:00:26.638919||5||0
+2015-12-01 18:11:46.973464||measurement||price||2015-12-01 18:11:28.978334@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:11:48.730857||measurement||price||2015-12-01 18:11:30.849158@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:11:49.131229||measurement||price||2015-12-01 18:11:29.973952@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:11:52.142145||measurement||price||2015-12-01 18:11:33.057598@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:11:54.088322||measurement||loadtime||0:00:26.669070||2||0
+2015-12-01 18:11:55.813527||measurement||loadtime||0:00:26.584513||1||0
+2015-12-01 18:11:56.349816||measurement||loadtime||0:00:29.353707||3||1
+2015-12-01 18:11:56.743489||measurement||price||2015-12-01 18:11:51.158682@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:11:59.363171||measurement||loadtime||0:00:29.964022||0||1
+2015-12-01 18:12:06.231479||measurement||price||2015-12-01 18:12:00.654367@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:12:09.085065||measurement||price||2015-12-01 18:11:51.158682@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:12:10.216779||measurement||price||2015-12-01 18:12:03.634342@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:12:13.662196||measurement||price||2015-12-01 18:12:07.324805@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:12:15.484819||event||progress-marker||training-start||4||1
+2015-12-01 18:12:15.485040||event||progress-marker||training-end||4||1
+2015-12-01 18:12:16.206013||measurement||loadtime||0:00:26.667000||5||0
+2015-12-01 18:12:18.025569||error||collecting ads||Error||1||0
+2015-12-01 18:12:18.581617||measurement||price||2015-12-01 18:12:00.654367@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:12:20.538989||event||progress-marker||measurement-start||4||1
+2015-12-01 18:12:23.033949||measurement||price||2015-12-01 18:12:03.634342@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:12:25.691642||measurement||loadtime||0:00:26.598112||2||0
+2015-12-01 18:12:26.839790||measurement||price||2015-12-01 18:12:07.324805@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:12:28.420479||measurement||price||2015-12-01 18:12:22.755132@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:12:30.228684||measurement||price||2015-12-01 18:12:24.650119@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:12:30.271152||measurement||loadtime||0:00:28.916015||3||1
+2015-12-01 18:12:34.079780||measurement||loadtime||0:00:29.711434||0||1
+2015-12-01 18:12:34.865300||measurement||price||2015-12-01 18:12:28.246260@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:12:37.826542||measurement||price||2015-12-01 18:12:32.235263@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:12:40.749101||measurement||price||2015-12-01 18:12:22.755132@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:12:42.565605||measurement||price||2015-12-01 18:12:24.650119@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:12:47.725616||measurement||price||2015-12-01 18:12:28.246260@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:12:47.853521||measurement||loadtime||0:00:26.642258||5||0
+2015-12-01 18:12:49.681647||measurement||loadtime||0:00:26.654469||1||0
+2015-12-01 18:12:50.179247||measurement||price||2015-12-01 18:12:32.235263@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:12:54.019975||error||collecting ads||Error||3||1
+2015-12-01 18:12:54.923180||measurement||loadtime||0:00:29.383297||4||1
+2015-12-01 18:12:57.294057||measurement||loadtime||0:00:26.597131||2||0
+2015-12-01 18:12:58.231080||error||collecting ads||Error||0||1
+2015-12-01 18:13:00.077279||measurement||price||2015-12-01 18:12:54.516355@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:13:01.866843||measurement||price||2015-12-01 18:12:56.330066@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:13:07.840958||measurement||price||2015-12-01 18:13:01.280941@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:13:11.846129||measurement||price||2015-12-01 18:13:05.675439@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:13:12.425649||measurement||price||2015-12-01 18:12:54.516355@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:13:14.208554||measurement||price||2015-12-01 18:12:56.330066@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:13:18.784633||error||collecting ads||Error||4||1
+2015-12-01 18:13:19.537649||measurement||loadtime||0:00:26.678933||5||0
+2015-12-01 18:13:19.827250||error||collecting ads||Error||2||0
+2015-12-01 18:13:20.723716||measurement||price||2015-12-01 18:13:01.280941@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:13:21.317669||measurement||loadtime||0:00:26.633246||1||0
+2015-12-01 18:13:24.803813||measurement||price||2015-12-01 18:13:05.675439@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:13:27.923146||measurement||loadtime||0:00:28.897969||3||1
+2015-12-01 18:13:31.845754||measurement||price||2015-12-01 18:13:26.163059@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:13:32.005099||measurement||loadtime||0:00:28.769929||0||1
+2015-12-01 18:13:32.123465||measurement||price||2015-12-01 18:13:26.401338@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:13:33.059458||measurement||price||2015-12-01 18:13:26.229956@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:13:33.663430||measurement||price||2015-12-01 18:13:28.057905@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:13:41.740358||measurement||price||2015-12-01 18:13:35.248668@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:13:44.178966||measurement||price||2015-12-01 18:13:26.163059@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:13:44.463573||measurement||price||2015-12-01 18:13:26.401338@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:13:45.928700||measurement||price||2015-12-01 18:13:26.229956@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:13:46.010630||measurement||price||2015-12-01 18:13:28.057905@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:13:51.290665||measurement||loadtime||0:00:26.747804||5||0
+2015-12-01 18:13:51.581410||measurement||loadtime||0:00:26.750263||2||0
+2015-12-01 18:13:53.123731||measurement||loadtime||0:00:26.802650||1||0
+2015-12-01 18:13:53.165295||measurement||loadtime||0:00:29.375407||4||1
+2015-12-01 18:13:54.547864||measurement||price||2015-12-01 18:13:35.248668@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:13:55.723613||error||collecting ads||Error||0||1
+2015-12-01 18:14:01.763439||measurement||loadtime||0:00:28.835082||3||1
+2015-12-01 18:14:03.888827||measurement||price||2015-12-01 18:13:58.281029@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:14:05.472303||measurement||price||2015-12-01 18:13:59.858481@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:14:07.037730||measurement||price||2015-12-01 18:14:00.663062@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:14:09.309485||measurement||price||2015-12-01 18:14:03.158138@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:14:13.807660||error||collecting ads||Error||5||0
+2015-12-01 18:14:15.858285||measurement||price||2015-12-01 18:14:09.361199@|Sony@| $349.00   @|PlayStation 4 500GB Console - Star Wars Battlefront Bundle||3||1
+2015-12-01 18:14:16.237457||measurement||price||2015-12-01 18:13:58.281029@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:14:17.815635||measurement||price||2015-12-01 18:13:59.858481@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:14:20.508731||measurement||price||2015-12-01 18:14:00.663062@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:14:22.156123||measurement||price||2015-12-01 18:14:03.158138@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:14:23.351159||measurement||loadtime||0:00:26.764524||2||0
+2015-12-01 18:14:24.931150||measurement||loadtime||0:00:26.804019||1||0
+2015-12-01 18:14:28.660380||measurement||price||2015-12-01 18:14:23.309052@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:14:28.706676||measurement||price||2015-12-01 18:14:09.361199@|Electronic Arts@| $59.88   @|Star Wars: Battlefront - Standard Edition - Xbox One||3||1
+2015-12-01 18:14:29.363168||measurement||loadtime||0:00:28.636032||0||1
+2015-12-01 18:14:29.475160||measurement||loadtime||0:00:31.304670||4||1
+2015-12-01 18:14:35.911287||measurement||loadtime||0:00:29.146533||3||1
+2015-12-01 18:14:37.170687||measurement||price||2015-12-01 18:14:31.527252@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:14:41.002928||measurement||price||2015-12-01 18:14:23.309052@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:14:43.059604||measurement||price||2015-12-01 18:14:36.728402@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:14:43.823238||measurement||price||2015-12-01 18:14:37.486799@|Mitchell@|$73.90@|Mitchell 300 Pro Spinning Rod and Reel Combo, 7-Feet/Medium||4||1
+2015-12-01 18:14:45.726046||error||collecting ads||Error||2||0
+2015-12-01 18:14:48.104665||measurement||loadtime||0:00:29.294794||5||0
+2015-12-01 18:14:49.507387||measurement||price||2015-12-01 18:14:31.527252@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:14:49.790027||measurement||price||2015-12-01 18:14:43.289913@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:14:56.056530||measurement||price||2015-12-01 18:14:36.728402@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:14:56.620588||measurement||loadtime||0:00:26.684245||1||0
+2015-12-01 18:14:56.764017||measurement||price||2015-12-01 18:14:37.486799@|Penn@|$89.65@|Penn Battle II Spinning Reel, 4000||4||1
+2015-12-01 18:15:00.250333||measurement||price||2015-12-01 18:14:54.671792@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:15:02.744507||measurement||price||2015-12-01 18:14:43.289913@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:15:03.259130||measurement||loadtime||0:00:28.890711||0||1
+2015-12-01 18:15:03.963174||measurement||loadtime||0:00:29.482808||4||1
+2015-12-01 18:15:08.010940||error||collecting ads||Error||2||0
+2015-12-01 18:15:08.885467||measurement||price||2015-12-01 18:15:03.248084@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:15:09.930278||measurement||loadtime||0:00:29.015124||3||1
+2015-12-01 18:15:12.536524||measurement||price||2015-12-01 18:14:54.671792@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:15:16.969443||measurement||price||2015-12-01 18:15:10.501182@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:15:17.880676||measurement||price||2015-12-01 18:15:11.372549@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:15:19.628362||measurement||loadtime||0:00:26.521181||5||0
+2015-12-01 18:15:20.348463||measurement||price||2015-12-01 18:15:14.753672@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:15:21.208368||measurement||price||2015-12-01 18:15:03.248084@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:15:23.856803||measurement||price||2015-12-01 18:15:17.142667@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:15:28.300304||measurement||loadtime||0:00:26.674517||1||0
+2015-12-01 18:15:29.850583||measurement||price||2015-12-01 18:15:10.501182@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:15:30.794193||measurement||price||2015-12-01 18:15:11.372549@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:15:31.790950||measurement||price||2015-12-01 18:15:26.200421@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:15:32.683225||measurement||price||2015-12-01 18:15:14.753672@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:15:36.859623||measurement||price||2015-12-01 18:15:17.142667@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:15:37.060139||measurement||loadtime||0:00:28.800553||0||1
+2015-12-01 18:15:38.002795||measurement||loadtime||0:00:29.035630||4||1
+2015-12-01 18:15:39.789072||measurement||loadtime||0:00:26.772851||2||0
+2015-12-01 18:15:40.404895||measurement||price||2015-12-01 18:15:34.860363@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:15:44.038375||measurement||loadtime||0:00:29.102901||3||1
+2015-12-01 18:15:44.093474||measurement||price||2015-12-01 18:15:26.200421@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:15:51.177832||measurement||loadtime||0:00:26.544200||5||0
+2015-12-01 18:15:52.521919||measurement||price||2015-12-01 18:15:45.917559@|Disney Software@|$9.00@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||4||1
+2015-12-01 18:15:52.740030||measurement||price||2015-12-01 18:15:34.860363@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:15:59.864335||measurement||loadtime||0:00:26.558795||1||0
+2015-12-01 18:16:00.476361||error||collecting ads||Error||0||1
+2015-12-01 18:16:01.991582||error||collecting ads||Error||2||0
+2015-12-01 18:16:03.434969||measurement||price||2015-12-01 18:15:57.812081@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:16:05.417937||measurement||price||2015-12-01 18:15:45.917559@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||4||1
+2015-12-01 18:16:07.843816||error||collecting ads||Error||3||1
+2015-12-01 18:16:12.097435||measurement||price||2015-12-01 18:16:06.504268@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:16:12.625407||measurement||loadtime||0:00:29.617401||4||1
+2015-12-01 18:16:14.253865||measurement||price||2015-12-01 18:16:08.695466@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:16:15.732609||measurement||price||2015-12-01 18:15:57.812081@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:16:21.945630||measurement||price||2015-12-01 18:16:15.459395@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:16:22.817752||measurement||loadtime||0:00:26.634697||5||0
+2015-12-01 18:16:24.255145||error||collecting ads||Error||0||1
+2015-12-01 18:16:24.434376||measurement||price||2015-12-01 18:16:06.504268@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:16:26.525982||measurement||price||2015-12-01 18:16:19.945115@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:16:26.584366||measurement||price||2015-12-01 18:16:08.695466@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:16:31.555163||measurement||loadtime||0:00:26.685620||1||0
+2015-12-01 18:16:33.688201||measurement||loadtime||0:00:26.693056||2||0
+2015-12-01 18:16:34.885523||measurement||price||2015-12-01 18:16:15.459395@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:16:35.070120||measurement||price||2015-12-01 18:16:29.439391@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:16:37.924358||measurement||price||2015-12-01 18:16:31.610827@|@|$274.95@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||0||1
+2015-12-01 18:16:39.618943||measurement||price||2015-12-01 18:16:19.945115@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:16:42.111683||measurement||loadtime||0:00:29.266987||3||1
+2015-12-01 18:16:45.854551||measurement||price||2015-12-01 18:16:40.326203@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:16:46.838648||measurement||loadtime||0:00:29.208034||4||1
+2015-12-01 18:16:47.362494||measurement||price||2015-12-01 18:16:29.439391@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:16:50.810847||measurement||price||2015-12-01 18:16:31.610827@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||0||1
+2015-12-01 18:16:53.835980||error||collecting ads||Error||1||0
+2015-12-01 18:16:54.451217||measurement||loadtime||0:00:26.630143||5||0
+2015-12-01 18:16:55.898391||measurement||price||2015-12-01 18:16:49.319297@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:16:58.027547||measurement||loadtime||0:00:28.767191||0||1
+2015-12-01 18:16:58.155666||measurement||price||2015-12-01 18:16:40.326203@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:17:00.745186||measurement||price||2015-12-01 18:16:54.131466@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:17:05.246018||measurement||loadtime||0:00:26.552608||2||0
+2015-12-01 18:17:06.476309||measurement||price||2015-12-01 18:17:00.850283@|Extech@|$17.75@|Extech MN35 Digital Mini MultiMeter||1||0
+2015-12-01 18:17:06.716931||measurement||price||2015-12-01 18:17:01.128787@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:17:08.696282||measurement||price||2015-12-01 18:16:49.319297@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:17:11.856902||measurement||price||2015-12-01 18:17:05.520214@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:17:13.738435||measurement||price||2015-12-01 18:16:54.131466@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:17:15.931493||measurement||loadtime||0:00:28.814612||3||1
+2015-12-01 18:17:17.428134||measurement||price||2015-12-01 18:17:11.841842@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:17:18.807810||measurement||price||2015-12-01 18:17:00.850283@|Extech@|$39.99@|Extech CB10 Circuit Breaker Finder locates fuses/breakers, t...||1||0
+2015-12-01 18:17:19.013027||measurement||price||2015-12-01 18:17:01.128787@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:17:21.139129||measurement||loadtime||0:00:29.295254||4||1
+2015-12-01 18:17:24.657201||measurement||price||2015-12-01 18:17:05.520214@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:17:25.918670||measurement||loadtime||0:00:27.077461||1||0
+2015-12-01 18:17:26.104481||measurement||loadtime||0:00:26.648078||5||0
+2015-12-01 18:17:29.544635||measurement||price||2015-12-01 18:17:23.169906@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:17:29.734264||measurement||price||2015-12-01 18:17:11.841842@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:17:31.923176||measurement||loadtime||0:00:28.892042||0||1
+2015-12-01 18:17:36.833759||measurement||loadtime||0:00:26.582497||2||0
+2015-12-01 18:17:38.103699||measurement||price||2015-12-01 18:17:32.484240@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:17:38.304972||measurement||price||2015-12-01 18:17:32.721758@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:17:42.392500||measurement||price||2015-12-01 18:17:23.169906@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:17:44.856217||error||collecting ads||Error||4||1
+2015-12-01 18:17:45.776764||measurement||price||2015-12-01 18:17:39.485696@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:17:49.067926||measurement||price||2015-12-01 18:17:43.495483@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:17:49.611281||measurement||loadtime||0:00:28.674539||3||1
+2015-12-01 18:17:50.447219||measurement||price||2015-12-01 18:17:32.484240@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:17:50.642077||measurement||price||2015-12-01 18:17:32.721758@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:17:57.558593||measurement||loadtime||0:00:26.634684||1||0
+2015-12-01 18:17:57.752039||measurement||loadtime||0:00:26.642355||5||0
+2015-12-01 18:17:58.660462||measurement||price||2015-12-01 18:17:39.485696@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:17:58.805520||measurement||price||2015-12-01 18:17:52.041888@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:18:01.356764||measurement||price||2015-12-01 18:17:43.495483@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:18:05.875136||measurement||loadtime||0:00:28.946805||0||1
+2015-12-01 18:18:08.440198||measurement||loadtime||0:00:26.605041||2||0
+2015-12-01 18:18:09.971825||measurement||price||2015-12-01 18:18:04.394145@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:18:10.071814||measurement||price||2015-12-01 18:18:04.495298@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:18:11.864585||measurement||price||2015-12-01 18:17:52.041888@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:18:13.573355||error||collecting ads||Error||3||1
+2015-12-01 18:18:19.063302||measurement||loadtime||0:00:29.201861||4||1
+2015-12-01 18:18:20.044645||measurement||price||2015-12-01 18:18:14.104363@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:18:20.769739||measurement||price||2015-12-01 18:18:15.226525@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:18:22.313073||measurement||price||2015-12-01 18:18:04.394145@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:18:22.417852||measurement||price||2015-12-01 18:18:04.495298@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:18:27.292946||measurement||price||2015-12-01 18:18:21.181458@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:18:29.423140||measurement||loadtime||0:00:26.859259||1||0
+2015-12-01 18:18:29.535961||measurement||loadtime||0:00:26.778739||5||0
+2015-12-01 18:18:32.736867||measurement||price||2015-12-01 18:18:26.267959@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:18:32.869302||measurement||price||2015-12-01 18:18:14.104363@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:18:33.092790||measurement||price||2015-12-01 18:18:15.226525@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:18:40.070441||measurement||loadtime||0:00:29.190120||0||1
+2015-12-01 18:18:40.153688||measurement||price||2015-12-01 18:18:21.181458@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:18:40.207153||measurement||loadtime||0:00:26.761745||2||0
+2015-12-01 18:18:41.788057||measurement||price||2015-12-01 18:18:36.135317@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:18:41.889691||measurement||price||2015-12-01 18:18:36.254949@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:18:45.779890||measurement||price||2015-12-01 18:18:26.267959@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:18:47.383128||measurement||loadtime||0:00:28.804573||3||1
+2015-12-01 18:18:52.582402||measurement||price||2015-12-01 18:18:46.996015@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:18:52.981251||measurement||loadtime||0:00:28.912707||4||1
+2015-12-01 18:18:53.957499||measurement||price||2015-12-01 18:18:47.390337@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:18:54.119500||measurement||price||2015-12-01 18:18:36.135317@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:18:54.226364||measurement||price||2015-12-01 18:18:36.254949@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:19:01.227157||measurement||loadtime||0:00:26.799150||1||0
+2015-12-01 18:19:01.355149||measurement||loadtime||0:00:26.813999||5||0
+2015-12-01 18:19:01.358349||measurement||price||2015-12-01 18:18:54.886522@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:19:04.905499||measurement||price||2015-12-01 18:18:46.996015@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:19:06.839894||measurement||price||2015-12-01 18:19:00.333212@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:19:07.024713||measurement||price||2015-12-01 18:18:47.390337@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:19:12.013331||measurement||loadtime||0:00:26.800972||2||0
+2015-12-01 18:19:14.212582||measurement||price||2015-12-01 18:18:54.886522@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:19:14.323926||measurement||loadtime||0:00:29.248284||0||1
+2015-12-01 18:19:19.802629||measurement||price||2015-12-01 18:19:00.333212@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:19:21.435158||measurement||loadtime||0:00:29.046833||3||1
+2015-12-01 18:19:23.503912||error||collecting ads||Error||1||0
+2015-12-01 18:19:23.748224||error||collecting ads||Error||5||0
+2015-12-01 18:19:24.367563||measurement||price||2015-12-01 18:19:18.804517@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:19:27.002436||measurement||loadtime||0:00:29.020689||4||1
+2015-12-01 18:19:28.475970||measurement||price||2015-12-01 18:19:21.990065@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||0||1
+2015-12-01 18:19:35.528244||measurement||price||2015-12-01 18:19:28.749150@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:19:35.961667||measurement||price||2015-12-01 18:19:30.309694@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:19:36.703332||measurement||price||2015-12-01 18:19:18.804517@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:19:41.327274||measurement||price||2015-12-01 18:19:21.990065@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||0||1
+2015-12-01 18:19:43.817411||measurement||loadtime||0:00:26.798829||2||0
+2015-12-01 18:19:43.817526||event||progress-marker||measurement-end||2||0
+2015-12-01 18:19:46.195273||error||collecting ads||Error||5||0
+2015-12-01 18:19:46.195373||event||progress-marker||measurement-end||5||0
+2015-12-01 18:19:48.286090||measurement||price||2015-12-01 18:19:30.309694@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:19:48.559193||measurement||loadtime||0:00:29.230075||0||1
+2015-12-01 18:19:48.595740||measurement||price||2015-12-01 18:19:28.749150@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:19:50.827518||error||collecting ads||Error||4||1
+2015-12-01 18:19:55.395499||measurement||loadtime||0:00:26.888334||1||0
+2015-12-01 18:19:55.395609||event||progress-marker||measurement-end||1||0
+2015-12-01 18:19:55.832092||measurement||loadtime||0:00:29.396629||3||1
+2015-12-01 18:20:02.195166||measurement||price||2015-12-01 18:19:55.748599@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:20:04.629948||measurement||price||2015-12-01 18:19:58.088890@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:20:15.013209||measurement||price||2015-12-01 18:19:55.748599@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:20:17.482358||measurement||price||2015-12-01 18:19:58.088890@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:20:19.751828||error||collecting ads||Error||3||1
+2015-12-01 18:20:22.226344||measurement||loadtime||0:00:28.663131||0||1
+2015-12-01 18:20:24.688732||measurement||loadtime||0:00:28.856481||4||1
+2015-12-01 18:20:33.538432||measurement||price||2015-12-01 18:20:27.142087@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:20:38.473666||measurement||price||2015-12-01 18:20:31.942834@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:20:46.051535||error||collecting ads||Error||0||1
+2015-12-01 18:20:46.386024||measurement||price||2015-12-01 18:20:27.142087@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:20:51.365539||measurement||price||2015-12-01 18:20:31.942834@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:20:53.619479||measurement||loadtime||0:00:28.862455||3||1
+2015-12-01 18:20:58.569866||measurement||loadtime||0:00:28.875915||4||1
+2015-12-01 18:20:59.646073||measurement||price||2015-12-01 18:20:53.361702@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:21:07.340246||measurement||price||2015-12-01 18:21:00.959365@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:21:12.450657||measurement||price||2015-12-01 18:21:05.814502@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:21:12.704642||measurement||price||2015-12-01 18:20:53.361702@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:21:19.932548||measurement||loadtime||0:00:28.877379||0||1
+2015-12-01 18:21:20.183064||measurement||price||2015-12-01 18:21:00.959365@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:21:25.300776||measurement||price||2015-12-01 18:21:05.814502@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:21:27.382930||measurement||loadtime||0:00:28.758236||3||1
+2015-12-01 18:21:32.499178||measurement||loadtime||0:00:28.924098||4||1
+2015-12-01 18:21:41.060431||measurement||price||2015-12-01 18:21:34.605837@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:21:44.047392||error||collecting ads||Error||0||1
+2015-12-01 18:21:44.047501||event||progress-marker||measurement-end||0||1
+2015-12-01 18:21:46.315807||measurement||price||2015-12-01 18:21:39.824679@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:21:53.890618||measurement||price||2015-12-01 18:21:34.605837@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:21:59.190035||measurement||price||2015-12-01 18:21:39.824679@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:22:01.107082||measurement||loadtime||0:00:28.718878||3||1
+2015-12-01 18:22:01.107224||event||progress-marker||measurement-end||3||1
+2015-12-01 18:22:06.371402||measurement||loadtime||0:00:28.866917||4||1
+2015-12-01 18:22:30.123315||error||collecting ads||Error||4||1
+2015-12-01 18:22:43.786710||measurement||price||2015-12-01 18:22:37.303619@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:22:56.799198||measurement||price||2015-12-01 18:22:37.303619@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:23:04.031434||measurement||loadtime||0:00:28.902890||4||1
+2015-12-01 18:23:04.031565||event||progress-marker||measurement-end||4||1
+2015-12-01 18:23:04.417230||meta||block_id end||19
+2015-12-01 18:23:04.417531||meta||block_id start||20
+2015-12-01 18:23:04.417562||meta||assignment||3@|5@|2@|4@|0@|1
+2015-12-01 18:23:05.974972||event||progress-marker||training-start||3||0
+2015-12-01 18:23:05.975100||event||progress-marker||training-end||3||0
+2015-12-01 18:23:06.015562||event||progress-marker||training-start||2||0
+2015-12-01 18:23:06.015666||event||progress-marker||training-end||2||0
+2015-12-01 18:23:11.027722||event||progress-marker||measurement-start||3||0
+2015-12-01 18:23:11.066086||event||progress-marker||measurement-start||2||0
+2015-12-01 18:23:23.994277||measurement||price||2015-12-01 18:23:18.560877@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:23:24.200007||measurement||price||2015-12-01 18:23:18.733903@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:23:36.321828||measurement||price||2015-12-01 18:23:18.560877@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:23:36.575336||measurement||price||2015-12-01 18:23:18.733903@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:23:43.423450||measurement||loadtime||0:00:27.390505||3||0
+2015-12-01 18:23:43.677782||measurement||loadtime||0:00:27.606623||2||0
+2015-12-01 18:23:55.846487||measurement||price||2015-12-01 18:23:50.457579@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:23:56.131599||measurement||price||2015-12-01 18:23:50.695930@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:24:08.157775||measurement||price||2015-12-01 18:23:50.457579@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:24:08.428743||measurement||price||2015-12-01 18:23:50.695930@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:24:13.549059||event||progress-marker||training-start||1||1
+2015-12-01 18:24:13.549207||event||progress-marker||training-end||1||1
+2015-12-01 18:24:15.270524||measurement||loadtime||0:00:26.841847||3||0
+2015-12-01 18:24:15.521765||measurement||loadtime||0:00:26.842603||2||0
+2015-12-01 18:24:18.600908||event||progress-marker||measurement-start||1||1
+2015-12-01 18:24:27.856151||measurement||price||2015-12-01 18:24:22.405797@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:24:38.024866||error||collecting ads||Error||2||0
+2015-12-01 18:24:40.181305||measurement||price||2015-12-01 18:24:22.405797@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:24:42.971418||error||collecting ads||Error||1||1
+2015-12-01 18:24:47.288532||measurement||loadtime||0:00:27.012811||3||0
+2015-12-01 18:24:57.019476||measurement||price||2015-12-01 18:24:50.246954@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:24:59.814817||measurement||price||2015-12-01 18:24:54.386619@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:25:00.364909||error||collecting ads||Error||2||0
+2015-12-01 18:25:09.925798||measurement||price||2015-12-01 18:24:50.246954@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:25:12.166461||measurement||price||2015-12-01 18:24:54.386619@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:25:12.933990||measurement||price||2015-12-01 18:25:07.512634@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:25:17.107185||measurement||loadtime||0:00:29.130556||1||1
+2015-12-01 18:25:19.276957||measurement||loadtime||0:00:26.985821||3||0
+2015-12-01 18:25:25.288698||measurement||price||2015-12-01 18:25:07.512634@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:25:30.764773||measurement||price||2015-12-01 18:25:24.432922@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:25:32.403188||measurement||loadtime||0:00:27.034237||2||0
+2015-12-01 18:25:41.005160||event||progress-marker||training-start||0||1
+2015-12-01 18:25:41.005260||event||progress-marker||training-end||0||1
+2015-12-01 18:25:41.913686||error||collecting ads||Error||3||0
+2015-12-01 18:25:43.661588||measurement||price||2015-12-01 18:25:24.432922@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:25:44.957167||measurement||price||2015-12-01 18:25:39.627212@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:25:46.057857||event||progress-marker||measurement-start||0||1
+2015-12-01 18:25:50.870778||measurement||loadtime||0:00:28.758443||1||1
+2015-12-01 18:25:54.419981||measurement||price||2015-12-01 18:25:49.033664@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:25:57.297769||measurement||price||2015-12-01 18:25:39.627212@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:25:59.998978||measurement||price||2015-12-01 18:25:53.868115@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:26:04.408660||measurement||loadtime||0:00:27.000269||2||0
+2015-12-01 18:26:04.483589||measurement||price||2015-12-01 18:25:58.178290@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:26:06.758813||measurement||price||2015-12-01 18:25:49.033664@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:26:07.850189||event||progress-marker||training-start||4||1
+2015-12-01 18:26:07.850331||event||progress-marker||training-end||4||1
+2015-12-01 18:26:12.867266||measurement||price||2015-12-01 18:25:53.868115@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:26:12.902114||event||progress-marker||measurement-start||4||1
+2015-12-01 18:26:13.874584||measurement||loadtime||0:00:26.955677||3||0
+2015-12-01 18:26:16.983285||measurement||price||2015-12-01 18:26:11.560361@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:26:17.317539||measurement||price||2015-12-01 18:25:58.178290@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:26:20.084386||measurement||loadtime||0:00:29.022243||0||1
+2015-12-01 18:26:24.530645||measurement||loadtime||0:00:28.657419||1||1
+2015-12-01 18:26:29.323051||measurement||price||2015-12-01 18:26:11.560361@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:26:33.847920||measurement||price||2015-12-01 18:26:27.550174@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:26:36.392478||error||collecting ads||Error||3||0
+2015-12-01 18:26:36.427153||measurement||loadtime||0:00:27.013317||2||0
+2015-12-01 18:26:36.951887||error||collecting ads||Error||4||1
+2015-12-01 18:26:38.315014||measurement||price||2015-12-01 18:26:31.855616@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:26:46.689488||measurement||price||2015-12-01 18:26:27.550174@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:26:48.963635||measurement||price||2015-12-01 18:26:43.576246@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:26:51.180608||measurement||price||2015-12-01 18:26:31.855616@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:26:53.869086||measurement||loadtime||0:00:28.783924||0||1
+2015-12-01 18:26:58.368457||measurement||loadtime||0:00:28.832578||1||1
+2015-12-01 18:26:59.095099||error||collecting ads||Error||2||0
+2015-12-01 18:27:00.799562||error||collecting ads||Error||4||1
+2015-12-01 18:27:01.306446||measurement||price||2015-12-01 18:26:43.576246@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:27:07.568628||measurement||price||2015-12-01 18:27:01.095181@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:27:08.413503||measurement||loadtime||0:00:27.015806||3||0
+2015-12-01 18:27:11.642998||measurement||price||2015-12-01 18:27:06.202963@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:27:14.929747||measurement||price||2015-12-01 18:27:08.174611@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:27:20.397478||measurement||price||2015-12-01 18:27:01.095181@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:27:22.647333||error||collecting ads||Error||1||1
+2015-12-01 18:27:23.965248||measurement||price||2015-12-01 18:27:06.202963@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:27:27.595483||measurement||loadtime||0:00:28.721205||0||1
+2015-12-01 18:27:28.178100||measurement||price||2015-12-01 18:27:08.174611@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:27:30.915840||error||collecting ads||Error||3||0
+2015-12-01 18:27:31.067154||measurement||loadtime||0:00:26.966868||2||0
+2015-12-01 18:27:35.372057||measurement||loadtime||0:00:29.567243||4||1
+2015-12-01 18:27:36.446022||measurement||price||2015-12-01 18:27:29.827356@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:27:41.346031||measurement||price||2015-12-01 18:27:34.832215@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:27:43.439926||measurement||price||2015-12-01 18:27:38.065704@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:27:43.646496||measurement||price||2015-12-01 18:27:38.265312@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:27:49.331716||measurement||price||2015-12-01 18:27:29.827356@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:27:54.233342||measurement||price||2015-12-01 18:27:34.832215@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:27:55.795387||measurement||price||2015-12-01 18:27:38.065704@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:27:55.995278||measurement||price||2015-12-01 18:27:38.265312@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:27:56.545831||measurement||loadtime||0:00:28.894648||1||1
+2015-12-01 18:27:59.433608||error||collecting ads||Error||4||1
+2015-12-01 18:28:01.437900||measurement||loadtime||0:00:28.837160||0||1
+2015-12-01 18:28:02.904365||measurement||loadtime||0:00:26.985219||3||0
+2015-12-01 18:28:03.110561||measurement||loadtime||0:00:27.039431||2||0
+2015-12-01 18:28:10.436889||measurement||price||2015-12-01 18:28:03.874518@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:28:13.327861||measurement||price||2015-12-01 18:28:06.624775@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:28:15.338267||measurement||price||2015-12-01 18:28:08.754960@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:28:23.309437||measurement||price||2015-12-01 18:28:03.874518@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:28:25.457675||error||collecting ads||Error||3||0
+2015-12-01 18:28:25.817287||error||collecting ads||Error||2||0
+2015-12-01 18:28:26.337981||measurement||price||2015-12-01 18:28:06.624775@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:28:28.340808||measurement||price||2015-12-01 18:28:08.754960@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:28:30.526438||measurement||loadtime||0:00:28.975359||1||1
+2015-12-01 18:28:33.552871||measurement||loadtime||0:00:29.114044||4||1
+2015-12-01 18:28:35.576024||measurement||loadtime||0:00:29.136881||0||1
+2015-12-01 18:28:37.941879||measurement||price||2015-12-01 18:28:32.583742@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:28:38.483093||measurement||price||2015-12-01 18:28:33.054404@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:28:44.273117||measurement||price||2015-12-01 18:28:37.798654@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:28:47.293865||measurement||price||2015-12-01 18:28:40.848332@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:28:50.274920||measurement||price||2015-12-01 18:28:32.583742@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:28:50.832639||measurement||price||2015-12-01 18:28:33.054404@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:28:57.098768||measurement||price||2015-12-01 18:28:37.798654@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:28:57.395278||measurement||loadtime||0:00:26.932369||3||0
+2015-12-01 18:28:57.931893||measurement||loadtime||0:00:27.109959||2||0
+2015-12-01 18:28:59.236009||error||collecting ads||Error||0||1
+2015-12-01 18:29:00.205087||measurement||price||2015-12-01 18:28:40.848332@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:29:04.299153||measurement||loadtime||0:00:28.767486||1||1
+2015-12-01 18:29:07.403170||measurement||loadtime||0:00:28.845111||4||1
+2015-12-01 18:29:09.823577||measurement||price||2015-12-01 18:29:04.482238@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 18:29:10.565049||measurement||price||2015-12-01 18:29:04.651411@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:29:13.032956||measurement||price||2015-12-01 18:29:06.492304@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:29:18.322972||measurement||price||2015-12-01 18:29:11.592361@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:29:21.043282||measurement||price||2015-12-01 18:29:14.634358@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:29:22.142902||measurement||price||2015-12-01 18:29:04.482238@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 18:29:22.917804||measurement||price||2015-12-01 18:29:04.651411@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:29:25.945304||measurement||price||2015-12-01 18:29:06.492304@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:29:29.266943||measurement||loadtime||0:00:26.866465||3||0
+2015-12-01 18:29:30.030787||measurement||loadtime||0:00:27.093662||2||0
+2015-12-01 18:29:31.163647||measurement||price||2015-12-01 18:29:11.592361@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:29:33.133831||measurement||loadtime||0:00:28.894613||0||1
+2015-12-01 18:29:34.055723||measurement||price||2015-12-01 18:29:14.634358@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:29:38.379140||measurement||loadtime||0:00:29.074806||1||1
+2015-12-01 18:29:41.254680||measurement||loadtime||0:00:28.848348||4||1
+2015-12-01 18:29:41.876130||measurement||price||2015-12-01 18:29:36.320866@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:29:43.000852||measurement||price||2015-12-01 18:29:37.548597@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||0
+2015-12-01 18:29:46.753572||measurement||price||2015-12-01 18:29:40.479619@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:29:52.660873||measurement||price||2015-12-01 18:29:46.219128@|SOG Specialty Knives@|$20.98@|SOG Specialty Knives  Tools F06TN-CP Fasthawk Tactical Toma...||1||1
+2015-12-01 18:29:54.203669||measurement||price||2015-12-01 18:29:36.320866@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:29:55.100659||measurement||price||2015-12-01 18:29:48.552739@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 18:29:55.308648||measurement||price||2015-12-01 18:29:37.548597@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||0
+2015-12-01 18:29:59.537025||measurement||price||2015-12-01 18:29:40.479619@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:30:01.308106||measurement||loadtime||0:00:27.035936||3||0
+2015-12-01 18:30:02.403259||measurement||loadtime||0:00:27.368096||2||0
+2015-12-01 18:30:05.726973||measurement||price||2015-12-01 18:29:46.219128@|SOG Specialty Knives@|$35.14@|SOG Specialty Knives  Tools F03T-N Jungle Primitive, Black...||1||1
+2015-12-01 18:30:06.753289||measurement||loadtime||0:00:28.614166||0||1
+2015-12-01 18:30:08.141631||measurement||price||2015-12-01 18:29:48.552739@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 18:30:12.927219||measurement||loadtime||0:00:29.544144||1||1
+2015-12-01 18:30:13.974999||measurement||price||2015-12-01 18:30:08.588919@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:30:14.983424||measurement||price||2015-12-01 18:30:09.628687@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:30:15.372760||measurement||loadtime||0:00:29.112915||4||1
+2015-12-01 18:30:20.601331||measurement||price||2015-12-01 18:30:14.148009@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:30:26.304854||measurement||price||2015-12-01 18:30:08.588919@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:30:26.912378||measurement||price||2015-12-01 18:30:20.168532@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:30:27.334619||measurement||price||2015-12-01 18:30:09.628687@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:30:29.142680||measurement||price||2015-12-01 18:30:22.709112@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:30:33.415743||measurement||loadtime||0:00:27.102958||3||0
+2015-12-01 18:30:33.518892||measurement||price||2015-12-01 18:30:14.148009@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:30:34.448839||measurement||loadtime||0:00:27.041697||2||0
+2015-12-01 18:30:40.015329||measurement||price||2015-12-01 18:30:20.168532@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:30:40.705470||measurement||loadtime||0:00:28.951106||0||1
+2015-12-01 18:30:41.965128||measurement||price||2015-12-01 18:30:22.709112@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:30:45.956011||measurement||price||2015-12-01 18:30:40.562790@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 18:30:47.059103||measurement||price||2015-12-01 18:30:41.685492@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:30:47.236330||measurement||loadtime||0:00:29.303912||1||1
+2015-12-01 18:30:49.203957||measurement||loadtime||0:00:28.825941||4||1
+2015-12-01 18:30:58.290477||measurement||price||2015-12-01 18:30:40.562790@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 18:30:59.396544||measurement||price||2015-12-01 18:30:41.685492@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:31:01.013077||measurement||price||2015-12-01 18:30:54.505948@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 18:31:03.167621||measurement||price||2015-12-01 18:30:56.555179@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:31:04.477086||error||collecting ads||Error||0||1
+2015-12-01 18:31:05.402663||measurement||loadtime||0:00:26.984773||3||0
+2015-12-01 18:31:06.513194||measurement||loadtime||0:00:27.062040||2||0
+2015-12-01 18:31:14.050705||measurement||price||2015-12-01 18:30:54.505948@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 18:31:16.026147||measurement||price||2015-12-01 18:30:56.555179@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:31:18.043461||measurement||price||2015-12-01 18:31:12.613844@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 18:31:18.472472||measurement||price||2015-12-01 18:31:11.782877@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:31:19.615678||measurement||price||2015-12-01 18:31:14.212571@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||0
+2015-12-01 18:31:21.281801||measurement||loadtime||0:00:29.040248||1||1
+2015-12-01 18:31:23.244839||measurement||loadtime||0:00:29.039808||4||1
+2015-12-01 18:31:30.391081||measurement||price||2015-12-01 18:31:12.613844@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 18:31:31.359655||measurement||price||2015-12-01 18:31:11.782877@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:31:31.936080||measurement||price||2015-12-01 18:31:14.212571@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||0
+2015-12-01 18:31:36.990925||measurement||price||2015-12-01 18:31:30.715127@|@|$494.95@|Motorola Nexus 6 Unlocked Cellphone, 32GB, Midnight Blue (U...||4||1
+2015-12-01 18:31:37.507115||measurement||loadtime||0:00:27.099167||3||0
+2015-12-01 18:31:38.593696||measurement||loadtime||0:00:29.111248||0||1
+2015-12-01 18:31:39.031206||measurement||loadtime||0:00:27.516029||2||0
+2015-12-01 18:31:45.231591||error||collecting ads||Error||1||1
+2015-12-01 18:31:50.037015||measurement||price||2015-12-01 18:31:44.568106@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:31:51.668724||measurement||price||2015-12-01 18:31:46.272282@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:31:52.671699||measurement||price||2015-12-01 18:31:45.898530@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:31:59.947356||error||collecting ads||Error||4||1
+2015-12-01 18:32:02.377069||measurement||price||2015-12-01 18:31:44.568106@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:32:03.968237||measurement||price||2015-12-01 18:31:46.272282@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:32:05.799230||measurement||price||2015-12-01 18:31:45.898530@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:32:09.124532||error||collecting ads||Error||1||1
+2015-12-01 18:32:09.500308||measurement||loadtime||0:00:26.987907||3||0
+2015-12-01 18:32:11.055512||measurement||loadtime||0:00:27.020355||2||0
+2015-12-01 18:32:13.031520||measurement||loadtime||0:00:29.436360||0||1
+2015-12-01 18:32:13.661940||measurement||price||2015-12-01 18:32:07.233705@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:32:22.076788||measurement||price||2015-12-01 18:32:16.705283@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 18:32:23.423447||measurement||price||2015-12-01 18:32:17.239624@|Makita@|$549.00@|Makita XT601 18-volt LXT Lithium-Ion Cordless Combo Kit, 6-P...||1||1
+2015-12-01 18:32:23.625547||measurement||price||2015-12-01 18:32:18.254360@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:32:26.541705||measurement||price||2015-12-01 18:32:07.233705@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:32:33.740650||measurement||loadtime||0:00:28.788038||4||1
+2015-12-01 18:32:34.415281||measurement||price||2015-12-01 18:32:16.705283@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 18:32:35.975367||measurement||price||2015-12-01 18:32:18.254360@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:32:36.376801||measurement||price||2015-12-01 18:32:17.239624@|Makita@|$469.00@|Makita BBX7600N 75.6 CC 4-Stroke Backpack Blower||1||1
+2015-12-01 18:32:36.751808||error||collecting ads||Error||0||1
+2015-12-01 18:32:41.530525||measurement||loadtime||0:00:27.027373||3||0
+2015-12-01 18:32:43.091144||measurement||loadtime||0:00:27.032007||2||0
+2015-12-01 18:32:43.570204||measurement||loadtime||0:00:29.440445||1||1
+2015-12-01 18:32:47.442674||measurement||price||2015-12-01 18:32:40.981705@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:32:50.838078||measurement||price||2015-12-01 18:32:44.593136@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||0||1
+2015-12-01 18:32:54.462420||measurement||price||2015-12-01 18:32:49.054325@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||3||0
+2015-12-01 18:32:55.728639||measurement||price||2015-12-01 18:32:50.241567@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:32:57.415454||measurement||price||2015-12-01 18:32:51.017512@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:33:00.305714||measurement||price||2015-12-01 18:32:40.981705@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:33:03.684400||measurement||price||2015-12-01 18:32:44.593136@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||0||1
+2015-12-01 18:33:06.810617||measurement||price||2015-12-01 18:32:49.054325@|Black  Decker@|$69.68@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||3||0
+2015-12-01 18:33:07.526979||measurement||loadtime||0:00:28.781096||4||1
+2015-12-01 18:33:08.070756||measurement||price||2015-12-01 18:32:50.241567@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:33:10.343756||measurement||price||2015-12-01 18:32:51.017512@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:33:10.899788||measurement||loadtime||0:00:29.142720||0||1
+2015-12-01 18:33:13.923519||measurement||loadtime||0:00:27.388305||3||0
+2015-12-01 18:33:13.923637||event||progress-marker||measurement-end||3||0
+2015-12-01 18:33:15.179167||measurement||loadtime||0:00:27.084025||2||0
+2015-12-01 18:33:15.179271||event||progress-marker||measurement-end||2||0
+2015-12-01 18:33:17.543158||measurement||loadtime||0:00:28.967758||1||1
+2015-12-01 18:33:21.455151||measurement||price||2015-12-01 18:33:14.932778@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:33:31.725262||measurement||price||2015-12-01 18:33:25.196203@|Disney Software@|$9.00@|Disney Infinity 3.0 Edition: Star Wars Darth Vader Figure||1||1
+2015-12-01 18:33:34.306988||measurement||price||2015-12-01 18:33:14.932778@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:33:34.347307||error||collecting ads||Error||0||1
+2015-12-01 18:33:41.507159||measurement||loadtime||0:00:28.974913||4||1
+2015-12-01 18:33:44.802081||measurement||price||2015-12-01 18:33:25.196203@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||1
+2015-12-01 18:33:48.022784||measurement||price||2015-12-01 18:33:41.570719@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:33:52.014892||measurement||loadtime||0:00:29.466512||1||1
+2015-12-01 18:33:55.480799||measurement||price||2015-12-01 18:33:48.794564@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:34:00.854645||measurement||price||2015-12-01 18:33:41.570719@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:34:05.744814||measurement||price||2015-12-01 18:33:59.358345@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 18:34:08.062890||measurement||loadtime||0:00:28.715202||0||1
+2015-12-01 18:34:08.396871||measurement||price||2015-12-01 18:33:48.794564@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:34:15.595153||measurement||loadtime||0:00:29.082797||4||1
+2015-12-01 18:34:18.773843||measurement||price||2015-12-01 18:33:59.358345@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 18:34:25.958136||measurement||loadtime||0:00:28.937951||1||1
+2015-12-01 18:34:31.886663||error||collecting ads||Error||0||1
+2015-12-01 18:34:39.196942||error||collecting ads||Error||4||1
+2015-12-01 18:34:39.751448||measurement||price||2015-12-01 18:34:33.272944@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 18:34:52.753947||measurement||price||2015-12-01 18:34:33.272944@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 18:34:52.923745||measurement||price||2015-12-01 18:34:46.486918@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:34:55.583715||error||collecting ads||Error||0||1
+2015-12-01 18:34:59.936949||measurement||loadtime||0:00:28.973800||1||1
+2015-12-01 18:34:59.937088||event||progress-marker||measurement-end||1||1
+2015-12-01 18:35:05.861906||measurement||price||2015-12-01 18:34:46.486918@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:35:09.255177||measurement||price||2015-12-01 18:35:02.688933@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:35:13.197794||measurement||loadtime||0:00:28.995619||4||1
+2015-12-01 18:35:22.067868||measurement||price||2015-12-01 18:35:02.688933@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:35:29.287188||measurement||loadtime||0:00:28.698250||0||1
+2015-12-01 18:35:37.163390||error||collecting ads||Error||4||1
+2015-12-01 18:35:43.143688||measurement||price||2015-12-01 18:35:36.590306@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:35:51.238617||measurement||price||2015-12-01 18:35:44.451159@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 18:35:55.953915||measurement||price||2015-12-01 18:35:36.590306@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:36:03.147606||measurement||loadtime||0:00:28.855141||0||1
+2015-12-01 18:36:03.147766||event||progress-marker||measurement-end||0||1
+2015-12-01 18:36:04.218769||measurement||price||2015-12-01 18:35:44.451159@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 18:36:11.443559||measurement||loadtime||0:00:29.274903||4||1
+2015-12-01 18:36:25.198689||measurement||price||2015-12-01 18:36:18.734102@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 18:36:38.244226||measurement||price||2015-12-01 18:36:18.734102@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 18:36:45.428529||measurement||loadtime||0:00:28.979743||4||1
+2015-12-01 18:36:45.428665||event||progress-marker||measurement-end||4||1
+2015-12-01 18:36:45.824911||meta||block_id end||20
+2015-12-01 18:36:45.825233||meta||block_id start||21
+2015-12-01 18:36:45.825264||meta||assignment||4@|1@|5@|2@|0@|3
+2015-12-01 18:36:47.447423||event||progress-marker||training-start||4||0
+2015-12-01 18:36:47.447513||event||progress-marker||training-end||4||0
+2015-12-01 18:36:47.473455||event||progress-marker||training-start||5||0
+2015-12-01 18:36:47.473565||event||progress-marker||training-end||5||0
+2015-12-01 18:36:47.475877||event||progress-marker||training-start||1||0
+2015-12-01 18:36:47.475962||event||progress-marker||training-end||1||0
+2015-12-01 18:36:52.508513||event||progress-marker||measurement-start||4||0
+2015-12-01 18:36:52.530350||event||progress-marker||measurement-start||1||0
+2015-12-01 18:36:52.530648||event||progress-marker||measurement-start||5||0
+2015-12-01 18:37:05.566623||measurement||price||2015-12-01 18:37:00.151071@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:37:06.156976||measurement||price||2015-12-01 18:36:59.840966@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:37:16.194411||error||collecting ads||Error||4||0
+2015-12-01 18:37:17.907982||measurement||price||2015-12-01 18:37:00.151071@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:37:18.504439||measurement||price||2015-12-01 18:36:59.840966@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:37:25.018312||measurement||loadtime||0:00:27.483155||5||0
+2015-12-01 18:37:25.612588||measurement||loadtime||0:00:28.077443||1||0
+2015-12-01 18:37:28.597822||measurement||price||2015-12-01 18:37:22.813487@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:37:37.373665||measurement||price||2015-12-01 18:37:31.980464@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:37:38.387141||measurement||price||2015-12-01 18:37:32.269589@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:37:40.940533||measurement||price||2015-12-01 18:37:22.813487@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:37:48.054919||measurement||loadtime||0:00:26.855268||4||0
+2015-12-01 18:37:49.716308||measurement||price||2015-12-01 18:37:31.980464@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:37:50.718342||measurement||price||2015-12-01 18:37:32.269589@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:37:56.838481||measurement||loadtime||0:00:26.814951||5||0
+2015-12-01 18:37:57.827343||measurement||loadtime||0:00:27.209556||1||0
+2015-12-01 18:38:09.292609||measurement||price||2015-12-01 18:38:03.852725@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:38:10.194086||error||collecting ads||Error||4||0
+2015-12-01 18:38:19.417782||event||progress-marker||training-start||0||1
+2015-12-01 18:38:19.417883||event||progress-marker||training-end||0||1
+2015-12-01 18:38:20.088119||error||collecting ads||Error||1||0
+2015-12-01 18:38:21.606240||measurement||price||2015-12-01 18:38:03.852725@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:38:22.399902||measurement||price||2015-12-01 18:38:16.829637@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:38:24.476974||event||progress-marker||measurement-start||0||1
+2015-12-01 18:38:28.690564||measurement||loadtime||0:00:26.846874||5||0
+2015-12-01 18:38:32.367554||measurement||price||2015-12-01 18:38:26.751060@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:38:34.720903||measurement||price||2015-12-01 18:38:16.829637@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:38:38.641340||measurement||price||2015-12-01 18:38:32.186025@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:38:41.103767||measurement||price||2015-12-01 18:38:35.754290@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:38:41.828133||measurement||loadtime||0:00:26.628810||4||0
+2015-12-01 18:38:44.715325||measurement||price||2015-12-01 18:38:26.751060@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:38:51.474939||measurement||price||2015-12-01 18:38:32.186025@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:38:51.827232||measurement||loadtime||0:00:26.733895||1||0
+2015-12-01 18:38:53.435033||measurement||price||2015-12-01 18:38:35.754290@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:38:54.186832||measurement||price||2015-12-01 18:38:48.679383@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:38:57.675135||event||progress-marker||training-start||2||1
+2015-12-01 18:38:57.675283||event||progress-marker||training-end||2||1
+2015-12-01 18:38:58.707190||measurement||loadtime||0:00:29.224983||0||1
+2015-12-01 18:39:00.540101||measurement||loadtime||0:00:26.844959||5||0
+2015-12-01 18:39:02.727960||event||progress-marker||measurement-start||2||1
+2015-12-01 18:39:04.050283||measurement||price||2015-12-01 18:38:58.545637@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:39:06.529873||measurement||price||2015-12-01 18:38:48.679383@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:39:13.642829||measurement||loadtime||0:00:26.809482||4||0
+2015-12-01 18:39:16.378174||measurement||price||2015-12-01 18:38:58.545637@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:39:17.106810||measurement||price||2015-12-01 18:39:10.877647@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:39:22.361407||error||collecting ads||Error||0||1
+2015-12-01 18:39:22.524982||event||progress-marker||training-start||3||1
+2015-12-01 18:39:22.525086||event||progress-marker||training-end||3||1
+2015-12-01 18:39:23.065597||error||collecting ads||Error||5||0
+2015-12-01 18:39:23.484660||measurement||loadtime||0:00:26.652162||1||0
+2015-12-01 18:39:25.860612||measurement||price||2015-12-01 18:39:20.277726@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:39:27.575359||event||progress-marker||measurement-start||3||1
+2015-12-01 18:39:30.045450||measurement||price||2015-12-01 18:39:10.877647@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:39:35.567629||measurement||price||2015-12-01 18:39:30.144613@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:39:35.841727||measurement||price||2015-12-01 18:39:30.113693@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:39:36.140620||measurement||price||2015-12-01 18:39:29.498462@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:39:37.251659||measurement||loadtime||0:00:29.520512||2||1
+2015-12-01 18:39:38.204138||measurement||price||2015-12-01 18:39:20.277726@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:39:45.323256||measurement||loadtime||0:00:26.675237||4||0
+2015-12-01 18:39:47.913981||measurement||price||2015-12-01 18:39:30.144613@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:39:48.190953||measurement||price||2015-12-01 18:39:30.113693@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:39:49.072180||measurement||price||2015-12-01 18:39:29.498462@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:39:51.151837||measurement||price||2015-12-01 18:39:45.057985@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:39:51.823180||error||collecting ads||Error||3||1
+2015-12-01 18:39:55.027113||measurement||loadtime||0:00:26.956287||5||0
+2015-12-01 18:39:55.299175||measurement||loadtime||0:00:26.809294||1||0
+2015-12-01 18:39:56.320034||measurement||loadtime||0:00:28.954123||0||1
+2015-12-01 18:39:57.540074||measurement||price||2015-12-01 18:39:51.932214@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:40:04.042383||measurement||price||2015-12-01 18:39:45.057985@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:40:05.246407||measurement||price||2015-12-01 18:39:59.174795@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:40:07.544241||measurement||price||2015-12-01 18:40:02.098262@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:40:09.886611||measurement||price||2015-12-01 18:39:51.932214@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:40:10.059105||measurement||price||2015-12-01 18:40:03.592354@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:40:11.271163||measurement||loadtime||0:00:29.014297||2||1
+2015-12-01 18:40:16.990233||measurement||loadtime||0:00:26.661748||4||0
+2015-12-01 18:40:17.651238||error||collecting ads||Error||1||0
+2015-12-01 18:40:18.277905||measurement||price||2015-12-01 18:39:59.174795@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:40:19.879249||measurement||price||2015-12-01 18:40:02.098262@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:40:22.939259||measurement||price||2015-12-01 18:40:03.592354@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:40:25.082710||measurement||price||2015-12-01 18:40:18.900134@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 18:40:25.511054||measurement||loadtime||0:00:28.682598||3||1
+2015-12-01 18:40:27.009802||measurement||loadtime||0:00:26.977466||5||0
+2015-12-01 18:40:29.397844||measurement||price||2015-12-01 18:40:23.746458@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:40:29.917215||measurement||price||2015-12-01 18:40:24.322073@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:40:30.158037||measurement||loadtime||0:00:28.832873||0||1
+2015-12-01 18:40:38.052415||measurement||price||2015-12-01 18:40:18.900134@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 18:40:39.370621||measurement||price||2015-12-01 18:40:32.850997@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:40:39.598923||measurement||price||2015-12-01 18:40:34.169394@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:40:41.726412||measurement||price||2015-12-01 18:40:23.746458@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:40:42.266212||measurement||price||2015-12-01 18:40:24.322073@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:40:43.915134||measurement||price||2015-12-01 18:40:37.461485@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:40:45.239407||measurement||loadtime||0:00:28.964935||2||1
+2015-12-01 18:40:48.834008||measurement||loadtime||0:00:26.838560||4||0
+2015-12-01 18:40:49.388491||measurement||loadtime||0:00:26.732038||1||0
+2015-12-01 18:40:51.961498||measurement||price||2015-12-01 18:40:34.169394@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:40:52.204317||measurement||price||2015-12-01 18:40:32.850997@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:40:56.738796||measurement||price||2015-12-01 18:40:37.461485@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:40:58.947150||measurement||price||2015-12-01 18:40:52.792106@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 18:40:59.077733||measurement||loadtime||0:00:27.062729||5||0
+2015-12-01 18:40:59.431171||measurement||loadtime||0:00:28.914925||3||1
+2015-12-01 18:41:01.111296||measurement||price||2015-12-01 18:40:55.450687@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:41:01.726623||measurement||price||2015-12-01 18:40:56.106463@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:41:03.969019||measurement||loadtime||0:00:28.805743||0||1
+2015-12-01 18:41:11.551654||measurement||price||2015-12-01 18:41:06.169549@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:41:11.983375||measurement||price||2015-12-01 18:40:52.792106@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 18:41:13.137700||measurement||price||2015-12-01 18:41:06.877076@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:41:13.462599||measurement||price||2015-12-01 18:40:55.450687@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:41:14.063510||measurement||price||2015-12-01 18:40:56.106463@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:41:17.673143||measurement||price||2015-12-01 18:41:11.153895@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:41:19.187945||measurement||loadtime||0:00:28.943283||2||1
+2015-12-01 18:41:20.583141||measurement||loadtime||0:00:26.744005||4||0
+2015-12-01 18:41:21.183218||measurement||loadtime||0:00:26.792075||1||0
+2015-12-01 18:41:23.872908||measurement||price||2015-12-01 18:41:06.169549@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:41:26.014889||measurement||price||2015-12-01 18:41:06.877076@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:41:30.553214||measurement||price||2015-12-01 18:41:11.153895@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:41:30.958663||measurement||loadtime||0:00:26.876758||5||0
+2015-12-01 18:41:32.959320||measurement||price||2015-12-01 18:41:27.365964@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:41:33.234076||measurement||loadtime||0:00:28.797686||3||1
+2015-12-01 18:41:33.430307||measurement||price||2015-12-01 18:41:27.139943@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 18:41:33.523983||measurement||price||2015-12-01 18:41:27.834063@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:41:37.751145||measurement||loadtime||0:00:28.780011||0||1
+2015-12-01 18:41:43.400742||measurement||price||2015-12-01 18:41:37.972841@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:41:45.276180||measurement||price||2015-12-01 18:41:27.365964@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:41:45.882516||measurement||price||2015-12-01 18:41:27.834063@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:41:46.480054||measurement||price||2015-12-01 18:41:27.139943@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 18:41:46.879416||measurement||price||2015-12-01 18:41:40.478131@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:41:51.333998||measurement||price||2015-12-01 18:41:44.924571@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:41:52.355211||measurement||loadtime||0:00:26.766689||4||0
+2015-12-01 18:41:52.995151||measurement||loadtime||0:00:26.808024||1||0
+2015-12-01 18:41:53.678987||measurement||loadtime||0:00:29.485776||2||1
+2015-12-01 18:41:55.738014||measurement||price||2015-12-01 18:41:37.972841@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:41:59.647405||measurement||price||2015-12-01 18:41:40.478131@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:42:02.838723||measurement||loadtime||0:00:26.874823||5||0
+2015-12-01 18:42:04.198591||measurement||price||2015-12-01 18:41:44.924571@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:42:05.386255||measurement||price||2015-12-01 18:41:59.728044@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:42:06.900153||measurement||loadtime||0:00:28.660848||3||1
+2015-12-01 18:42:07.802985||measurement||price||2015-12-01 18:42:01.561533@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:42:11.408180||measurement||loadtime||0:00:28.651831||0||1
+2015-12-01 18:42:14.576271||error||collecting ads||Error||4||0
+2015-12-01 18:42:15.297430||measurement||price||2015-12-01 18:42:09.922923@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:42:17.734558||measurement||price||2015-12-01 18:41:59.728044@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:42:20.709360||measurement||price||2015-12-01 18:42:01.561533@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:42:24.839422||measurement||loadtime||0:00:26.840268||1||0
+2015-12-01 18:42:25.038015||measurement||price||2015-12-01 18:42:18.601666@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:42:27.648407||measurement||price||2015-12-01 18:42:09.922923@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:42:27.911464||measurement||loadtime||0:00:29.228300||2||1
+2015-12-01 18:42:30.493056||error||collecting ads||Error||3||1
+2015-12-01 18:42:34.759214||measurement||loadtime||0:00:26.915286||5||0
+2015-12-01 18:42:36.789089||error||collecting ads||Error||4||0
+2015-12-01 18:42:37.075012||measurement||price||2015-12-01 18:42:31.459360@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:42:37.910531||measurement||price||2015-12-01 18:42:18.601666@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:42:41.806939||measurement||price||2015-12-01 18:42:35.588371@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:42:44.126078||measurement||price||2015-12-01 18:42:37.723222@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:42:45.121220||measurement||loadtime||0:00:28.707842||0||1
+2015-12-01 18:42:47.255730||measurement||price||2015-12-01 18:42:41.701476@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:42:49.054626||measurement||price||2015-12-01 18:42:43.441796@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:42:49.412524||measurement||price||2015-12-01 18:42:31.459360@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:42:54.695199||measurement||price||2015-12-01 18:42:35.588371@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:42:56.536466||measurement||loadtime||0:00:26.691787||1||0
+2015-12-01 18:42:56.983139||measurement||price||2015-12-01 18:42:37.723222@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:42:58.837083||measurement||price||2015-12-01 18:42:52.306883@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:42:59.582311||measurement||price||2015-12-01 18:42:41.701476@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:43:01.432163||measurement||price||2015-12-01 18:42:43.441796@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:43:01.896895||measurement||loadtime||0:00:28.982188||2||1
+2015-12-01 18:43:04.219222||measurement||loadtime||0:00:28.724059||3||1
+2015-12-01 18:43:06.690858||measurement||loadtime||0:00:26.926427||5||0
+2015-12-01 18:43:08.547167||measurement||loadtime||0:00:26.753784||4||0
+2015-12-01 18:43:08.977144||measurement||price||2015-12-01 18:43:03.272294@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:43:11.719560||measurement||price||2015-12-01 18:42:52.306883@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:43:18.932842||measurement||loadtime||0:00:28.806615||0||1
+2015-12-01 18:43:20.734106||measurement||price||2015-12-01 18:43:15.223193@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:43:21.282730||measurement||price||2015-12-01 18:43:03.272294@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:43:25.766690||error||collecting ads||Error||2||1
+2015-12-01 18:43:28.022122||error||collecting ads||Error||3||1
+2015-12-01 18:43:28.375915||measurement||loadtime||0:00:26.834223||1||0
+2015-12-01 18:43:29.120303||error||collecting ads||Error||5||0
+2015-12-01 18:43:32.573454||measurement||price||2015-12-01 18:43:26.086991@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:43:33.075061||measurement||price||2015-12-01 18:43:15.223193@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:43:40.203185||measurement||loadtime||0:00:26.652008||4||0
+2015-12-01 18:43:40.585624||measurement||price||2015-12-01 18:43:35.014887@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:43:42.087562||measurement||price||2015-12-01 18:43:36.683909@|TomTom@|$299.99@|TomTom Spark Music + Cardio Large Black (Headphones Bundle)||5||0
+2015-12-01 18:43:45.441992||measurement||price||2015-12-01 18:43:26.086991@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:43:49.645653||error||collecting ads||Error||2||1
+2015-12-01 18:43:52.032060||error||collecting ads||Error||3||1
+2015-12-01 18:43:52.492561||measurement||price||2015-12-01 18:43:46.930991@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:43:52.643184||measurement||loadtime||0:00:28.705116||0||1
+2015-12-01 18:43:52.869180||measurement||price||2015-12-01 18:43:35.014887@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:43:54.432211||measurement||price||2015-12-01 18:43:36.683909@|TomTom@|$149.99@|TomTom Spark Large Shocking Blue||5||0
+2015-12-01 18:43:59.956331||measurement||loadtime||0:00:26.577183||1||0
+2015-12-01 18:44:01.541676||measurement||loadtime||0:00:27.418529||5||0
+2015-12-01 18:44:03.427984||measurement||price||2015-12-01 18:43:57.244659@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:44:04.825051||measurement||price||2015-12-01 18:43:46.930991@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:44:06.387493||measurement||price||2015-12-01 18:44:00.181183@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:44:11.945036||measurement||loadtime||0:00:26.736604||4||0
+2015-12-01 18:44:12.302910||measurement||price||2015-12-01 18:44:06.630523@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:44:14.153968||measurement||price||2015-12-01 18:44:08.767341@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:44:16.328729||measurement||price||2015-12-01 18:43:57.244659@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:44:16.392485||error||collecting ads||Error||0||1
+2015-12-01 18:44:19.309314||measurement||price||2015-12-01 18:44:00.181183@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:44:23.547946||measurement||loadtime||0:00:28.898945||2||1
+2015-12-01 18:44:24.641422||measurement||price||2015-12-01 18:44:06.630523@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:44:26.490635||measurement||price||2015-12-01 18:44:08.767341@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:44:26.571174||measurement||loadtime||0:00:29.536022||3||1
+2015-12-01 18:44:30.113200||measurement||price||2015-12-01 18:44:23.496157@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:44:31.759159||measurement||loadtime||0:00:26.797617||1||0
+2015-12-01 18:44:33.567156||measurement||loadtime||0:00:27.020292||5||0
+2015-12-01 18:44:34.121047||error||collecting ads||Error||4||0
+2015-12-01 18:44:40.331567||measurement||price||2015-12-01 18:44:33.872987@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:44:42.975956||measurement||price||2015-12-01 18:44:23.496157@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:44:44.009145||measurement||price||2015-12-01 18:44:38.430930@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:44:46.150053||measurement||price||2015-12-01 18:44:40.731503@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 18:44:46.396559||measurement||price||2015-12-01 18:44:40.826916@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:44:47.417739||error||collecting ads||Error||2||1
+2015-12-01 18:44:50.202172||measurement||loadtime||0:00:28.807013||0||1
+2015-12-01 18:44:53.155498||measurement||price||2015-12-01 18:44:33.872987@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:44:56.306874||measurement||price||2015-12-01 18:44:38.430930@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:44:58.489917||measurement||price||2015-12-01 18:44:40.731503@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 18:44:58.756162||measurement||price||2015-12-01 18:44:40.826916@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:45:00.393437||measurement||loadtime||0:00:28.817051||3||1
+2015-12-01 18:45:01.520531||measurement||price||2015-12-01 18:44:55.138204@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 18:45:03.399176||measurement||loadtime||0:00:26.634805||1||0
+2015-12-01 18:45:03.940496||measurement||price||2015-12-01 18:44:57.460211@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:45:05.599173||measurement||loadtime||0:00:27.026829||5||0
+2015-12-01 18:45:05.874061||measurement||loadtime||0:00:26.747788||4||0
+2015-12-01 18:45:14.112463||measurement||price||2015-12-01 18:45:07.547719@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:45:14.423420||measurement||price||2015-12-01 18:44:55.138204@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 18:45:15.668225||measurement||price||2015-12-01 18:45:10.118705@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:45:16.824415||measurement||price||2015-12-01 18:44:57.460211@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:45:18.202372||measurement||price||2015-12-01 18:45:12.619425@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:45:21.639313||measurement||loadtime||0:00:29.216939||2||1
+2015-12-01 18:45:24.025240||measurement||loadtime||0:00:28.818077||0||1
+2015-12-01 18:45:26.978583||measurement||price||2015-12-01 18:45:07.547719@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:45:27.973700||measurement||price||2015-12-01 18:45:10.118705@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:45:28.063830||error||collecting ads||Error||5||0
+2015-12-01 18:45:30.530169||measurement||price||2015-12-01 18:45:12.619425@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:45:34.181087||measurement||loadtime||0:00:28.782412||3||1
+2015-12-01 18:45:35.054182||measurement||loadtime||0:00:26.649819||1||0
+2015-12-01 18:45:37.637887||measurement||loadtime||0:00:26.758625||4||0
+2015-12-01 18:45:37.728281||measurement||price||2015-12-01 18:45:31.313596@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:45:45.309221||error||collecting ads||Error||2||1
+2015-12-01 18:45:47.293309||measurement||price||2015-12-01 18:45:41.704922@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:45:49.911185||measurement||price||2015-12-01 18:45:44.371501@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:45:50.373806||error||collecting ads||Error||5||0
+2015-12-01 18:45:50.549133||measurement||price||2015-12-01 18:45:31.313596@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:45:57.783168||measurement||loadtime||0:00:28.752727||0||1
+2015-12-01 18:45:57.804568||error||collecting ads||Error||3||1
+2015-12-01 18:45:59.626227||measurement||price||2015-12-01 18:45:41.704922@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:45:59.716388||measurement||price||2015-12-01 18:45:53.601518@|Black  Decker@|$49.97@|Black  Decker Pivot Vac 18V Cordless Pivoting Hand Vac, PHV...||2||1
+2015-12-01 18:46:02.263999||measurement||price||2015-12-01 18:45:44.371501@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:46:02.791573||measurement||price||2015-12-01 18:45:57.356104@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 18:46:06.745560||measurement||loadtime||0:00:26.686174||1||0
+2015-12-01 18:46:09.386135||measurement||loadtime||0:00:26.746979||4||0
+2015-12-01 18:46:11.413067||measurement||price||2015-12-01 18:46:05.017729@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:46:11.754959||measurement||price||2015-12-01 18:46:05.348202@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||1
+2015-12-01 18:46:12.621853||measurement||price||2015-12-01 18:45:53.601518@|Black  Decker@|$69.68@|Black  Decker BV5600 High Performance Blower/Vac/Mulcher||2||1
+2015-12-01 18:46:15.133071||measurement||price||2015-12-01 18:45:57.356104@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 18:46:19.803160||measurement||loadtime||0:00:29.488716||2||1
+2015-12-01 18:46:21.650407||measurement||price||2015-12-01 18:46:16.059183@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:46:22.237318||measurement||loadtime||0:00:26.862168||5||0
+2015-12-01 18:46:24.212008||measurement||price||2015-12-01 18:46:05.017729@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:46:24.674019||measurement||price||2015-12-01 18:46:05.348202@|Warner Bros@|$46.03@|Jurassic World Team Pack - LEGO Dimensions||0||1
+2015-12-01 18:46:28.969463||error||collecting ads||Error||1||0
+2015-12-01 18:46:31.439159||measurement||loadtime||0:00:28.632001||3||1
+2015-12-01 18:46:31.899229||measurement||loadtime||0:00:29.112077||0||1
+2015-12-01 18:46:33.794010||measurement||price||2015-12-01 18:46:27.637724@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:46:33.986311||measurement||price||2015-12-01 18:46:16.059183@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:46:34.849797||measurement||price||2015-12-01 18:46:29.415526@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 18:46:41.107149||measurement||loadtime||0:00:26.719614||4||0
+2015-12-01 18:46:41.107261||event||progress-marker||measurement-end||4||0
+2015-12-01 18:46:41.210239||measurement||price||2015-12-01 18:46:35.607226@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:46:45.136567||measurement||price||2015-12-01 18:46:38.645351@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:46:46.698797||measurement||price||2015-12-01 18:46:27.637724@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:46:47.180922||measurement||price||2015-12-01 18:46:29.415526@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 18:46:53.580151||measurement||price||2015-12-01 18:46:35.607226@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:46:53.899168||measurement||loadtime||0:00:29.090776||2||1
+2015-12-01 18:46:54.298968||measurement||loadtime||0:00:27.056402||5||0
+2015-12-01 18:46:54.299124||event||progress-marker||measurement-end||5||0
+2015-12-01 18:46:55.553744||error||collecting ads||Error||0||1
+2015-12-01 18:46:57.964265||measurement||price||2015-12-01 18:46:38.645351@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:47:00.690915||measurement||loadtime||0:00:26.716227||1||0
+2015-12-01 18:47:00.691018||event||progress-marker||measurement-end||1||0
+2015-12-01 18:47:05.196773||measurement||loadtime||0:00:28.752397||3||1
+2015-12-01 18:47:07.900407||measurement||price||2015-12-01 18:47:01.603797@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 18:47:09.189692||measurement||price||2015-12-01 18:47:02.848958@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:47:20.745742||measurement||price||2015-12-01 18:47:01.603797@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 18:47:22.142397||measurement||price||2015-12-01 18:47:02.848958@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:47:27.961866||measurement||loadtime||0:00:29.057494||2||1
+2015-12-01 18:47:28.734055||error||collecting ads||Error||3||1
+2015-12-01 18:47:29.340275||measurement||loadtime||0:00:28.785289||0||1
+2015-12-01 18:47:42.373879||measurement||price||2015-12-01 18:47:35.936205@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:47:42.940279||measurement||price||2015-12-01 18:47:36.549550@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:47:51.963567||error||collecting ads||Error||2||1
+2015-12-01 18:47:55.376818||measurement||price||2015-12-01 18:47:35.936205@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:47:55.744112||measurement||price||2015-12-01 18:47:36.549550@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:48:02.595993||measurement||loadtime||0:00:28.856847||3||1
+2015-12-01 18:48:02.924875||measurement||loadtime||0:00:28.579400||0||1
+2015-12-01 18:48:05.491990||measurement||price||2015-12-01 18:47:59.393489@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 18:48:16.102377||measurement||price||2015-12-01 18:48:09.714863@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:48:16.611487||measurement||price||2015-12-01 18:48:10.152815@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:48:18.364653||measurement||price||2015-12-01 18:47:59.393489@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 18:48:25.563267||measurement||loadtime||0:00:28.594448||2||1
+2015-12-01 18:48:28.928313||measurement||price||2015-12-01 18:48:09.714863@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:48:29.615798||measurement||price||2015-12-01 18:48:10.152815@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:48:36.134308||measurement||loadtime||0:00:28.533069||3||1
+2015-12-01 18:48:36.831625||measurement||loadtime||0:00:28.901541||0||1
+2015-12-01 18:48:39.497351||measurement||price||2015-12-01 18:48:33.327296@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 18:48:49.740904||measurement||price||2015-12-01 18:48:43.329446@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:48:52.323328||measurement||price||2015-12-01 18:48:33.327296@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 18:48:59.521955||measurement||loadtime||0:00:28.953440||2||1
+2015-12-01 18:49:00.490263||error||collecting ads||Error||0||1
+2015-12-01 18:49:00.490413||event||progress-marker||measurement-end||0||1
+2015-12-01 18:49:02.525594||measurement||price||2015-12-01 18:48:43.329446@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:49:09.725372||measurement||loadtime||0:00:28.585837||3||1
+2015-12-01 18:49:13.439496||measurement||price||2015-12-01 18:49:07.113419@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 18:49:26.347970||measurement||price||2015-12-01 18:49:07.113419@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 18:49:33.227754||error||collecting ads||Error||3||1
+2015-12-01 18:49:33.227854||event||progress-marker||measurement-end||3||1
+2015-12-01 18:49:33.526267||measurement||loadtime||0:00:28.999083||2||1
+2015-12-01 18:49:33.526385||event||progress-marker||measurement-end||2||1
+2015-12-01 18:49:33.815409||meta||block_id end||21
+2015-12-01 18:49:33.815848||meta||block_id start||22
+2015-12-01 18:49:33.815879||meta||assignment||2@|1@|4@|0@|5@|3
+2015-12-01 18:49:35.401359||event||progress-marker||training-start||4||0
+2015-12-01 18:49:35.401475||event||progress-marker||training-end||4||0
+2015-12-01 18:49:35.418474||event||progress-marker||training-start||1||0
+2015-12-01 18:49:35.418578||event||progress-marker||training-end||1||0
+2015-12-01 18:49:35.464238||event||progress-marker||training-start||2||0
+2015-12-01 18:49:35.464335||event||progress-marker||training-end||2||0
+2015-12-01 18:49:40.472561||event||progress-marker||measurement-start||4||0
+2015-12-01 18:49:40.474479||event||progress-marker||measurement-start||1||0
+2015-12-01 18:49:40.518396||event||progress-marker||measurement-start||2||0
+2015-12-01 18:49:53.896449||measurement||price||2015-12-01 18:49:47.838706@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:50:03.866249||error||collecting ads||Error||4||0
+2015-12-01 18:50:03.982404||error||collecting ads||Error||2||0
+2015-12-01 18:50:06.248891||measurement||price||2015-12-01 18:49:47.838706@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:50:07.663107||event||progress-marker||training-start||5||1
+2015-12-01 18:50:07.663275||event||progress-marker||training-end||5||1
+2015-12-01 18:50:12.720650||event||progress-marker||measurement-start||5||1
+2015-12-01 18:50:13.360684||measurement||loadtime||0:00:27.881528||1||0
+2015-12-01 18:50:16.067864||measurement||price||2015-12-01 18:50:10.347548@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:50:16.314396||measurement||price||2015-12-01 18:50:10.609506@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:50:27.010895||measurement||price||2015-12-01 18:50:20.664129@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:50:28.397479||measurement||price||2015-12-01 18:50:10.347548@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:50:28.658987||measurement||price||2015-12-01 18:50:10.609506@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:50:35.515658||measurement||loadtime||0:00:26.644164||4||0
+2015-12-01 18:50:35.596114||error||collecting ads||Error||1||0
+2015-12-01 18:50:35.754670||measurement||loadtime||0:00:26.767077||2||0
+2015-12-01 18:50:39.923901||measurement||price||2015-12-01 18:50:20.664129@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:50:46.821928||event||progress-marker||training-start||0||1
+2015-12-01 18:50:46.822073||event||progress-marker||training-end||0||1
+2015-12-01 18:50:47.136025||measurement||loadtime||0:00:29.413914||5||1
+2015-12-01 18:50:47.947334||measurement||price||2015-12-01 18:50:42.354448@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:50:51.876715||event||progress-marker||measurement-start||0||1
+2015-12-01 18:50:57.753510||error||collecting ads||Error||4||0
+2015-12-01 18:50:57.991215||error||collecting ads||Error||2||0
+2015-12-01 18:51:00.285629||measurement||price||2015-12-01 18:50:42.354448@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:51:00.998291||measurement||price||2015-12-01 18:50:54.483188@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:51:07.399164||measurement||loadtime||0:00:26.800029||1||0
+2015-12-01 18:51:10.238460||measurement||price||2015-12-01 18:51:04.644698@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:51:13.208973||event||progress-marker||training-start||3||1
+2015-12-01 18:51:13.209117||event||progress-marker||training-end||3||1
+2015-12-01 18:51:13.870920||measurement||price||2015-12-01 18:50:54.483188@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:51:15.954562||error||collecting ads||Error||0||1
+2015-12-01 18:51:18.274708||event||progress-marker||measurement-start||3||1
+2015-12-01 18:51:19.959695||measurement||price||2015-12-01 18:51:14.387185@|Dremel@|$23.99@|Dremel 7300-PT 4.8-Volt Pet Grooming Kit||1||0
+2015-12-01 18:51:20.015432||error||collecting ads||Error||4||0
+2015-12-01 18:51:21.087102||measurement||loadtime||0:00:28.947915||5||1
+2015-12-01 18:51:22.544967||measurement||price||2015-12-01 18:51:04.644698@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:51:29.509135||measurement||price||2015-12-01 18:51:23.127491@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:51:29.649624||measurement||loadtime||0:00:26.653196||2||0
+2015-12-01 18:51:32.250229||measurement||price||2015-12-01 18:51:14.387185@|Dremel@|$39.12@|Dremel 7700-1/15 MultiPro 7.2-Volt Cordless Rotary Tool Kit||1||0
+2015-12-01 18:51:32.294908||measurement||price||2015-12-01 18:51:26.688455@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:51:32.785618||measurement||price||2015-12-01 18:51:26.037057@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:51:34.990164||measurement||price||2015-12-01 18:51:28.445209@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:51:39.338137||measurement||loadtime||0:00:26.933790||1||0
+2015-12-01 18:51:41.958331||measurement||price||2015-12-01 18:51:36.373856@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:51:42.562439||measurement||price||2015-12-01 18:51:23.127491@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:51:44.645059||measurement||price||2015-12-01 18:51:26.688455@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:51:45.645627||measurement||price||2015-12-01 18:51:26.037057@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:51:47.812001||measurement||price||2015-12-01 18:51:28.445209@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:51:49.784341||measurement||loadtime||0:00:28.824536||0||1
+2015-12-01 18:51:51.743194||measurement||loadtime||0:00:26.724028||4||0
+2015-12-01 18:51:52.847642||measurement||loadtime||0:00:29.567713||3||1
+2015-12-01 18:51:54.265182||measurement||price||2015-12-01 18:51:36.373856@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:51:55.026244||measurement||loadtime||0:00:28.933884||5||1
+2015-12-01 18:52:01.347171||measurement||loadtime||0:00:26.692334||2||0
+2015-12-01 18:52:01.579098||error||collecting ads||Error||1||0
+2015-12-01 18:52:03.252269||measurement||price||2015-12-01 18:51:57.004555@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:52:03.928115||measurement||price||2015-12-01 18:51:58.293074@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:52:06.461762||measurement||price||2015-12-01 18:52:00.211411@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:52:08.776523||measurement||price||2015-12-01 18:52:02.228181@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 18:52:13.823362||measurement||price||2015-12-01 18:52:08.249596@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:52:16.116650||measurement||price||2015-12-01 18:51:57.004555@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:52:16.262041||measurement||price||2015-12-01 18:51:58.293074@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:52:19.443396||measurement||price||2015-12-01 18:52:00.211411@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:52:21.674204||measurement||price||2015-12-01 18:52:02.228181@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 18:52:23.331188||measurement||loadtime||0:00:28.541594||0||1
+2015-12-01 18:52:23.376319||measurement||loadtime||0:00:26.627864||4||0
+2015-12-01 18:52:23.839089||error||collecting ads||Error||1||0
+2015-12-01 18:52:26.163056||measurement||price||2015-12-01 18:52:08.249596@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:52:26.660586||measurement||loadtime||0:00:28.807748||3||1
+2015-12-01 18:52:28.894027||measurement||loadtime||0:00:28.862853||5||1
+2015-12-01 18:52:33.278806||measurement||loadtime||0:00:26.926426||2||0
+2015-12-01 18:52:35.744447||measurement||price||2015-12-01 18:52:30.102680@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:52:36.619628||measurement||price||2015-12-01 18:52:30.942788@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||0
+2015-12-01 18:52:37.060411||measurement||price||2015-12-01 18:52:30.663403@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:52:40.449104||measurement||price||2015-12-01 18:52:34.043564@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:52:42.643460||measurement||price||2015-12-01 18:52:36.085065@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:52:48.110631||measurement||price||2015-12-01 18:52:30.102680@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:52:48.948278||measurement||price||2015-12-01 18:52:30.942788@|Warner Bros@|$45.85@|Jurassic World Team Pack - LEGO Dimensions||1||0
+2015-12-01 18:52:49.898912||measurement||price||2015-12-01 18:52:30.663403@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:52:53.310743||measurement||price||2015-12-01 18:52:34.043564@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:52:55.219159||measurement||loadtime||0:00:26.839979||4||0
+2015-12-01 18:52:55.499724||error||collecting ads||Error||2||0
+2015-12-01 18:52:55.515737||measurement||price||2015-12-01 18:52:36.085065@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:52:56.062391||measurement||loadtime||0:00:27.218058||1||0
+2015-12-01 18:52:57.114142||measurement||loadtime||0:00:28.777732||0||1
+2015-12-01 18:53:00.511193||measurement||loadtime||0:00:28.848040||3||1
+2015-12-01 18:53:02.731194||measurement||loadtime||0:00:28.831912||5||1
+2015-12-01 18:53:07.649042||measurement||price||2015-12-01 18:53:02.007393@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:53:07.779970||measurement||price||2015-12-01 18:53:02.118762@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:53:08.472736||measurement||price||2015-12-01 18:53:02.814477@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:53:10.797766||measurement||price||2015-12-01 18:53:04.407314@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:53:14.394718||measurement||price||2015-12-01 18:53:07.786531@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:53:16.261559||measurement||price||2015-12-01 18:53:09.887119@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 18:53:19.998933||measurement||price||2015-12-01 18:53:02.007393@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:53:20.115881||measurement||price||2015-12-01 18:53:02.118762@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:53:20.805964||measurement||price||2015-12-01 18:53:02.814477@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:53:23.636424||measurement||price||2015-12-01 18:53:04.407314@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:53:27.115573||measurement||loadtime||0:00:26.891177||4||0
+2015-12-01 18:53:27.220417||measurement||loadtime||0:00:26.715443||2||0
+2015-12-01 18:53:27.372701||measurement||price||2015-12-01 18:53:07.786531@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:53:27.920881||measurement||loadtime||0:00:26.853723||1||0
+2015-12-01 18:53:29.142692||measurement||price||2015-12-01 18:53:09.887119@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 18:53:30.834490||measurement||loadtime||0:00:28.715326||0||1
+2015-12-01 18:53:34.567181||measurement||loadtime||0:00:29.050738||3||1
+2015-12-01 18:53:36.373961||measurement||loadtime||0:00:28.638802||5||1
+2015-12-01 18:53:44.289995||measurement||price||2015-12-01 18:53:37.962295@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:53:49.335342||error||collecting ads||Error||4||0
+2015-12-01 18:53:49.473391||error||collecting ads||Error||2||0
+2015-12-01 18:53:50.248749||error||collecting ads||Error||1||0
+2015-12-01 18:53:57.131341||measurement||price||2015-12-01 18:53:37.962295@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:53:58.358766||error||collecting ads||Error||3||1
+2015-12-01 18:54:00.179210||error||collecting ads||Error||5||1
+2015-12-01 18:54:01.743443||measurement||price||2015-12-01 18:53:55.953417@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:54:03.023108||measurement||price||2015-12-01 18:53:57.348108@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||1||0
+2015-12-01 18:54:04.359189||measurement||loadtime||0:00:28.519453||0||1
+2015-12-01 18:54:11.669964||error||collecting ads||Error||4||0
+2015-12-01 18:54:12.429918||measurement||price||2015-12-01 18:54:05.600125@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:54:13.974934||measurement||price||2015-12-01 18:54:07.523548@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:54:14.090604||measurement||price||2015-12-01 18:53:55.953417@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:54:15.370402||measurement||price||2015-12-01 18:53:57.348108@|Warner Bros@|$45.85@|Jurassic World Team Pack - LEGO Dimensions||1||0
+2015-12-01 18:54:17.964677||measurement||price||2015-12-01 18:54:11.507866@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:54:21.210686||measurement||loadtime||0:00:26.735561||2||0
+2015-12-01 18:54:22.487252||measurement||loadtime||0:00:27.236112||1||0
+2015-12-01 18:54:23.871777||measurement||price||2015-12-01 18:54:18.206564@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:54:25.347903||measurement||price||2015-12-01 18:54:05.600125@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:54:26.814307||measurement||price||2015-12-01 18:54:07.523548@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:54:30.735878||measurement||price||2015-12-01 18:54:11.507866@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:54:32.569111||measurement||loadtime||0:00:29.205116||3||1
+2015-12-01 18:54:33.454388||measurement||price||2015-12-01 18:54:27.853982@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:54:34.030316||measurement||loadtime||0:00:28.845912||5||1
+2015-12-01 18:54:34.757802||measurement||price||2015-12-01 18:54:29.112072@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:54:36.211162||measurement||price||2015-12-01 18:54:18.206564@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:54:37.967222||measurement||loadtime||0:00:28.602816||0||1
+2015-12-01 18:54:43.328786||measurement||loadtime||0:00:26.653599||4||0
+2015-12-01 18:54:45.790444||measurement||price||2015-12-01 18:54:27.853982@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:54:46.344075||measurement||price||2015-12-01 18:54:39.818637@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 18:54:47.089076||measurement||price||2015-12-01 18:54:29.112072@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:54:47.889169||measurement||price||2015-12-01 18:54:41.249295@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:54:52.902938||measurement||loadtime||0:00:26.687019||2||0
+2015-12-01 18:54:54.196309||measurement||loadtime||0:00:26.705187||1||0
+2015-12-01 18:54:59.305495||measurement||price||2015-12-01 18:54:39.818637@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 18:55:00.736193||measurement||price||2015-12-01 18:54:41.249295@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:55:01.638647||error||collecting ads||Error||0||1
+2015-12-01 18:55:05.433177||error||collecting ads||Error||4||0
+2015-12-01 18:55:05.630536||measurement||price||2015-12-01 18:55:00.025735@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 18:55:06.555163||measurement||loadtime||0:00:28.980822||3||1
+2015-12-01 18:55:06.563444||measurement||price||2015-12-01 18:55:00.939892@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:55:07.960687||measurement||loadtime||0:00:28.925161||5||1
+2015-12-01 18:55:15.493876||measurement||price||2015-12-01 18:55:09.221859@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:55:17.726225||measurement||price||2015-12-01 18:55:12.131433@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:55:17.978079||measurement||price||2015-12-01 18:55:00.025735@|Warner Bros@|$45.85@|Jurassic World Team Pack - LEGO Dimensions||2||0
+2015-12-01 18:55:18.916984||measurement||price||2015-12-01 18:55:00.939892@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:55:25.089051||measurement||loadtime||0:00:27.180857||2||0
+2015-12-01 18:55:26.028760||measurement||loadtime||0:00:26.829607||1||0
+2015-12-01 18:55:28.462685||measurement||price||2015-12-01 18:55:09.221859@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:55:30.056122||measurement||price||2015-12-01 18:55:12.131433@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:55:31.010260||error||collecting ads||Error||3||1
+2015-12-01 18:55:31.717472||error||collecting ads||Error||5||1
+2015-12-01 18:55:35.677876||measurement||loadtime||0:00:29.034740||0||1
+2015-12-01 18:55:37.163620||measurement||loadtime||0:00:26.725227||4||0
+2015-12-01 18:55:37.771578||measurement||price||2015-12-01 18:55:32.172234@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:55:38.274502||measurement||price||2015-12-01 18:55:32.676094@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:55:45.347379||measurement||price||2015-12-01 18:55:38.855614@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||1
+2015-12-01 18:55:45.838939||measurement||price||2015-12-01 18:55:38.230869@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:55:49.218528||measurement||price||2015-12-01 18:55:42.822588@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:55:49.386971||measurement||price||2015-12-01 18:55:43.691265@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:55:50.122019||measurement||price||2015-12-01 18:55:32.172234@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:55:50.609395||measurement||price||2015-12-01 18:55:32.676094@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:55:57.258961||measurement||loadtime||0:00:27.167810||2||0
+2015-12-01 18:55:57.720342||measurement||loadtime||0:00:26.689168||1||0
+2015-12-01 18:55:58.459965||measurement||price||2015-12-01 18:55:38.855614@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||1
+2015-12-01 18:55:58.755506||measurement||price||2015-12-01 18:55:38.230869@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:56:01.731384||measurement||price||2015-12-01 18:55:43.691265@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:56:02.109310||measurement||price||2015-12-01 18:55:42.822588@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:56:05.687672||measurement||loadtime||0:00:28.964970||5||1
+2015-12-01 18:56:05.959431||measurement||loadtime||0:00:29.943972||3||1
+2015-12-01 18:56:08.866605||measurement||loadtime||0:00:26.697788||4||0
+2015-12-01 18:56:09.349744||measurement||loadtime||0:00:28.670568||0||1
+2015-12-01 18:56:19.468107||error||collecting ads||Error||2||0
+2015-12-01 18:56:19.816578||measurement||price||2015-12-01 18:56:13.119778@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:56:20.069076||error||collecting ads||Error||1||0
+2015-12-01 18:56:21.201335||measurement||price||2015-12-01 18:56:15.573533@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:56:23.224454||measurement||price||2015-12-01 18:56:16.758205@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||0||1
+2015-12-01 18:56:29.580145||error||collecting ads||Error||5||1
+2015-12-01 18:56:31.709894||measurement||price||2015-12-01 18:56:26.161727@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:56:32.398235||measurement||price||2015-12-01 18:56:26.732680@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:56:32.633598||measurement||price||2015-12-01 18:56:13.119778@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:56:33.547511||measurement||price||2015-12-01 18:56:15.573533@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:56:36.107942||measurement||price||2015-12-01 18:56:16.758205@|Warner Bros@|$46.03@|Jurassic World Team Pack - LEGO Dimensions||0||1
+2015-12-01 18:56:39.845097||measurement||loadtime||0:00:28.883431||3||1
+2015-12-01 18:56:40.658948||measurement||loadtime||0:00:26.787609||4||0
+2015-12-01 18:56:43.213444||measurement||price||2015-12-01 18:56:36.769240@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:56:43.313139||measurement||loadtime||0:00:28.961979||0||1
+2015-12-01 18:56:44.041536||measurement||price||2015-12-01 18:56:26.161727@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:56:44.728721||measurement||price||2015-12-01 18:56:26.732680@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:56:51.158160||measurement||loadtime||0:00:26.687025||2||0
+2015-12-01 18:56:51.845493||measurement||loadtime||0:00:26.775780||1||0
+2015-12-01 18:56:52.962740||measurement||price||2015-12-01 18:56:47.335139@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:56:56.052615||measurement||price||2015-12-01 18:56:36.769240@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:56:56.940049||measurement||price||2015-12-01 18:56:50.472590@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:57:03.282309||measurement||loadtime||0:00:28.696929||5||1
+2015-12-01 18:57:03.442305||measurement||price||2015-12-01 18:56:57.729660@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:57:03.799663||error||collecting ads||Error||3||1
+2015-12-01 18:57:04.156075||measurement||price||2015-12-01 18:56:58.527980@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:57:05.308706||measurement||price||2015-12-01 18:56:47.335139@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:57:09.836226||measurement||price||2015-12-01 18:56:50.472590@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 18:57:12.418137||measurement||loadtime||0:00:26.753920||4||0
+2015-12-01 18:57:15.765762||measurement||price||2015-12-01 18:56:57.729660@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:57:16.509585||measurement||price||2015-12-01 18:56:58.527980@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:57:17.034544||measurement||loadtime||0:00:28.716193||0||1
+2015-12-01 18:57:17.181597||measurement||price||2015-12-01 18:57:10.501551@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||1
+2015-12-01 18:57:17.924413||measurement||price||2015-12-01 18:57:11.145557@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:57:22.875167||measurement||loadtime||0:00:26.711814||2||0
+2015-12-01 18:57:23.619172||measurement||loadtime||0:00:26.769093||1||0
+2015-12-01 18:57:24.667654||measurement||price||2015-12-01 18:57:19.034051@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 18:57:30.273100||measurement||price||2015-12-01 18:57:10.501551@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||1
+2015-12-01 18:57:30.571553||measurement||price||2015-12-01 18:57:24.351295@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:57:30.846536||measurement||price||2015-12-01 18:57:11.145557@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:57:35.153350||measurement||price||2015-12-01 18:57:29.480216@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 18:57:35.986218||measurement||price||2015-12-01 18:57:30.318327@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:57:37.027636||measurement||price||2015-12-01 18:57:19.034051@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 18:57:37.526195||measurement||loadtime||0:00:29.238636||5||1
+2015-12-01 18:57:38.082762||measurement||loadtime||0:00:29.277877||3||1
+2015-12-01 18:57:43.399689||measurement||price||2015-12-01 18:57:24.351295@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:57:44.135824||measurement||loadtime||0:00:26.712473||4||0
+2015-12-01 18:57:47.489746||measurement||price||2015-12-01 18:57:29.480216@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 18:57:48.344141||measurement||price||2015-12-01 18:57:30.318327@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:57:50.636611||measurement||loadtime||0:00:28.599467||0||1
+2015-12-01 18:57:52.119287||measurement||price||2015-12-01 18:57:45.319657@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:57:54.598330||measurement||loadtime||0:00:26.717943||2||0
+2015-12-01 18:57:55.455207||measurement||loadtime||0:00:26.830849||1||0
+2015-12-01 18:57:56.356326||measurement||price||2015-12-01 18:57:50.779081@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 18:58:01.374613||error||collecting ads||Error||5||1
+2015-12-01 18:58:04.231807||measurement||price||2015-12-01 18:57:57.785600@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:58:04.980994||measurement||price||2015-12-01 18:57:45.319657@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:58:06.852242||measurement||price||2015-12-01 18:58:01.241536@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 18:58:07.714429||measurement||price||2015-12-01 18:58:01.953561@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||0
+2015-12-01 18:58:08.690931||measurement||price||2015-12-01 18:57:50.779081@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 18:58:12.191549||measurement||loadtime||0:00:29.104397||3||1
+2015-12-01 18:58:15.143219||measurement||price||2015-12-01 18:58:08.523458@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:58:15.809034||measurement||loadtime||0:00:26.667996||4||0
+2015-12-01 18:58:17.052466||measurement||price||2015-12-01 18:57:57.785600@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:58:19.196789||measurement||price||2015-12-01 18:58:01.241536@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 18:58:20.067129||measurement||price||2015-12-01 18:58:01.953561@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||0
+2015-12-01 18:58:24.266757||measurement||loadtime||0:00:28.626742||0||1
+2015-12-01 18:58:25.912150||measurement||price||2015-12-01 18:58:19.421845@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:58:26.315753||measurement||loadtime||0:00:26.712590||2||0
+2015-12-01 18:58:27.186406||measurement||loadtime||0:00:26.727237||1||0
+2015-12-01 18:58:28.054771||measurement||price||2015-12-01 18:58:08.523458@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:58:28.116958||measurement||price||2015-12-01 18:58:22.449326@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:58:35.251184||measurement||loadtime||0:00:28.872265||5||1
+2015-12-01 18:58:37.968487||measurement||price||2015-12-01 18:58:31.413135@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 18:58:38.879535||measurement||price||2015-12-01 18:58:19.421845@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 18:58:38.930097||measurement||price||2015-12-01 18:58:33.255669@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||2||0
+2015-12-01 18:58:39.515279||measurement||price||2015-12-01 18:58:33.758336@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||0
+2015-12-01 18:58:40.445502||measurement||price||2015-12-01 18:58:22.449326@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:58:46.063206||measurement||loadtime||0:00:28.866392||3||1
+2015-12-01 18:58:47.558245||measurement||loadtime||0:00:26.748666||4||0
+2015-12-01 18:58:48.979916||measurement||price||2015-12-01 18:58:42.408827@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:58:50.826755||measurement||price||2015-12-01 18:58:31.413135@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 18:58:51.273974||measurement||price||2015-12-01 18:58:33.255669@|Warner Bros@|$46.03@|Jurassic World Team Pack - LEGO Dimensions||2||0
+2015-12-01 18:58:51.857289||measurement||price||2015-12-01 18:58:33.758336@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||0
+2015-12-01 18:58:58.043244||measurement||loadtime||0:00:28.771261||0||1
+2015-12-01 18:58:58.386762||measurement||loadtime||0:00:27.067625||2||0
+2015-12-01 18:58:58.971177||measurement||loadtime||0:00:26.779567||1||0
+2015-12-01 18:58:59.816392||measurement||price||2015-12-01 18:58:54.240722@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 18:59:01.857103||measurement||price||2015-12-01 18:58:42.408827@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:59:09.062172||measurement||loadtime||0:00:28.805767||5||1
+2015-12-01 18:59:09.984313||error||collecting ads||Error||3||1
+2015-12-01 18:59:10.655259||measurement||price||2015-12-01 18:59:04.922108@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 18:59:11.276347||measurement||price||2015-12-01 18:59:05.592528@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||0
+2015-12-01 18:59:11.812124||measurement||price||2015-12-01 18:59:05.284719@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 18:59:12.162865||measurement||price||2015-12-01 18:58:54.240722@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 18:59:19.287167||measurement||loadtime||0:00:26.723686||4||0
+2015-12-01 18:59:19.287277||event||progress-marker||measurement-end||4||0
+2015-12-01 18:59:22.907439||measurement||price||2015-12-01 18:59:16.331297@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:59:23.003248||measurement||price||2015-12-01 18:59:04.922108@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 18:59:23.626401||measurement||price||2015-12-01 18:59:05.592528@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||0
+2015-12-01 18:59:23.983906||measurement||price||2015-12-01 18:59:17.123778@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 18:59:24.689960||measurement||price||2015-12-01 18:59:05.284719@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 18:59:30.120487||measurement||loadtime||0:00:26.728511||2||0
+2015-12-01 18:59:30.120577||event||progress-marker||measurement-end||2||0
+2015-12-01 18:59:30.739216||measurement||loadtime||0:00:26.763832||1||0
+2015-12-01 18:59:30.739360||event||progress-marker||measurement-end||1||0
+2015-12-01 18:59:31.887663||measurement||loadtime||0:00:28.839166||0||1
+2015-12-01 18:59:35.765096||measurement||price||2015-12-01 18:59:16.331297@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 18:59:36.857788||measurement||price||2015-12-01 18:59:17.123778@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 18:59:42.966201||measurement||loadtime||0:00:28.898777||5||1
+2015-12-01 18:59:44.073394||measurement||loadtime||0:00:29.086230||3||1
+2015-12-01 18:59:45.382415||measurement||price||2015-12-01 18:59:39.125720@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 18:59:56.687394||measurement||price||2015-12-01 18:59:50.106535@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||1
+2015-12-01 18:59:58.163576||measurement||price||2015-12-01 18:59:51.311247@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 18:59:58.207710||measurement||price||2015-12-01 18:59:39.125720@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:00:05.425242||measurement||loadtime||0:00:28.532334||0||1
+2015-12-01 19:00:09.589917||measurement||price||2015-12-01 18:59:50.106535@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||1
+2015-12-01 19:00:11.142204||measurement||price||2015-12-01 18:59:51.311247@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:00:16.803230||measurement||loadtime||0:00:28.834885||5||1
+2015-12-01 19:00:18.372046||measurement||loadtime||0:00:29.293359||3||1
+2015-12-01 19:00:19.038994||measurement||price||2015-12-01 19:00:12.513381@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 19:00:31.791517||measurement||price||2015-12-01 19:00:12.513381@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 19:00:32.191339||measurement||price||2015-12-01 19:00:25.615068@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 19:00:38.985669||measurement||loadtime||0:00:28.555203||0||1
+2015-12-01 19:00:40.511223||error||collecting ads||Error||5||1
+2015-12-01 19:00:40.511333||event||progress-marker||measurement-end||5||1
+2015-12-01 19:00:45.054906||measurement||price||2015-12-01 19:00:25.615068@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 19:00:52.268905||measurement||loadtime||0:00:28.891626||3||1
+2015-12-01 19:01:02.482732||error||collecting ads||Error||0||1
+2015-12-01 19:01:05.882137||measurement||price||2015-12-01 19:00:59.357262@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:01:15.742572||measurement||price||2015-12-01 19:01:09.609514@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 19:01:18.752093||measurement||price||2015-12-01 19:00:59.357262@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:01:25.964222||measurement||loadtime||0:00:28.690105||3||1
+2015-12-01 19:01:28.550965||measurement||price||2015-12-01 19:01:09.609514@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 19:01:35.795220||measurement||loadtime||0:00:28.307219||0||1
+2015-12-01 19:01:35.795353||event||progress-marker||measurement-end||0||1
+2015-12-01 19:01:39.627697||measurement||price||2015-12-01 19:01:33.097453@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 19:01:52.519835||measurement||price||2015-12-01 19:01:33.097453@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 19:01:59.731167||measurement||loadtime||0:00:28.765373||3||1
+2015-12-01 19:01:59.731294||event||progress-marker||measurement-end||3||1
+2015-12-01 19:02:00.120247||meta||block_id end||22
+2015-12-01 19:02:00.120609||meta||block_id start||23
+2015-12-01 19:02:00.120641||meta||assignment||5@|0@|4@|2@|1@|3
+2015-12-01 19:02:01.710516||event||progress-marker||training-start||5||0
+2015-12-01 19:02:01.710619||event||progress-marker||training-end||5||0
+2015-12-01 19:02:01.755598||event||progress-marker||training-start||4||0
+2015-12-01 19:02:01.755696||event||progress-marker||training-end||4||0
+2015-12-01 19:02:01.756232||event||progress-marker||training-start||0||0
+2015-12-01 19:02:01.756330||event||progress-marker||training-end||0||0
+2015-12-01 19:02:06.770364||event||progress-marker||measurement-start||5||0
+2015-12-01 19:02:06.810694||event||progress-marker||measurement-start||0||0
+2015-12-01 19:02:06.818006||event||progress-marker||measurement-start||4||0
+2015-12-01 19:02:21.015360||measurement||price||2015-12-01 19:02:14.060853@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 19:02:30.925445||error||collecting ads||Error||5||0
+2015-12-01 19:02:30.989597||error||collecting ads||Error||0||0
+2015-12-01 19:02:33.370712||measurement||price||2015-12-01 19:02:14.060853@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 19:02:40.475197||measurement||loadtime||0:00:28.652045||4||0
+2015-12-01 19:02:43.197006||measurement||price||2015-12-01 19:02:37.574602@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:02:43.358617||measurement||price||2015-12-01 19:02:37.621898@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 19:02:52.869946||measurement||price||2015-12-01 19:02:47.073404@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 19:02:55.561217||measurement||price||2015-12-01 19:02:37.574602@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:02:55.686844||measurement||price||2015-12-01 19:02:37.621898@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 19:03:02.671178||measurement||loadtime||0:00:26.744022||5||0
+2015-12-01 19:03:02.803160||measurement||loadtime||0:00:26.811990||0||0
+2015-12-01 19:03:05.191738||measurement||price||2015-12-01 19:02:47.073404@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 19:03:06.004516||event||progress-marker||training-start||1||1
+2015-12-01 19:03:06.004617||event||progress-marker||training-end||1||1
+2015-12-01 19:03:06.995467||event||progress-marker||training-start||2||1
+2015-12-01 19:03:06.995568||event||progress-marker||training-end||2||1
+2015-12-01 19:03:11.055571||event||progress-marker||measurement-start||1||1
+2015-12-01 19:03:12.052006||event||progress-marker||measurement-start||2||1
+2015-12-01 19:03:12.314949||measurement||loadtime||0:00:26.834521||4||0
+2015-12-01 19:03:13.257420||event||progress-marker||training-start||3||1
+2015-12-01 19:03:13.257521||event||progress-marker||training-end||3||1
+2015-12-01 19:03:14.828779||measurement||price||2015-12-01 19:03:09.152469@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:03:15.026763||measurement||price||2015-12-01 19:03:09.473277@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 19:03:18.308349||event||progress-marker||measurement-start||3||1
+2015-12-01 19:03:24.558354||measurement||price||2015-12-01 19:03:18.839120@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 19:03:25.176318||measurement||price||2015-12-01 19:03:18.897033@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:03:26.683898||measurement||price||2015-12-01 19:03:19.874140@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 19:03:27.154752||measurement||price||2015-12-01 19:03:09.152469@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:03:27.365304||measurement||price||2015-12-01 19:03:09.473277@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 19:03:34.272237||measurement||loadtime||0:00:26.596040||5||0
+2015-12-01 19:03:34.479140||measurement||loadtime||0:00:26.672009||0||0
+2015-12-01 19:03:36.908518||measurement||price||2015-12-01 19:03:18.839120@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 19:03:38.113909||measurement||price||2015-12-01 19:03:18.897033@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:03:39.631773||measurement||price||2015-12-01 19:03:19.874140@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 19:03:42.352246||error||collecting ads||Error||3||1
+2015-12-01 19:03:44.022654||measurement||loadtime||0:00:26.702455||4||0
+2015-12-01 19:03:45.350993||measurement||loadtime||0:00:29.291720||1||1
+2015-12-01 19:03:46.535503||measurement||price||2015-12-01 19:03:40.925470@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:03:46.866312||measurement||loadtime||0:00:29.811153||2||1
+2015-12-01 19:03:55.918875||measurement||price||2015-12-01 19:03:49.448490@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 19:03:56.227548||measurement||price||2015-12-01 19:03:50.583469@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 19:03:56.769817||error||collecting ads||Error||0||0
+2015-12-01 19:03:58.886748||measurement||price||2015-12-01 19:03:40.925470@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:04:06.000568||measurement||loadtime||0:00:26.723097||5||0
+2015-12-01 19:04:08.580466||measurement||price||2015-12-01 19:03:50.583469@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 19:04:08.988072||measurement||price||2015-12-01 19:03:49.448490@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 19:04:09.005196||error||collecting ads||Error||1||1
+2015-12-01 19:04:09.052842||measurement||price||2015-12-01 19:04:03.316086@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 19:04:10.833522||error||collecting ads||Error||2||1
+2015-12-01 19:04:15.689410||measurement||loadtime||0:00:26.661543||4||0
+2015-12-01 19:04:16.203256||measurement||loadtime||0:00:28.845794||3||1
+2015-12-01 19:04:18.209047||measurement||price||2015-12-01 19:04:12.606624@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:04:21.392680||measurement||price||2015-12-01 19:04:03.316086@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 19:04:22.640029||measurement||price||2015-12-01 19:04:16.036254@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:04:27.914500||measurement||price||2015-12-01 19:04:22.276521@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:04:28.503818||measurement||loadtime||0:00:26.728738||0||0
+2015-12-01 19:04:30.065714||measurement||price||2015-12-01 19:04:23.604087@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 19:04:30.550630||measurement||price||2015-12-01 19:04:12.606624@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:04:34.744187||error||collecting ads||Error||2||1
+2015-12-01 19:04:35.725903||measurement||price||2015-12-01 19:04:16.036254@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:04:37.659161||measurement||loadtime||0:00:26.653381||5||0
+2015-12-01 19:04:40.241412||measurement||price||2015-12-01 19:04:22.276521@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:04:40.684173||measurement||price||2015-12-01 19:04:35.084017@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 19:04:42.913530||measurement||price||2015-12-01 19:04:23.604087@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 19:04:42.974491||measurement||loadtime||0:00:28.964104||1||1
+2015-12-01 19:04:47.361444||measurement||loadtime||0:00:26.669526||4||0
+2015-12-01 19:04:48.481110||measurement||price||2015-12-01 19:04:41.922818@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 19:04:49.943571||measurement||price||2015-12-01 19:04:44.343308@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:04:50.115417||measurement||loadtime||0:00:28.906974||3||1
+2015-12-01 19:04:53.025763||measurement||price||2015-12-01 19:04:35.084017@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 19:04:56.569199||measurement||price||2015-12-01 19:04:50.177268@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:04:59.553091||measurement||price||2015-12-01 19:04:53.945439@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 19:05:00.138012||measurement||loadtime||0:00:26.628977||0||0
+2015-12-01 19:05:01.403279||measurement||price||2015-12-01 19:04:41.922818@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 19:05:02.273817||measurement||price||2015-12-01 19:04:44.343308@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:05:03.960916||measurement||price||2015-12-01 19:04:57.327702@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:05:08.636368||measurement||loadtime||0:00:28.886952||2||1
+2015-12-01 19:05:09.389152||measurement||loadtime||0:00:26.724819||5||0
+2015-12-01 19:05:09.499672||measurement||price||2015-12-01 19:04:50.177268@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:05:11.867765||measurement||price||2015-12-01 19:04:53.945439@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 19:05:12.391196||measurement||price||2015-12-01 19:05:06.659253@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 19:05:16.719157||measurement||loadtime||0:00:28.742682||1||1
+2015-12-01 19:05:16.873318||measurement||price||2015-12-01 19:04:57.327702@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:05:18.962298||measurement||loadtime||0:00:26.595651||4||0
+2015-12-01 19:05:21.717150||measurement||price||2015-12-01 19:05:15.968566@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:05:24.091162||measurement||loadtime||0:00:28.972012||3||1
+2015-12-01 19:05:24.750329||measurement||price||2015-12-01 19:05:06.659253@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 19:05:30.268672||measurement||price||2015-12-01 19:05:23.800756@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:05:31.867154||measurement||loadtime||0:00:26.723943||0||0
+2015-12-01 19:05:32.456235||error||collecting ads||Error||2||1
+2015-12-01 19:05:34.024636||measurement||price||2015-12-01 19:05:15.968566@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:05:41.104177||measurement||loadtime||0:00:26.709833||5||0
+2015-12-01 19:05:41.286731||error||collecting ads||Error||4||0
+2015-12-01 19:05:43.161100||measurement||price||2015-12-01 19:05:23.800756@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:05:44.188998||measurement||price||2015-12-01 19:05:38.430961@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 19:05:47.678941||error||collecting ads||Error||3||1
+2015-12-01 19:05:50.370496||measurement||loadtime||0:00:28.646143||1||1
+2015-12-01 19:05:53.364101||measurement||price||2015-12-01 19:05:47.622209@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:05:56.184598||error||collecting ads||Error||2||1
+2015-12-01 19:05:56.477087||measurement||price||2015-12-01 19:05:38.430961@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 19:06:01.288653||measurement||price||2015-12-01 19:05:54.849600@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:06:03.431452||error||collecting ads||Error||4||0
+2015-12-01 19:06:03.567171||measurement||loadtime||0:00:26.694824||0||0
+2015-12-01 19:06:03.933614||measurement||price||2015-12-01 19:05:57.441656@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:06:05.707867||measurement||price||2015-12-01 19:05:47.622209@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:06:12.815668||measurement||loadtime||0:00:26.706256||5||0
+2015-12-01 19:06:14.363534||measurement||price||2015-12-01 19:05:54.849600@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:06:15.749490||measurement||price||2015-12-01 19:06:10.112948@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 19:06:16.776980||measurement||price||2015-12-01 19:05:57.441656@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:06:20.017953||error||collecting ads||Error||2||1
+2015-12-01 19:06:21.560529||measurement||loadtime||0:00:28.876408||3||1
+2015-12-01 19:06:23.977842||measurement||loadtime||0:00:28.602687||1||1
+2015-12-01 19:06:24.988554||measurement||price||2015-12-01 19:06:19.376091@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:06:25.845628||error||collecting ads||Error||0||0
+2015-12-01 19:06:28.085035||measurement||price||2015-12-01 19:06:10.112948@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 19:06:34.115235||measurement||price||2015-12-01 19:06:27.692967@|@|$274.95@|Samsung Gear S2 Smartwatch for Most Android Phones - Dark Gray||2||1
+2015-12-01 19:06:35.199171||measurement||loadtime||0:00:26.762493||4||0
+2015-12-01 19:06:35.319359||measurement||price||2015-12-01 19:06:28.741137@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:06:37.318944||measurement||price||2015-12-01 19:06:19.376091@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:06:38.182172||measurement||price||2015-12-01 19:06:32.520327@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 19:06:44.429820||measurement||loadtime||0:00:26.608893||5||0
+2015-12-01 19:06:47.376444||measurement||price||2015-12-01 19:06:41.755801@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||0
+2015-12-01 19:06:47.689351||error||collecting ads||Error||1||1
+2015-12-01 19:06:47.837044||measurement||price||2015-12-01 19:06:27.692967@|Microsoft@|$249.99@|Microsoft Band 2 - Medium||2||1
+2015-12-01 19:06:48.360863||measurement||price||2015-12-01 19:06:28.741137@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:06:50.534407||measurement||price||2015-12-01 19:06:32.520327@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 19:06:55.050347||measurement||loadtime||0:00:30.027205||2||1
+2015-12-01 19:06:55.542301||measurement||loadtime||0:00:28.979453||3||1
+2015-12-01 19:06:56.606613||measurement||price||2015-12-01 19:06:50.907982@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:06:57.651673||measurement||loadtime||0:00:26.804525||0||0
+2015-12-01 19:06:59.713020||measurement||price||2015-12-01 19:06:41.755801@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||0
+2015-12-01 19:07:06.829274||measurement||loadtime||0:00:26.624838||4||0
+2015-12-01 19:07:08.685857||measurement||price||2015-12-01 19:07:02.269910@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 19:07:08.952513||measurement||price||2015-12-01 19:06:50.907982@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:07:09.198182||measurement||price||2015-12-01 19:07:02.675070@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:07:10.346626||measurement||price||2015-12-01 19:07:04.750303@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||0||0
+2015-12-01 19:07:11.382330||error||collecting ads||Error||1||1
+2015-12-01 19:07:16.067181||measurement||loadtime||0:00:26.632289||5||0
+2015-12-01 19:07:21.680197||measurement||price||2015-12-01 19:07:02.269910@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 19:07:22.127915||measurement||price||2015-12-01 19:07:02.675070@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:07:22.649146||measurement||price||2015-12-01 19:07:04.750303@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||0||0
+2015-12-01 19:07:25.059504||measurement||price||2015-12-01 19:07:18.637906@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:07:28.314163||measurement||price||2015-12-01 19:07:22.590757@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:07:28.930048||measurement||loadtime||0:00:28.874465||2||1
+2015-12-01 19:07:29.024605||error||collecting ads||Error||4||0
+2015-12-01 19:07:29.360566||measurement||loadtime||0:00:28.813033||3||1
+2015-12-01 19:07:29.731279||measurement||loadtime||0:00:27.074333||0||0
+2015-12-01 19:07:37.937563||measurement||price||2015-12-01 19:07:18.637906@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:07:40.667721||measurement||price||2015-12-01 19:07:22.590757@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:07:41.293274||measurement||price||2015-12-01 19:07:35.621644@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:07:42.122883||measurement||price||2015-12-01 19:07:36.426742@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 19:07:43.407068||measurement||price||2015-12-01 19:07:36.680854@|Lonve@| $19.98   @|Lonve Music Player 16GB MP4/MP3 Player Blue 1.81'' Screen MP...||2||1
+2015-12-01 19:07:43.451920||measurement||price||2015-12-01 19:07:36.826019@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:07:45.130051||measurement||loadtime||0:00:28.742502||1||1
+2015-12-01 19:07:47.782907||measurement||loadtime||0:00:26.710341||5||0
+2015-12-01 19:07:53.627779||measurement||price||2015-12-01 19:07:35.621644@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:07:54.453445||measurement||price||2015-12-01 19:07:36.426742@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 19:07:56.286658||measurement||price||2015-12-01 19:07:36.680854@|Apple@| $155.99   @|Apple iPod touch 32GB 4th Generation - Black (Certified Refu...||2||1
+2015-12-01 19:07:56.473892||measurement||price||2015-12-01 19:07:36.826019@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:07:58.689725||measurement||price||2015-12-01 19:07:52.251923@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:08:00.731662||measurement||loadtime||0:00:26.706293||4||0
+2015-12-01 19:08:01.544459||measurement||loadtime||0:00:26.809306||0||0
+2015-12-01 19:08:03.468164||measurement||loadtime||0:00:29.532891||2||1
+2015-12-01 19:08:03.696424||measurement||loadtime||0:00:29.333277||3||1
+2015-12-01 19:08:10.086859||error||collecting ads||Error||5||0
+2015-12-01 19:08:11.584457||measurement||price||2015-12-01 19:07:52.251923@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:08:12.991281||measurement||price||2015-12-01 19:08:07.400263@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 19:08:13.853700||measurement||price||2015-12-01 19:08:08.233712@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 19:08:17.410316||measurement||price||2015-12-01 19:08:10.877210@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:08:17.898588||measurement||price||2015-12-01 19:08:11.110023@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 19:08:18.819334||measurement||loadtime||0:00:28.684183||1||1
+2015-12-01 19:08:22.239588||measurement||price||2015-12-01 19:08:16.616323@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:08:25.325239||measurement||price||2015-12-01 19:08:07.400263@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 19:08:26.218788||measurement||price||2015-12-01 19:08:08.233712@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 19:08:30.442512||measurement||price||2015-12-01 19:08:10.877210@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:08:30.831205||measurement||price||2015-12-01 19:08:11.110023@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 19:08:32.423642||measurement||loadtime||0:00:26.688732||4||0
+2015-12-01 19:08:32.440081||measurement||price||2015-12-01 19:08:26.155435@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 19:08:33.326927||measurement||loadtime||0:00:26.779752||0||0
+2015-12-01 19:08:34.562633||measurement||price||2015-12-01 19:08:16.616323@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:08:37.652452||measurement||loadtime||0:00:28.953289||3||1
+2015-12-01 19:08:38.032147||measurement||loadtime||0:00:29.560911||2||1
+2015-12-01 19:08:41.660433||measurement||loadtime||0:00:26.568336||5||0
+2015-12-01 19:08:44.596586||measurement||price||2015-12-01 19:08:38.910277@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:08:45.306885||measurement||price||2015-12-01 19:08:26.155435@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 19:08:45.632690||measurement||price||2015-12-01 19:08:39.879297@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 19:08:51.527784||measurement||price||2015-12-01 19:08:44.801919@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:08:51.760260||measurement||price||2015-12-01 19:08:45.507388@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 19:08:52.543530||measurement||loadtime||0:00:28.721915||1||1
+2015-12-01 19:08:53.851416||measurement||price||2015-12-01 19:08:48.306670@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:08:56.897808||measurement||price||2015-12-01 19:08:38.910277@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:08:57.964317||measurement||price||2015-12-01 19:08:39.879297@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 19:09:03.981889||measurement||loadtime||0:00:26.553056||4||0
+2015-12-01 19:09:04.550177||measurement||price||2015-12-01 19:08:44.801919@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:09:04.781472||measurement||price||2015-12-01 19:08:45.507388@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 19:09:05.078091||measurement||loadtime||0:00:26.745965||0||0
+2015-12-01 19:09:06.092953||measurement||price||2015-12-01 19:08:59.707539@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 19:09:06.156708||measurement||price||2015-12-01 19:08:48.306670@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:09:11.764207||measurement||loadtime||0:00:29.106528||3||1
+2015-12-01 19:09:11.975153||measurement||loadtime||0:00:28.940024||2||1
+2015-12-01 19:09:13.247861||measurement||loadtime||0:00:26.584705||5||0
+2015-12-01 19:09:16.128851||measurement||price||2015-12-01 19:09:10.493862@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||0
+2015-12-01 19:09:17.772204||measurement||price||2015-12-01 19:09:12.187750@|Gerber@|$24.71@|Gerber Moment Field Dress Kit I [31-002218]||0||0
+2015-12-01 19:09:18.948455||measurement||price||2015-12-01 19:08:59.707539@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 19:09:25.528276||measurement||price||2015-12-01 19:09:19.829581@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:09:26.181987||measurement||loadtime||0:00:28.633195||1||1
+2015-12-01 19:09:26.195458||measurement||price||2015-12-01 19:09:19.260087@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 19:09:28.477588||measurement||price||2015-12-01 19:09:10.493862@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||0
+2015-12-01 19:09:30.107428||measurement||price||2015-12-01 19:09:12.187750@|Gerber@|$20.26@|Gerber Bear Grylls Paracord Fixed Blade Knife [31-001683]||0||0
+2015-12-01 19:09:35.591162||measurement||loadtime||0:00:26.604053||4||0
+2015-12-01 19:09:35.724794||error||collecting ads||Error||3||1
+2015-12-01 19:09:37.218679||measurement||loadtime||0:00:27.135381||0||0
+2015-12-01 19:09:37.865708||measurement||price||2015-12-01 19:09:19.829581@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:09:39.075250||measurement||price||2015-12-01 19:09:19.260087@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 19:09:44.981229||measurement||loadtime||0:00:26.728146||5||0
+2015-12-01 19:09:46.298869||measurement||loadtime||0:00:29.318459||2||1
+2015-12-01 19:09:47.911746||measurement||price||2015-12-01 19:09:42.266962@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:09:49.538334||measurement||price||2015-12-01 19:09:43.016897@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 19:09:49.849839||error||collecting ads||Error||1||1
+2015-12-01 19:09:57.344322||measurement||price||2015-12-01 19:09:51.710447@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:09:59.524508||error||collecting ads||Error||0||0
+2015-12-01 19:10:00.234243||measurement||price||2015-12-01 19:09:42.266962@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:10:02.423481||measurement||price||2015-12-01 19:09:43.016897@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 19:10:07.324638||measurement||loadtime||0:00:26.728216||4||0
+2015-12-01 19:10:09.639224||measurement||loadtime||0:00:28.912097||3||1
+2015-12-01 19:10:09.700580||measurement||price||2015-12-01 19:09:51.710447@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:10:10.013902||error||collecting ads||Error||2||1
+2015-12-01 19:10:11.670597||measurement||price||2015-12-01 19:10:06.096984@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 19:10:13.433768||error||collecting ads||Error||1||1
+2015-12-01 19:10:16.803170||measurement||loadtime||0:00:26.816747||5||0
+2015-12-01 19:10:19.469786||measurement||price||2015-12-01 19:10:13.808265@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:10:23.552426||measurement||price||2015-12-01 19:10:17.067569@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||1
+2015-12-01 19:10:23.891995||measurement||price||2015-12-01 19:10:17.269906@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||1
+2015-12-01 19:10:24.007569||measurement||price||2015-12-01 19:10:06.096984@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 19:10:27.092494||measurement||price||2015-12-01 19:10:20.661034@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:10:29.054320||measurement||price||2015-12-01 19:10:23.372152@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:10:31.126868||measurement||loadtime||0:00:26.599704||0||0
+2015-12-01 19:10:31.757993||measurement||price||2015-12-01 19:10:13.808265@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:10:36.419605||measurement||price||2015-12-01 19:10:17.067569@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||1
+2015-12-01 19:10:36.924541||measurement||price||2015-12-01 19:10:17.269906@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||1
+2015-12-01 19:10:38.849806||measurement||loadtime||0:00:26.519922||4||0
+2015-12-01 19:10:39.900696||measurement||price||2015-12-01 19:10:20.661034@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:10:41.393725||measurement||price||2015-12-01 19:10:23.372152@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:10:43.377878||measurement||price||2015-12-01 19:10:37.775872@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||0
+2015-12-01 19:10:43.601586||measurement||loadtime||0:00:28.958436||3||1
+2015-12-01 19:10:44.107179||measurement||loadtime||0:00:29.088043||2||1
+2015-12-01 19:10:47.126372||measurement||loadtime||0:00:28.691237||1||1
+2015-12-01 19:10:48.505280||measurement||loadtime||0:00:26.696897||5||0
+2015-12-01 19:10:51.029678||measurement||price||2015-12-01 19:10:45.476588@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:10:55.705731||measurement||price||2015-12-01 19:10:37.775872@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||0
+2015-12-01 19:10:58.113322||measurement||price||2015-12-01 19:10:51.432846@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 19:11:00.681153||measurement||price||2015-12-01 19:10:54.277660@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 19:11:00.768846||measurement||price||2015-12-01 19:10:55.039079@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:11:02.822975||measurement||loadtime||0:00:26.690867||0||0
+2015-12-01 19:11:03.350844||measurement||price||2015-12-01 19:10:45.476588@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:11:07.397967||error||collecting ads||Error||3||1
+2015-12-01 19:11:10.437900||measurement||loadtime||0:00:26.585496||4||0
+2015-12-01 19:11:11.083958||measurement||price||2015-12-01 19:10:51.432846@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 19:11:13.122538||measurement||price||2015-12-01 19:10:55.039079@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:11:13.535433||measurement||price||2015-12-01 19:10:54.277660@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 19:11:15.096941||measurement||price||2015-12-01 19:11:09.568625@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||0
+2015-12-01 19:11:18.318658||measurement||loadtime||0:00:29.206275||2||1
+2015-12-01 19:11:20.232308||measurement||loadtime||0:00:26.725161||5||0
+2015-12-01 19:11:20.753845||measurement||loadtime||0:00:28.622278||1||1
+2015-12-01 19:11:27.445554||measurement||price||2015-12-01 19:11:09.568625@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||0
+2015-12-01 19:11:31.308965||error||collecting ads||Error||3||1
+2015-12-01 19:11:32.052001||measurement||price||2015-12-01 19:11:25.558605@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 19:11:32.674280||error||collecting ads||Error||4||0
+2015-12-01 19:11:34.571335||measurement||loadtime||0:00:26.743083||0||0
+2015-12-01 19:11:34.846773||measurement||price||2015-12-01 19:11:28.528712@|@|$39.95@|*NEW* OtterBox SYMMETRY Series iPhone 6/6s Case - Frustratio...||1||1
+2015-12-01 19:11:42.497346||error||collecting ads||Error||5||0
+2015-12-01 19:11:45.037502||measurement||price||2015-12-01 19:11:39.239083@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||0
+2015-12-01 19:11:45.108283||measurement||price||2015-12-01 19:11:25.558605@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 19:11:45.361921||measurement||price||2015-12-01 19:11:38.668772@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:11:46.882470||measurement||price||2015-12-01 19:11:41.194190@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||0
+2015-12-01 19:11:47.868660||measurement||price||2015-12-01 19:11:28.528712@|@|$79.95@|Lifeproof FRE iPhone 6/6s Case - Retail Packaging - BLACK||1||1
+2015-12-01 19:11:52.320143||measurement||loadtime||0:00:28.996282||2||1
+2015-12-01 19:11:54.693484||measurement||price||2015-12-01 19:11:49.078234@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:11:55.063282||measurement||loadtime||0:00:29.304228||1||1
+2015-12-01 19:11:57.371612||measurement||price||2015-12-01 19:11:39.239083@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||0
+2015-12-01 19:11:58.254940||measurement||price||2015-12-01 19:11:38.668772@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:11:59.225521||measurement||price||2015-12-01 19:11:41.194190@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||0
+2015-12-01 19:12:04.479166||measurement||loadtime||0:00:26.799323||4||0
+2015-12-01 19:12:04.479262||event||progress-marker||measurement-end||4||0
+2015-12-01 19:12:05.452645||measurement||loadtime||0:00:29.138438||3||1
+2015-12-01 19:12:06.346247||measurement||loadtime||0:00:26.771101||0||0
+2015-12-01 19:12:06.346363||event||progress-marker||measurement-end||0||0
+2015-12-01 19:12:07.022734||measurement||price||2015-12-01 19:11:49.078234@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:12:08.561762||measurement||price||2015-12-01 19:12:02.361686@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 19:12:14.129576||measurement||loadtime||0:00:26.627407||5||0
+2015-12-01 19:12:14.129702||event||progress-marker||measurement-end||5||0
+2015-12-01 19:12:16.099202||error||collecting ads||Error||2||1
+2015-12-01 19:12:19.062111||measurement||price||2015-12-01 19:12:12.567099@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||1
+2015-12-01 19:12:21.422220||measurement||price||2015-12-01 19:12:02.361686@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 19:12:28.632479||measurement||loadtime||0:00:28.563957||1||1
+2015-12-01 19:12:29.874932||measurement||price||2015-12-01 19:12:23.319311@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||1
+2015-12-01 19:12:31.910193||measurement||price||2015-12-01 19:12:12.567099@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||1
+2015-12-01 19:12:39.142478||measurement||loadtime||0:00:28.684608||3||1
+2015-12-01 19:12:42.234005||measurement||price||2015-12-01 19:12:35.719150@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:12:42.741622||measurement||price||2015-12-01 19:12:23.319311@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||1
+2015-12-01 19:12:49.941805||measurement||loadtime||0:00:28.837368||2||1
+2015-12-01 19:12:53.190142||measurement||price||2015-12-01 19:12:47.001193@|Disney INFINITY@|$13.00@|Disney Infinity 3.0 Edition: Star Wars The Force Awakens Kyl...||3||1
+2015-12-01 19:12:55.023788||measurement||price||2015-12-01 19:12:35.719150@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:13:02.238943||measurement||loadtime||0:00:28.601209||1||1
+2015-12-01 19:13:03.865334||measurement||price||2015-12-01 19:12:57.257789@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||1
+2015-12-01 19:13:06.016670||measurement||price||2015-12-01 19:12:47.001193@|Warner Bros@|$45.68@|Jurassic World Team Pack - LEGO Dimensions||3||1
+2015-12-01 19:13:13.224283||measurement||loadtime||0:00:29.076574||3||1
+2015-12-01 19:13:15.697612||measurement||price||2015-12-01 19:13:09.422105@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:13:16.689762||measurement||price||2015-12-01 19:12:57.257789@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||1
+2015-12-01 19:13:23.883499||measurement||loadtime||0:00:28.940343||2||1
+2015-12-01 19:13:23.883652||event||progress-marker||measurement-end||2||1
+2015-12-01 19:13:27.033451||measurement||price||2015-12-01 19:13:20.511514@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||1
+2015-12-01 19:13:28.474902||measurement||price||2015-12-01 19:13:09.422105@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:13:35.705694||measurement||loadtime||0:00:28.461472||1||1
+2015-12-01 19:13:35.705851||event||progress-marker||measurement-end||1||1
+2015-12-01 19:13:39.878522||measurement||price||2015-12-01 19:13:20.511514@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||1
+2015-12-01 19:13:47.077829||measurement||loadtime||0:00:28.848309||3||1
+2015-12-01 19:13:47.077968||event||progress-marker||measurement-end||3||1
+2015-12-01 19:13:47.531766||meta||block_id end||23
+2015-12-01 19:13:47.532071||meta||block_id start||24
+2015-12-01 19:13:47.532122||meta||assignment||3@|5@|2@|0@|1@|4
+2015-12-01 19:13:49.093804||event||progress-marker||training-start||3||0
+2015-12-01 19:13:49.098603||event||progress-marker||training-end||3||0
+2015-12-01 19:13:49.165520||event||progress-marker||training-start||2||0
+2015-12-01 19:13:49.165623||event||progress-marker||training-end||2||0
+2015-12-01 19:13:49.171753||event||progress-marker||training-start||5||0
+2015-12-01 19:13:49.172118||event||progress-marker||training-end||5||0
+2015-12-01 19:13:54.161778||event||progress-marker||measurement-start||3||0
+2015-12-01 19:13:54.230423||event||progress-marker||measurement-start||2||0
+2015-12-01 19:13:54.231481||event||progress-marker||measurement-start||5||0
+2015-12-01 19:14:11.128219||measurement||price||2015-12-01 19:14:01.543695@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:14:17.201145||error||collecting ads||Error||3||0
+2015-12-01 19:14:17.622402||error||collecting ads||Error||2||0
+2015-12-01 19:14:23.487667||measurement||price||2015-12-01 19:14:01.543695@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:14:29.885062||measurement||price||2015-12-01 19:14:24.466954@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 19:14:30.607210||measurement||loadtime||0:00:31.372041||5||0
+2015-12-01 19:14:39.981000||error||collecting ads||Error||2||0
+2015-12-01 19:14:42.220374||measurement||price||2015-12-01 19:14:24.466954@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 19:14:43.076125||measurement||price||2015-12-01 19:14:37.113361@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:14:49.345236||measurement||loadtime||0:00:27.138857||3||0
+2015-12-01 19:14:52.138399||measurement||price||2015-12-01 19:14:46.557751@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:14:55.385944||measurement||price||2015-12-01 19:14:37.113361@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:15:01.941853||measurement||price||2015-12-01 19:14:56.494680@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:15:02.483780||measurement||loadtime||0:00:26.871338||5||0
+2015-12-01 19:15:03.656079||event||progress-marker||training-start||1||1
+2015-12-01 19:15:03.656180||event||progress-marker||training-end||1||1
+2015-12-01 19:15:04.473040||measurement||price||2015-12-01 19:14:46.557751@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:15:08.681503||event||progress-marker||training-start||0||1
+2015-12-01 19:15:08.681651||event||progress-marker||training-end||0||1
+2015-12-01 19:15:08.713684||event||progress-marker||measurement-start||1||1
+2015-12-01 19:15:11.585483||measurement||loadtime||0:00:26.603531||2||0
+2015-12-01 19:15:13.747464||event||progress-marker||measurement-start||0||1
+2015-12-01 19:15:14.282069||measurement||price||2015-12-01 19:14:56.494680@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:15:14.653993||measurement||price||2015-12-01 19:15:09.013125@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:15:21.392112||measurement||loadtime||0:00:27.045609||3||0
+2015-12-01 19:15:22.057823||event||progress-marker||training-start||4||1
+2015-12-01 19:15:22.057974||event||progress-marker||training-end||4||1
+2015-12-01 19:15:22.658065||measurement||price||2015-12-01 19:15:16.450968@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:15:23.776847||measurement||price||2015-12-01 19:15:18.236376@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:15:26.977806||measurement||price||2015-12-01 19:15:09.013125@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:15:27.118890||event||progress-marker||measurement-start||4||1
+2015-12-01 19:15:28.646122||measurement||price||2015-12-01 19:15:21.879884@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 19:15:34.093941||measurement||loadtime||0:00:26.604942||5||0
+2015-12-01 19:15:35.501317||measurement||price||2015-12-01 19:15:16.450968@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:15:36.106776||measurement||price||2015-12-01 19:15:18.236376@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:15:41.536067||measurement||price||2015-12-01 19:15:21.879884@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 19:15:42.711185||measurement||loadtime||0:00:28.992294||1||1
+2015-12-01 19:15:43.222181||measurement||loadtime||0:00:26.631415||2||0
+2015-12-01 19:15:43.966166||error||collecting ads||Error||3||0
+2015-12-01 19:15:46.357631||measurement||price||2015-12-01 19:15:40.754156@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:15:48.758240||measurement||loadtime||0:00:30.007096||0||1
+2015-12-01 19:15:51.052901||error||collecting ads||Error||4||1
+2015-12-01 19:15:55.456593||measurement||price||2015-12-01 19:15:49.730390@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 19:15:56.401493||measurement||price||2015-12-01 19:15:49.991177@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:15:56.600709||measurement||price||2015-12-01 19:15:51.161786@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 19:15:58.688506||measurement||price||2015-12-01 19:15:40.754156@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:16:04.762222||measurement||price||2015-12-01 19:15:58.233517@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 19:16:05.791097||measurement||loadtime||0:00:26.696015||5||0
+2015-12-01 19:16:07.822130||measurement||price||2015-12-01 19:15:49.730390@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 19:16:08.949250||measurement||price||2015-12-01 19:15:51.161786@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 19:16:09.262279||measurement||price||2015-12-01 19:15:49.991177@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:16:12.468821||error||collecting ads||Error||0||1
+2015-12-01 19:16:14.936049||measurement||loadtime||0:00:26.708625||2||0
+2015-12-01 19:16:16.069351||measurement||loadtime||0:00:27.098183||3||0
+2015-12-01 19:16:16.463960||measurement||loadtime||0:00:28.747577||1||1
+2015-12-01 19:16:17.815636||measurement||price||2015-12-01 19:15:58.233517@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 19:16:17.985620||measurement||price||2015-12-01 19:16:12.372147@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:16:25.018280||measurement||loadtime||0:00:28.960292||4||1
+2015-12-01 19:16:26.149487||measurement||price||2015-12-01 19:16:19.630286@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 19:16:27.154941||measurement||price||2015-12-01 19:16:21.428265@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 19:16:28.556533||measurement||price||2015-12-01 19:16:23.026713@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 19:16:30.344871||measurement||price||2015-12-01 19:16:12.372147@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:16:37.457166||measurement||loadtime||0:00:26.660848||5||0
+2015-12-01 19:16:38.682507||measurement||price||2015-12-01 19:16:32.248785@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:16:39.019973||measurement||price||2015-12-01 19:16:19.630286@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:16:39.486017||measurement||price||2015-12-01 19:16:21.428265@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 19:16:40.166021||error||collecting ads||Error||1||1
+2015-12-01 19:16:40.897613||measurement||price||2015-12-01 19:16:23.026713@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 19:16:46.247317||measurement||loadtime||0:00:28.773287||0||1
+2015-12-01 19:16:46.595164||measurement||loadtime||0:00:26.653901||2||0
+2015-12-01 19:16:48.006515||measurement||loadtime||0:00:26.931929||3||0
+2015-12-01 19:16:50.163640||measurement||price||2015-12-01 19:16:44.415646@|Mitchell@|$73.90@|Mitchell 300 Pro Spinning Rod and Reel Combo, 7-Feet/Medium||5||0
+2015-12-01 19:16:51.616924||measurement||price||2015-12-01 19:16:32.248785@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:16:58.831156||measurement||loadtime||0:00:28.809116||4||1
+2015-12-01 19:16:58.832542||measurement||price||2015-12-01 19:16:53.181699@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:17:00.543375||measurement||price||2015-12-01 19:16:54.126753@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 19:17:00.711755||measurement||price||2015-12-01 19:16:55.319168@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 19:17:02.507888||measurement||price||2015-12-01 19:16:44.415646@|Penn@|$89.65@|Penn Battle II Spinning Reel, 4000||5||0
+2015-12-01 19:17:03.620701||error||collecting ads||Error||1||1
+2015-12-01 19:17:09.626183||measurement||loadtime||0:00:27.163782||5||0
+2015-12-01 19:17:11.153893||measurement||price||2015-12-01 19:16:53.181699@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:17:12.437411||measurement||price||2015-12-01 19:17:05.918017@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 19:17:13.059392||measurement||price||2015-12-01 19:16:55.319168@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 19:17:13.366742||measurement||price||2015-12-01 19:16:54.126753@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:17:18.246527||measurement||loadtime||0:00:26.647388||2||0
+2015-12-01 19:17:20.168778||measurement||loadtime||0:00:27.157985||3||0
+2015-12-01 19:17:20.585451||measurement||loadtime||0:00:29.332896||0||1
+2015-12-01 19:17:21.825896||measurement||price||2015-12-01 19:17:16.144209@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:17:25.334243||measurement||price||2015-12-01 19:17:05.918017@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 19:17:27.044853||error||collecting ads||Error||1||1
+2015-12-01 19:17:32.568973||measurement||loadtime||0:00:28.732570||4||1
+2015-12-01 19:17:32.906407||measurement||price||2015-12-01 19:17:27.471159@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:17:34.181567||measurement||price||2015-12-01 19:17:16.144209@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:17:34.882489||measurement||price||2015-12-01 19:17:28.168575@|Progress Lighting@|$192.00@|Progress Lighting P4459-09 5-Light Alexa Chandelier, Brushed...||0||1
+2015-12-01 19:17:40.443854||error||collecting ads||Error||2||0
+2015-12-01 19:17:41.299454||measurement||loadtime||0:00:26.668056||5||0
+2015-12-01 19:17:45.254792||measurement||price||2015-12-01 19:17:27.471159@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:17:47.867349||measurement||price||2015-12-01 19:17:28.168575@|Progress Lighting@|$114.39@|Progress Lighting P5675-82 Wall Cylinder Outdoor Light, PAR...||0||1
+2015-12-01 19:17:50.540233||error||collecting ads||Error||1||1
+2015-12-01 19:17:52.367168||measurement||loadtime||0:00:27.195957||3||0
+2015-12-01 19:17:52.671976||measurement||price||2015-12-01 19:17:47.080736@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:17:55.106648||measurement||loadtime||0:00:29.519495||0||1
+2015-12-01 19:17:56.192015||error||collecting ads||Error||4||1
+2015-12-01 19:18:03.590974||error||collecting ads||Error||5||0
+2015-12-01 19:18:05.029023||measurement||price||2015-12-01 19:17:47.080736@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:18:08.849574||measurement||price||2015-12-01 19:18:02.704071@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 19:18:09.819439||measurement||price||2015-12-01 19:18:03.410728@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:18:12.143531||measurement||loadtime||0:00:26.694470||2||0
+2015-12-01 19:18:14.209157||error||collecting ads||Error||1||1
+2015-12-01 19:18:15.418363||error||collecting ads||Error||3||0
+2015-12-01 19:18:15.949218||measurement||price||2015-12-01 19:18:10.324548@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:18:21.760896||measurement||price||2015-12-01 19:18:02.704071@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 19:18:22.642537||measurement||price||2015-12-01 19:18:03.410728@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:18:24.516411||measurement||price||2015-12-01 19:18:18.936707@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:18:27.912790||measurement||price||2015-12-01 19:18:21.414711@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 19:18:28.173128||measurement||price||2015-12-01 19:18:22.671426@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:18:28.300670||measurement||price||2015-12-01 19:18:10.324548@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:18:28.962286||measurement||loadtime||0:00:28.850958||0||1
+2015-12-01 19:18:29.867471||measurement||loadtime||0:00:28.672307||4||1
+2015-12-01 19:18:35.419157||measurement||loadtime||0:00:26.823901||5||0
+2015-12-01 19:18:36.843628||measurement||price||2015-12-01 19:18:18.936707@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:18:40.526652||measurement||price||2015-12-01 19:18:22.671426@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:18:40.939505||measurement||price||2015-12-01 19:18:21.414711@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 19:18:43.218877||measurement||price||2015-12-01 19:18:36.693785@|Amy Poehler@| $19.96   @|Inside Out (Blu-ray/DVD Combo Pack + Digital Copy)||0||1
+2015-12-01 19:18:43.653526||measurement||price||2015-12-01 19:18:37.239440@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 19:18:43.950731||measurement||loadtime||0:00:26.801990||2||0
+2015-12-01 19:18:47.640174||measurement||loadtime||0:00:27.217003||3||0
+2015-12-01 19:18:48.100658||measurement||price||2015-12-01 19:18:42.404619@|Amy Poehler@| $19.96   @|Inside Out (Blu-ray/DVD Combo Pack + Digital Copy)||5||0
+2015-12-01 19:18:48.139142||measurement||loadtime||0:00:28.927740||1||1
+2015-12-01 19:18:56.057478||measurement||price||2015-12-01 19:18:36.693785@|Sandra Bullock@| $18.99   @|Minions (Blu-ray + DVD + DIGITAL HD)||0||1
+2015-12-01 19:18:56.451330||measurement||price||2015-12-01 19:18:37.239440@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 19:19:00.340827||measurement||price||2015-12-01 19:18:54.913429@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:19:00.446941||measurement||price||2015-12-01 19:18:42.404619@|Sandra Bullock@| $18.99   @|Minions (Blu-ray + DVD + DIGITAL HD)||5||0
+2015-12-01 19:19:01.908709||measurement||price||2015-12-01 19:18:55.472309@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||1||1
+2015-12-01 19:19:03.252594||measurement||loadtime||0:00:29.285054||0||1
+2015-12-01 19:19:03.684109||measurement||loadtime||0:00:28.811402||4||1
+2015-12-01 19:19:06.390679||error||collecting ads||Error||2||0
+2015-12-01 19:19:07.564633||measurement||loadtime||0:00:27.140273||5||0
+2015-12-01 19:19:12.703556||measurement||price||2015-12-01 19:18:54.913429@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:19:14.909936||measurement||price||2015-12-01 19:18:55.472309@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||1||1
+2015-12-01 19:19:17.147573||measurement||price||2015-12-01 19:19:10.637348@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 19:19:17.405817||measurement||price||2015-12-01 19:19:10.894565@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:19:19.815423||measurement||loadtime||0:00:27.170044||3||0
+2015-12-01 19:19:22.142362||measurement||loadtime||0:00:28.998018||1||1
+2015-12-01 19:19:28.785704||error||collecting ads||Error||2||0
+2015-12-01 19:19:29.911383||error||collecting ads||Error||5||0
+2015-12-01 19:19:30.110235||measurement||price||2015-12-01 19:19:10.637348@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 19:19:30.253364||measurement||price||2015-12-01 19:19:10.894565@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:19:32.413868||measurement||price||2015-12-01 19:19:27.022212@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 19:19:35.841235||measurement||price||2015-12-01 19:19:29.400812@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:19:37.311178||measurement||loadtime||0:00:29.056878||0||1
+2015-12-01 19:19:37.469315||measurement||loadtime||0:00:28.780024||4||1
+2015-12-01 19:19:42.233832||measurement||price||2015-12-01 19:19:36.678136@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:19:44.751741||measurement||price||2015-12-01 19:19:27.022212@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 19:19:48.770502||measurement||price||2015-12-01 19:19:29.400812@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:19:51.120920||error||collecting ads||Error||2||0
+2015-12-01 19:19:51.185736||measurement||price||2015-12-01 19:19:44.739108@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 19:19:51.447383||measurement||price||2015-12-01 19:19:44.732454@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 19:19:51.876102||measurement||loadtime||0:00:27.056960||3||0
+2015-12-01 19:19:54.620564||measurement||price||2015-12-01 19:19:36.678136@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:19:55.981800||measurement||loadtime||0:00:28.834625||1||1
+2015-12-01 19:20:01.721720||measurement||loadtime||0:00:26.807720||5||0
+2015-12-01 19:20:03.486499||measurement||price||2015-12-01 19:19:57.727596@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 19:20:04.023332||measurement||price||2015-12-01 19:19:44.739108@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 19:20:04.592221||measurement||price||2015-12-01 19:19:44.732454@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 19:20:04.734036||measurement||price||2015-12-01 19:19:59.144551@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:20:09.606759||measurement||price||2015-12-01 19:20:03.182874@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:20:11.219473||measurement||loadtime||0:00:28.744965||4||1
+2015-12-01 19:20:11.834449||measurement||loadtime||0:00:29.521273||0||1
+2015-12-01 19:20:15.815876||measurement||price||2015-12-01 19:19:57.727596@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 19:20:17.064017||measurement||price||2015-12-01 19:19:59.144551@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:20:22.554128||measurement||price||2015-12-01 19:20:03.182874@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:20:22.927861||measurement||loadtime||0:00:26.801699||2||0
+2015-12-01 19:20:23.999244||error||collecting ads||Error||5||0
+2015-12-01 19:20:24.156957||measurement||loadtime||0:00:27.275637||3||0
+2015-12-01 19:20:24.904637||measurement||price||2015-12-01 19:20:18.489475@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 19:20:25.660743||measurement||price||2015-12-01 19:20:19.367855@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 19:20:29.771425||measurement||loadtime||0:00:28.784392||1||1
+2015-12-01 19:20:35.281235||measurement||price||2015-12-01 19:20:29.684571@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 19:20:36.304952||measurement||price||2015-12-01 19:20:30.548984@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:20:36.908887||measurement||price||2015-12-01 19:20:31.337849@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 19:20:37.815912||measurement||price||2015-12-01 19:20:18.489475@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 19:20:38.706020||measurement||price||2015-12-01 19:20:19.367855@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 19:20:43.453865||measurement||price||2015-12-01 19:20:36.956664@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:20:45.020382||measurement||loadtime||0:00:28.795696||4||1
+2015-12-01 19:20:45.891517||measurement||loadtime||0:00:29.051851||0||1
+2015-12-01 19:20:47.646724||measurement||price||2015-12-01 19:20:29.684571@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 19:20:48.623160||measurement||price||2015-12-01 19:20:30.548984@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:20:49.273850||measurement||price||2015-12-01 19:20:31.337849@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 19:20:54.755170||measurement||loadtime||0:00:26.822101||2||0
+2015-12-01 19:20:55.731216||measurement||loadtime||0:00:26.726733||5||0
+2015-12-01 19:20:56.345873||measurement||price||2015-12-01 19:20:36.956664@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:20:56.398426||measurement||loadtime||0:00:27.236257||3||0
+2015-12-01 19:20:58.662881||measurement||price||2015-12-01 19:20:52.140648@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 19:20:59.751247||measurement||price||2015-12-01 19:20:53.034977@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 19:21:03.555673||measurement||loadtime||0:00:28.779661||1||1
+2015-12-01 19:21:07.002643||measurement||price||2015-12-01 19:21:01.357214@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:21:09.005405||measurement||price||2015-12-01 19:21:03.604359@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||3||0
+2015-12-01 19:21:11.550605||measurement||price||2015-12-01 19:20:52.140648@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 19:21:12.777672||measurement||price||2015-12-01 19:20:53.034977@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:21:17.012893||measurement||price||2015-12-01 19:21:10.708202@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:21:17.984989||error||collecting ads||Error||5||0
+2015-12-01 19:21:18.778023||measurement||loadtime||0:00:28.752403||4||1
+2015-12-01 19:21:19.360048||measurement||price||2015-12-01 19:21:01.357214@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:21:19.995847||measurement||loadtime||0:00:29.100696||0||1
+2015-12-01 19:21:21.355448||measurement||price||2015-12-01 19:21:03.604359@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||3||0
+2015-12-01 19:21:26.467376||measurement||loadtime||0:00:26.707015||2||0
+2015-12-01 19:21:28.473361||measurement||loadtime||0:00:27.069713||3||0
+2015-12-01 19:21:29.911611||measurement||price||2015-12-01 19:21:10.708202@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:21:30.175596||measurement||price||2015-12-01 19:21:24.452222@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||5||0
+2015-12-01 19:21:32.501741||measurement||price||2015-12-01 19:21:26.114845@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:21:33.743557||measurement||price||2015-12-01 19:21:27.244702@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 19:21:37.109543||measurement||loadtime||0:00:28.549340||1||1
+2015-12-01 19:21:38.663921||measurement||price||2015-12-01 19:21:33.102783@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||2||0
+2015-12-01 19:21:40.917608||measurement||price||2015-12-01 19:21:35.534687@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||3||0
+2015-12-01 19:21:42.521160||measurement||price||2015-12-01 19:21:24.452222@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||5||0
+2015-12-01 19:21:45.347502||measurement||price||2015-12-01 19:21:26.114845@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:21:46.569962||measurement||price||2015-12-01 19:21:27.244702@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 19:21:49.620130||measurement||loadtime||0:00:26.629747||5||0
+2015-12-01 19:21:50.546128||measurement||price||2015-12-01 19:21:44.265665@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:21:51.008384||measurement||price||2015-12-01 19:21:33.102783@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||2||0
+2015-12-01 19:21:52.564670||measurement||loadtime||0:00:28.781415||4||1
+2015-12-01 19:21:53.231183||measurement||price||2015-12-01 19:21:35.534687@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||3||0
+2015-12-01 19:21:53.802044||measurement||loadtime||0:00:28.802883||0||1
+2015-12-01 19:21:58.115151||measurement||loadtime||0:00:26.646736||2||0
+2015-12-01 19:22:00.331276||measurement||loadtime||0:00:26.856139||3||0
+2015-12-01 19:22:01.754888||measurement||price||2015-12-01 19:21:56.252443@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||5||0
+2015-12-01 19:22:03.375741||measurement||price||2015-12-01 19:21:44.265665@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:22:06.200871||measurement||price||2015-12-01 19:21:59.857979@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||4||1
+2015-12-01 19:22:07.577359||measurement||price||2015-12-01 19:22:01.103937@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 19:22:10.404522||measurement||price||2015-12-01 19:22:04.717543@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||2||0
+2015-12-01 19:22:10.584726||measurement||loadtime||0:00:28.469979||1||1
+2015-12-01 19:22:12.943115||measurement||price||2015-12-01 19:22:07.515928@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:22:14.024136||measurement||price||2015-12-01 19:21:56.252443@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||5||0
+2015-12-01 19:22:19.063361||measurement||price||2015-12-01 19:21:59.857979@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||4||1
+2015-12-01 19:22:20.424282||measurement||price||2015-12-01 19:22:01.103937@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 19:22:21.123304||measurement||loadtime||0:00:26.497920||5||0
+2015-12-01 19:22:22.740455||measurement||price||2015-12-01 19:22:04.717543@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||2||0
+2015-12-01 19:22:25.306063||measurement||price||2015-12-01 19:22:07.515928@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:22:26.275257||measurement||loadtime||0:00:28.705357||4||1
+2015-12-01 19:22:27.646791||measurement||loadtime||0:00:28.839639||0||1
+2015-12-01 19:22:29.851175||measurement||loadtime||0:00:26.730780||2||0
+2015-12-01 19:22:32.417956||measurement||loadtime||0:00:27.082814||3||0
+2015-12-01 19:22:33.297550||measurement||price||2015-12-01 19:22:27.738686@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:22:34.175083||error||collecting ads||Error||1||1
+2015-12-01 19:22:39.569303||measurement||price||2015-12-01 19:22:33.477062@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:22:41.276210||measurement||price||2015-12-01 19:22:34.841472@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||0||1
+2015-12-01 19:22:42.518550||measurement||price||2015-12-01 19:22:36.929105@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||2||0
+2015-12-01 19:22:45.636973||measurement||price||2015-12-01 19:22:27.738686@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:22:47.874583||measurement||price||2015-12-01 19:22:41.326770@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:22:52.401892||measurement||price||2015-12-01 19:22:33.477062@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:22:52.753769||measurement||loadtime||0:00:26.626499||5||0
+2015-12-01 19:22:54.093439||measurement||price||2015-12-01 19:22:34.841472@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||0||1
+2015-12-01 19:22:54.857141||measurement||price||2015-12-01 19:22:36.929105@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||2||0
+2015-12-01 19:22:55.031916||error||collecting ads||Error||3||0
+2015-12-01 19:22:59.615173||measurement||loadtime||0:00:28.334716||4||1
+2015-12-01 19:23:00.717420||measurement||price||2015-12-01 19:22:41.326770@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:23:01.296417||measurement||loadtime||0:00:28.644443||0||1
+2015-12-01 19:23:01.966617||measurement||loadtime||0:00:27.110622||2||0
+2015-12-01 19:23:04.976745||measurement||price||2015-12-01 19:22:59.365016@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:23:07.694131||measurement||price||2015-12-01 19:23:02.282219@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||3||0
+2015-12-01 19:23:07.947169||measurement||loadtime||0:00:28.766937||1||1
+2015-12-01 19:23:13.232216||measurement||price||2015-12-01 19:23:06.734254@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:23:14.353919||measurement||price||2015-12-01 19:23:08.698844@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||2||0
+2015-12-01 19:23:15.795706||measurement||price||2015-12-01 19:23:09.303324@|Bosch@|$245.26@|Bosch 1250DEVS 6-1/2-Amp 6-Inch Random Orbit Sander with Vac...||0||1
+2015-12-01 19:23:17.307123||measurement||price||2015-12-01 19:22:59.365016@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:23:20.038536||measurement||price||2015-12-01 19:23:02.282219@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||3||0
+2015-12-01 19:23:24.433010||measurement||loadtime||0:00:26.677749||5||0
+2015-12-01 19:23:26.036802||measurement||price||2015-12-01 19:23:06.734254@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:23:26.719171||measurement||price||2015-12-01 19:23:08.698844@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||2||0
+2015-12-01 19:23:27.152100||measurement||loadtime||0:00:27.114935||3||0
+2015-12-01 19:23:28.739786||measurement||price||2015-12-01 19:23:09.303324@|Bosch@|$150.09@|Bosch CLPK27-120 12-Volt Max Lithium-Ion 2-Tool Combo Kit (D...||0||1
+2015-12-01 19:23:31.553827||error||collecting ads||Error||1||1
+2015-12-01 19:23:33.254532||measurement||loadtime||0:00:28.634161||4||1
+2015-12-01 19:23:33.840598||measurement||loadtime||0:00:26.869426||2||0
+2015-12-01 19:23:33.840731||event||progress-marker||measurement-end||2||0
+2015-12-01 19:23:35.927138||measurement||loadtime||0:00:29.625457||0||1
+2015-12-01 19:23:36.635017||measurement||price||2015-12-01 19:23:31.045132@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||5||0
+2015-12-01 19:23:45.040644||measurement||price||2015-12-01 19:23:38.579793@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:23:46.806739||measurement||price||2015-12-01 19:23:40.384573@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 19:23:48.979279||measurement||price||2015-12-01 19:23:31.045132@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||5||0
+2015-12-01 19:23:49.546403||error||collecting ads||Error||3||0
+2015-12-01 19:23:49.546502||event||progress-marker||measurement-end||3||0
+2015-12-01 19:23:49.627944||measurement||price||2015-12-01 19:23:43.252912@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 19:23:56.097256||measurement||loadtime||0:00:26.659009||5||0
+2015-12-01 19:23:56.097396||event||progress-marker||measurement-end||5||0
+2015-12-01 19:23:57.972413||measurement||price||2015-12-01 19:23:38.579793@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:23:59.637606||measurement||price||2015-12-01 19:23:40.384573@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 19:24:02.570572||measurement||price||2015-12-01 19:23:43.252912@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:24:05.183488||measurement||loadtime||0:00:28.628346||1||1
+2015-12-01 19:24:06.844490||measurement||loadtime||0:00:28.584745||4||1
+2015-12-01 19:24:09.755991||measurement||loadtime||0:00:28.825689||0||1
+2015-12-01 19:24:18.724140||measurement||price||2015-12-01 19:24:12.308463@|DEWALT@|$21.99@|DEWALT DWA2T40IR IMPACT READY FlexTorq Screw Driving Set, 40...||1||1
+2015-12-01 19:24:20.453605||measurement||price||2015-12-01 19:24:14.082849@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||4||1
+2015-12-01 19:24:23.483108||measurement||price||2015-12-01 19:24:16.988480@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 19:24:31.575738||measurement||price||2015-12-01 19:24:12.308463@|DEWALT@|$15.62@|DEWALT DW2166 45-Piece Screwdriving Set||1||1
+2015-12-01 19:24:33.327055||measurement||price||2015-12-01 19:24:14.082849@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||4||1
+2015-12-01 19:24:36.293958||measurement||price||2015-12-01 19:24:16.988480@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 19:24:38.789166||measurement||loadtime||0:00:28.600443||1||1
+2015-12-01 19:24:40.564657||measurement||loadtime||0:00:28.714935||4||1
+2015-12-01 19:24:43.511825||measurement||loadtime||0:00:28.750618||0||1
+2015-12-01 19:24:52.366721||measurement||price||2015-12-01 19:24:45.923124@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||1||1
+2015-12-01 19:24:57.280945||measurement||price||2015-12-01 19:24:50.658698@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 19:25:04.143871||error||collecting ads||Error||4||1
+2015-12-01 19:25:05.253040||measurement||price||2015-12-01 19:24:45.923124@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||1||1
+2015-12-01 19:25:10.185360||measurement||price||2015-12-01 19:24:50.658698@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:25:12.474386||measurement||loadtime||0:00:28.679978||1||1
+2015-12-01 19:25:12.474513||event||progress-marker||measurement-end||1||1
+2015-12-01 19:25:17.398612||measurement||loadtime||0:00:28.881491||0||1
+2015-12-01 19:25:27.672419||error||collecting ads||Error||4||1
+2015-12-01 19:25:30.981455||measurement||price||2015-12-01 19:25:24.565759@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||0||1
+2015-12-01 19:25:41.164190||measurement||price||2015-12-01 19:25:34.741644@|@|$12.99@|AmazonBasics Dual Port USB Wall Charger - 4.2 Amp||4||1
+2015-12-01 19:25:43.784605||measurement||price||2015-12-01 19:25:24.565759@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||0||1
+2015-12-01 19:25:50.980871||measurement||loadtime||0:00:28.577009||0||1
+2015-12-01 19:25:53.945851||measurement||price||2015-12-01 19:25:34.741644@|@|$16.79@|iOttie Easy One Touch Windshield Dashboard Car Mount Holder...||4||1
+2015-12-01 19:26:01.163535||measurement||loadtime||0:00:28.485895||4||1
+2015-12-01 19:26:01.163709||event||progress-marker||measurement-end||4||1
+2015-12-01 19:26:04.542246||measurement||price||2015-12-01 19:25:58.293484@|Canon@|$69.99@|Canon MG5720 Wireless All-In-One Printer with Scanner and Co...||0||1
+2015-12-01 19:26:17.327999||measurement||price||2015-12-01 19:25:58.293484@|Epson@|$399.99@|Epson Expression ET-2550 EcoTank Wireless Color All-in-One S...||0||1
+2015-12-01 19:26:24.520405||measurement||loadtime||0:00:28.534297||0||1
+2015-12-01 19:26:24.520528||event||progress-marker||measurement-end||0||1
+2015-12-01 19:26:24.962435||meta||block_id end||24

--- a/AdFisher/examples/log.group_baseline.txt
+++ b/AdFisher/examples/log.group_baseline.txt
@@ -1,0 +1,3282 @@
+2015-11-21 20:46:44.039747||meta||agents||4
+2015-11-21 20:46:44.039809||meta||treatnames||control (chrome)@|experimental (firefox)
+2015-11-21 20:46:44.040272||meta||block_id start||0
+2015-11-21 20:46:44.040288||meta||assignment||2@|3@|1@|0
+2015-11-21 20:46:46.680093||event||progress-marker||training-start||2||0
+2015-11-21 20:46:46.680357||event||progress-marker||training-end||2||0
+2015-11-21 20:46:46.680488||event||progress-marker||training-start||3||0
+2015-11-21 20:46:46.680744||event||progress-marker||training-end||3||0
+2015-11-21 20:46:49.535408||event||progress-marker||training-start||0||1
+2015-11-21 20:46:49.535795||event||progress-marker||training-end||0||1
+2015-11-21 20:46:49.688130||event||progress-marker||training-start||1||1
+2015-11-21 20:46:49.688390||event||progress-marker||training-end||1||1
+2015-11-21 20:46:51.682250||event||progress-marker||measurement-start||2||0
+2015-11-21 20:46:51.682566||event||progress-marker||measurement-start||3||0
+2015-11-21 20:46:54.538077||event||progress-marker||measurement-start||0||1
+2015-11-21 20:46:54.690633||event||progress-marker||measurement-start||1||1
+2015-11-21 20:47:01.049289||measurement||ad||2015-11-21 20:46:59.014902@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:47:01.193249||measurement||ad||2015-11-21 20:46:59.014902@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||0
+2015-11-21 20:47:01.204301||measurement||ad||2015-11-21 20:46:59.388408@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:47:01.380483||measurement||ad||2015-11-21 20:46:59.014902@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||2||0
+2015-11-21 20:47:01.381472||measurement||loadtime||0:00:04.697034||2||0
+2015-11-21 20:47:01.689352||measurement||ad||2015-11-21 20:46:59.388408@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||0
+2015-11-21 20:47:02.066618||measurement||ad||2015-11-21 20:46:59.388408@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||3||0
+2015-11-21 20:47:02.066992||measurement||loadtime||0:00:05.383170||3||0
+2015-11-21 20:47:07.724004||error||collecting ads||Error||3||0
+2015-11-21 20:47:10.312932||measurement||ad||2015-11-21 20:47:07.077249@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:47:10.472247||measurement||ad||2015-11-21 20:47:07.077249@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:47:10.587431||measurement||ad||2015-11-21 20:47:07.077249@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 20:47:10.587705||measurement||loadtime||0:00:04.205701||2||0
+2015-11-21 20:47:14.461414||error||collecting ads||Error||3||0
+2015-11-21 20:47:17.359922||measurement||ad||2015-11-21 20:47:16.353461@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:47:17.525776||measurement||ad||2015-11-21 20:47:16.353461@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 20:47:17.775366||measurement||ad||2015-11-21 20:47:16.353461@|Earth Day@|cafepress.com@|1000s of Earth Day Gifts to Choose From. Shop Online Now!||2||0
+2015-11-21 20:47:17.775624||measurement||loadtime||0:00:02.185941||2||0
+2015-11-21 20:47:17.938024||measurement||ad||2015-11-21 20:47:16.686347@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:47:18.112508||measurement||ad||2015-11-21 20:47:16.686347@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 20:47:18.471872||measurement||ad||2015-11-21 20:47:16.686347@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||1
+2015-11-21 20:47:18.472222||measurement||loadtime||0:00:18.781018||1||1
+2015-11-21 20:47:18.746820||measurement||ad||2015-11-21 20:47:17.245682@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 20:47:18.929511||measurement||ad||2015-11-21 20:47:17.245682@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 20:47:19.197969||measurement||ad||2015-11-21 20:47:17.245682@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 20:47:19.198431||measurement||loadtime||0:00:19.659838||0||1
+2015-11-21 20:47:21.155053||measurement||ad||2015-11-21 20:47:20.476516@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:47:21.328358||measurement||ad||2015-11-21 20:47:20.476516@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||3||0
+2015-11-21 20:47:21.616251||measurement||ad||2015-11-21 20:47:20.476516@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:47:21.616438||measurement||loadtime||0:00:02.153864||3||0
+2015-11-21 20:47:23.290905||error||collecting ads||Error||2||0
+2015-11-21 20:47:29.040654||measurement||ad||2015-11-21 20:47:27.215754@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:47:29.215769||measurement||ad||2015-11-21 20:47:27.215754@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:47:29.465194||measurement||ad||2015-11-21 20:47:27.215754@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||3||0
+2015-11-21 20:47:29.465513||measurement||loadtime||0:00:02.848224||3||0
+2015-11-21 20:47:30.671553||measurement||ad||2015-11-21 20:47:29.105379@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:47:30.871332||measurement||ad||2015-11-21 20:47:29.105379@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:47:31.011832||measurement||ad||2015-11-21 20:47:29.105379@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 20:47:31.012210||measurement||loadtime||0:00:02.720745||2||0
+2015-11-21 20:47:35.693889||measurement||ad||2015-11-21 20:47:35.362171@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:47:35.862214||measurement||ad||2015-11-21 20:47:35.362171@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:47:35.926111||measurement||ad||2015-11-21 20:47:35.029747@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:47:35.991521||measurement||ad||2015-11-21 20:47:35.362171@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||1
+2015-11-21 20:47:35.991764||measurement||loadtime||0:00:11.791944||0||1
+2015-11-21 20:47:36.157979||measurement||ad||2015-11-21 20:47:35.029747@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:47:36.337016||measurement||ad||2015-11-21 20:47:35.029747@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||3||0
+2015-11-21 20:47:36.337276||measurement||loadtime||0:00:01.870621||3||0
+2015-11-21 20:47:36.500684||error||collecting ads||Error||2||0
+2015-11-21 20:47:42.596142||measurement||ad||2015-11-21 20:47:41.925458@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 20:47:42.696125||measurement||ad||2015-11-21 20:47:41.925458@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 20:47:42.761668||measurement||ad||2015-11-21 20:47:42.017192@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:47:42.847588||measurement||ad||2015-11-21 20:47:41.925458@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:47:42.847935||measurement||loadtime||0:00:01.508754||3||0
+2015-11-21 20:47:42.858320||measurement||ad||2015-11-21 20:47:42.017192@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:47:42.931443||measurement||ad||2015-11-21 20:47:42.017192@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||0
+2015-11-21 20:47:42.931685||measurement||loadtime||0:00:01.430429||2||0
+2015-11-21 20:47:49.068932||measurement||ad||2015-11-21 20:47:48.203488@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:47:49.131564||measurement||ad||2015-11-21 20:47:48.477180@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:47:49.169359||measurement||ad||2015-11-21 20:47:48.203488@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||3||0
+2015-11-21 20:47:49.220938||measurement||ad||2015-11-21 20:47:48.477180@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 20:47:49.257377||measurement||ad||2015-11-21 20:47:48.203488@|Free Printable Will Forms@|wills.rocketlawyer.com@|Printable Will Forms. All States. Free to Print, Save  Download!||3||0
+2015-11-21 20:47:49.257732||measurement||loadtime||0:00:01.408726||3||0
+2015-11-21 20:47:49.346677||measurement||ad||2015-11-21 20:47:48.477180@|Earth Day@|cafepress.com@|1000s of Earth Day Gifts to Choose From. Shop Online Now!||2||0
+2015-11-21 20:47:49.346967||measurement||loadtime||0:00:01.414722||2||0
+2015-11-21 20:47:55.619642||measurement||ad||2015-11-21 20:47:54.936126@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:47:55.699512||measurement||ad||2015-11-21 20:47:54.982415@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:47:55.718108||measurement||ad||2015-11-21 20:47:54.936126@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:47:55.795626||measurement||ad||2015-11-21 20:47:54.982415@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||3||0
+2015-11-21 20:47:55.817095||measurement||ad||2015-11-21 20:47:54.936126@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||0
+2015-11-21 20:47:55.817458||measurement||loadtime||0:00:01.469652||2||0
+2015-11-21 20:47:55.993652||measurement||ad||2015-11-21 20:47:54.982415@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:47:55.994017||measurement||loadtime||0:00:01.735313||3||0
+2015-11-21 20:48:01.019132||measurement||ad||2015-11-21 20:48:00.687136@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:48:01.159596||measurement||ad||2015-11-21 20:48:00.687136@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:48:01.241130||measurement||ad||2015-11-21 20:48:00.687136@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||1
+2015-11-21 20:48:01.241423||measurement||loadtime||0:00:20.248370||0||1
+2015-11-21 20:48:02.426141||measurement||ad||2015-11-21 20:48:01.647235@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 20:48:02.573064||measurement||ad||2015-11-21 20:48:01.647235@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 20:48:02.611439||measurement||ad||2015-11-21 20:48:01.712740@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:48:02.657953||measurement||ad||2015-11-21 20:48:01.647235@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||0
+2015-11-21 20:48:02.658235||measurement||loadtime||0:00:01.663505||3||0
+2015-11-21 20:48:02.658388||event||progress-marker||measurement-end||3||0
+2015-11-21 20:48:02.907783||measurement||ad||2015-11-21 20:48:01.712740@|Earth Day@|cafepress.com@|1000s of Earth Day Gifts to Choose From. Shop Online Now!||2||0
+2015-11-21 20:48:03.020598||measurement||ad||2015-11-21 20:48:01.712740@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-21 20:48:03.020783||measurement||loadtime||0:00:02.200048||2||0
+2015-11-21 20:48:03.020976||event||progress-marker||measurement-end||2||0
+2015-11-21 20:48:10.005216||measurement||ad||2015-11-21 20:48:09.937829@|Business Loan@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 20:48:10.097889||measurement||ad||2015-11-21 20:48:09.937829@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 20:48:10.143974||measurement||ad||2015-11-21 20:48:09.937829@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 20:48:10.144214||measurement||loadtime||0:00:03.901607||0||1
+2015-11-21 20:48:19.495187||measurement||ad||2015-11-21 20:48:19.008413@|Business Loan@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 20:48:19.719325||measurement||ad||2015-11-21 20:48:19.008413@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 20:48:19.988988||measurement||ad||2015-11-21 20:48:19.008413@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 20:48:19.989240||measurement||loadtime||0:00:04.844675||0||1
+2015-11-21 20:48:29.236630||measurement||ad||2015-11-21 20:48:26.317713@|Business Loan@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 20:48:29.296834||measurement||ad||2015-11-21 20:48:26.317713@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 20:48:29.403020||measurement||ad||2015-11-21 20:48:26.317713@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 20:48:29.403804||measurement||loadtime||0:00:04.413011||0||1
+2015-11-21 20:48:39.375718||measurement||ad||2015-11-21 20:48:39.292583@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 20:48:39.426921||measurement||ad||2015-11-21 20:48:39.292583@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 20:48:39.468168||measurement||ad||2015-11-21 20:48:39.292583@|Man Cracks Credit "Code"@|www.thecreditsolutionprogram.com@|This pro's "Shocking Little Trick" can boost credit score by 217 pts.||0||1
+2015-11-21 20:48:39.468388||measurement||loadtime||0:00:05.063223||0||1
+2015-11-21 20:48:48.557785||measurement||ad||2015-11-21 20:48:48.436863@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 20:48:48.616965||measurement||ad||2015-11-21 20:48:48.436863@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 20:48:48.678950||measurement||ad||2015-11-21 20:48:48.436863@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-21 20:48:48.679413||measurement||loadtime||0:00:04.209534||0||1
+2015-11-21 20:48:58.301724||measurement||ad||2015-11-21 20:48:58.070506@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:48:58.539441||measurement||ad||2015-11-21 20:48:58.070506@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:48:58.662843||measurement||ad||2015-11-21 20:48:58.070506@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||1
+2015-11-21 20:48:58.663141||measurement||loadtime||0:00:04.982221||0||1
+2015-11-21 20:49:07.035562||measurement||ad||2015-11-21 20:49:06.926953@|Your Breast Cancer Type@|mybreastcancercoach.org@|Answer a Few Questions  Learn More About Your Breast Cancer Type.||0||1
+2015-11-21 20:49:07.080111||measurement||ad||2015-11-21 20:49:06.926953@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 20:49:07.121264||measurement||ad||2015-11-21 20:49:06.926953@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 20:49:07.121439||measurement||loadtime||0:00:03.456676||0||1
+2015-11-21 20:49:07.121503||event||progress-marker||measurement-end||0||1
+2015-11-21 20:49:07.914812||measurement||ad||2015-11-21 20:47:35.115411@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:49:08.017976||measurement||ad||2015-11-21 20:47:35.115411@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:49:08.057454||measurement||ad||2015-11-21 20:47:35.115411@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 20:49:08.057667||measurement||loadtime||0:01:44.584869||1||1
+2015-11-21 20:49:25.194349||measurement||ad||2015-11-21 20:49:24.872743@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:49:25.639612||measurement||ad||2015-11-21 20:49:24.872743@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:49:26.976719||measurement||ad||2015-11-21 20:49:24.872743@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 20:49:26.977077||measurement||loadtime||0:00:13.917926||1||1
+2015-11-21 20:49:44.634492||measurement||ad||2015-11-21 20:49:42.935452@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:49:48.029511||measurement||ad||2015-11-21 20:49:42.935452@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:49:48.608336||measurement||ad||2015-11-21 20:49:42.935452@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||1
+2015-11-21 20:49:48.608587||measurement||loadtime||0:00:16.630029||1||1
+2015-11-21 20:50:01.529420||measurement||ad||2015-11-21 20:50:00.680001@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:50:02.978450||measurement||ad||2015-11-21 20:50:00.680001@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:50:05.827845||measurement||ad||2015-11-21 20:50:00.680001@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 20:50:05.828045||measurement||loadtime||0:00:12.218019||1||1
+2015-11-21 20:50:19.312557||measurement||ad||2015-11-21 20:50:18.934744@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||1||1
+2015-11-21 20:50:20.808428||measurement||ad||2015-11-21 20:50:18.934744@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||1||1
+2015-11-21 20:50:21.038863||measurement||ad||2015-11-21 20:50:18.934744@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||1||1
+2015-11-21 20:50:21.039139||measurement||loadtime||0:00:10.210498||1||1
+2015-11-21 20:50:34.584798||measurement||ad||2015-11-21 20:50:33.203620@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:50:34.861321||measurement||ad||2015-11-21 20:50:33.203620@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:50:34.928613||measurement||ad||2015-11-21 20:50:33.203620@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 20:50:34.928926||measurement||loadtime||0:00:08.888865||1||1
+2015-11-21 20:50:48.306622||measurement||ad||2015-11-21 20:50:47.843073@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||1||1
+2015-11-21 20:50:58.994778||measurement||ad||2015-11-21 20:50:47.843073@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||1||1
+2015-11-21 20:50:59.733382||measurement||ad||2015-11-21 20:50:47.843073@|Genetics vs. Genomics@|www.healio.com/genetics@|Learn the difference between these commonly confused terms.||1||1
+2015-11-21 20:50:59.733678||measurement||loadtime||0:00:19.803013||1||1
+2015-11-21 20:51:21.983011||measurement||ad||2015-11-21 20:51:21.183194@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:51:23.514019||measurement||ad||2015-11-21 20:51:21.183194@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 20:51:23.679065||measurement||ad||2015-11-21 20:51:21.183194@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||1||1
+2015-11-21 20:51:23.679393||measurement||loadtime||0:00:18.944234||1||1
+2015-11-21 20:51:36.322750||measurement||ad||2015-11-21 20:51:35.398156@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||1||1
+2015-11-21 20:51:36.696119||measurement||ad||2015-11-21 20:51:35.398156@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||1||1
+2015-11-21 20:51:39.998088||measurement||ad||2015-11-21 20:51:35.398156@|Genetics vs. Genomics@|www.healio.com/genetics@|Learn the difference between these commonly confused terms.||1||1
+2015-11-21 20:51:39.998415||measurement||loadtime||0:00:11.318540||1||1
+2015-11-21 20:51:39.998536||event||progress-marker||measurement-end||1||1
+2015-11-21 20:51:40.257833||meta||block_id end||0
+2015-11-21 20:51:40.259515||meta||block_id start||1
+2015-11-21 20:51:40.259557||meta||assignment||3@|2@|0@|1
+2015-11-21 20:51:42.558594||event||progress-marker||training-start||3||0
+2015-11-21 20:51:42.558893||event||progress-marker||training-end||3||0
+2015-11-21 20:51:42.623940||event||progress-marker||training-start||2||0
+2015-11-21 20:51:42.624279||event||progress-marker||training-end||2||0
+2015-11-21 20:51:45.475183||event||progress-marker||training-start||1||1
+2015-11-21 20:51:45.475428||event||progress-marker||training-end||1||1
+2015-11-21 20:51:45.475399||event||progress-marker||training-start||0||1
+2015-11-21 20:51:45.475736||event||progress-marker||training-end||0||1
+2015-11-21 20:51:47.562223||event||progress-marker||measurement-start||3||0
+2015-11-21 20:51:47.628896||event||progress-marker||measurement-start||2||0
+2015-11-21 20:51:50.479180||event||progress-marker||measurement-start||1||1
+2015-11-21 20:51:50.479183||event||progress-marker||measurement-start||0||1
+2015-11-21 20:51:55.284504||measurement||ad||2015-11-21 20:51:55.050747@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:51:55.368220||measurement||ad||2015-11-21 20:51:55.074808@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:51:56.779566||measurement||ad||2015-11-21 20:51:55.050747@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||0
+2015-11-21 20:51:56.897969||measurement||ad||2015-11-21 20:51:55.074808@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||0
+2015-11-21 20:51:56.946548||measurement||ad||2015-11-21 20:51:55.050747@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||3||0
+2015-11-21 20:51:56.946856||measurement||loadtime||0:00:04.383017||3||0
+2015-11-21 20:51:57.030189||measurement||ad||2015-11-21 20:51:55.074808@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||2||0
+2015-11-21 20:51:57.031308||measurement||loadtime||0:00:04.400643||2||0
+2015-11-21 20:52:04.845825||error||collecting ads||Error||3||0
+2015-11-21 20:52:06.054699||measurement||ad||2015-11-21 20:52:04.004569@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||2||0
+2015-11-21 20:52:06.066199||measurement||ad||2015-11-21 20:52:04.898205@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 20:52:06.140848||measurement||ad||2015-11-21 20:52:04.898205@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Black Friday Top Offers||0||1
+2015-11-21 20:52:06.442444||measurement||ad||2015-11-21 20:52:04.898205@|Graphene: Miracle Mineral@|outsiderclub.com/Graphene@|Graphene Will “Change The World” Find Out How You Can Invest Now.||0||1
+2015-11-21 20:52:06.442717||measurement||loadtime||0:00:10.962851||0||1
+2015-11-21 20:52:06.566569||measurement||ad||2015-11-21 20:52:04.004569@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 20:52:07.085206||measurement||ad||2015-11-21 20:52:06.522936@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:52:07.159422||measurement||ad||2015-11-21 20:52:06.522936@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 20:52:07.268164||measurement||ad||2015-11-21 20:52:06.522936@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||1
+2015-11-21 20:52:07.268563||measurement||loadtime||0:00:11.788657||1||1
+2015-11-21 20:52:07.606567||measurement||ad||2015-11-21 20:52:04.004569@|Leaking Petroleum Tanks?@|rawlingsforestry.com@|Phytoremediation can clean-up and and remove petroleum hydrocarbons.||2||0
+2015-11-21 20:52:07.606898||measurement||loadtime||0:00:05.574970||2||0
+2015-11-21 20:52:10.642652||error||collecting ads||Error||3||0
+2015-11-21 20:52:15.895525||measurement||ad||2015-11-21 20:52:13.749877@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:52:16.705184||measurement||ad||2015-11-21 20:52:13.749877@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:52:18.467925||measurement||ad||2015-11-21 20:52:13.749877@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||2||0
+2015-11-21 20:52:18.468177||measurement||loadtime||0:00:05.860249||2||0
+2015-11-21 20:52:19.718632||measurement||ad||2015-11-21 20:52:17.118427@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||0
+2015-11-21 20:52:20.661458||measurement||ad||2015-11-21 20:52:17.118427@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-21 20:52:21.282868||measurement||ad||2015-11-21 20:52:17.118427@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||3||0
+2015-11-21 20:52:21.283174||measurement||loadtime||0:00:05.639843||3||0
+2015-11-21 20:52:22.182522||measurement||ad||2015-11-21 20:52:21.793739@|6 Stocks Set to Soar@|profitabletrading.com@|Proprietary stock-ranking system signals: "buy these 6 stocks now".||0||1
+2015-11-21 20:52:22.301177||measurement||ad||2015-11-21 20:52:21.793739@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||0||1
+2015-11-21 20:52:22.374279||measurement||ad||2015-11-21 20:52:21.793739@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||0||1
+2015-11-21 20:52:22.374536||measurement||loadtime||0:00:10.930735||0||1
+2015-11-21 20:52:23.104431||measurement||ad||2015-11-21 20:52:22.555450@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:52:23.173003||measurement||ad||2015-11-21 20:52:22.555450@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:52:23.224198||measurement||ad||2015-11-21 20:52:22.555450@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-21 20:52:23.224476||measurement||loadtime||0:00:10.954810||1||1
+2015-11-21 20:52:25.484799||measurement||ad||2015-11-21 20:52:24.293449@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:52:25.666746||measurement||ad||2015-11-21 20:52:24.293449@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:52:25.779124||measurement||ad||2015-11-21 20:52:24.293449@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||2||0
+2015-11-21 20:52:25.779430||measurement||loadtime||0:00:02.310532||2||0
+2015-11-21 20:52:28.355591||measurement||ad||2015-11-21 20:52:26.973189@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||0
+2015-11-21 20:52:28.587715||measurement||ad||2015-11-21 20:52:26.973189@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-21 20:52:29.139781||measurement||ad||2015-11-21 20:52:26.973189@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||3||0
+2015-11-21 20:52:29.140054||measurement||loadtime||0:00:02.855496||3||0
+2015-11-21 20:52:33.704558||measurement||ad||2015-11-21 20:52:32.115767@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||2||0
+2015-11-21 20:52:33.993711||measurement||ad||2015-11-21 20:52:32.115767@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||2||0
+2015-11-21 20:52:34.171768||measurement||ad||2015-11-21 20:52:32.115767@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:52:34.172414||measurement||loadtime||0:00:03.391038||2||0
+2015-11-21 20:52:37.428646||measurement||ad||2015-11-21 20:52:35.461972@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:52:38.079649||measurement||ad||2015-11-21 20:52:35.461972@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:52:39.027145||measurement||ad||2015-11-21 20:52:38.588027@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:52:39.250456||measurement||ad||2015-11-21 20:52:38.588027@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:52:39.294956||measurement||ad||2015-11-21 20:52:37.354735@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||0||1
+2015-11-21 20:52:39.365839||measurement||ad||2015-11-21 20:52:35.461972@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-21 20:52:39.366428||measurement||loadtime||0:00:05.225530||3||0
+2015-11-21 20:52:39.458871||measurement||ad||2015-11-21 20:52:38.588027@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 20:52:39.459342||measurement||loadtime||0:00:11.233908||1||1
+2015-11-21 20:52:39.693005||measurement||ad||2015-11-21 20:52:37.354735@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||0||1
+2015-11-21 20:52:40.099007||measurement||ad||2015-11-21 20:52:37.354735@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 20:52:40.099295||measurement||loadtime||0:00:12.724086||0||1
+2015-11-21 20:52:41.820320||measurement||ad||2015-11-21 20:52:40.035595@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:52:41.953653||measurement||ad||2015-11-21 20:52:40.035595@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:52:42.108314||measurement||ad||2015-11-21 20:52:40.035595@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||2||0
+2015-11-21 20:52:42.108728||measurement||loadtime||0:00:02.934842||2||0
+2015-11-21 20:52:47.593519||measurement||ad||2015-11-21 20:52:45.665259@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 20:52:47.828300||measurement||ad||2015-11-21 20:52:45.665259@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 20:52:48.160132||measurement||ad||2015-11-21 20:52:45.665259@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:52:48.160445||measurement||loadtime||0:00:03.792678||3||0
+2015-11-21 20:52:50.632759||measurement||ad||2015-11-21 20:52:48.129937@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||2||0
+2015-11-21 20:52:50.853213||measurement||ad||2015-11-21 20:52:48.129937@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||2||0
+2015-11-21 20:52:52.064236||measurement||ad||2015-11-21 20:52:48.129937@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:52:52.064548||measurement||loadtime||0:00:04.955468||2||0
+2015-11-21 20:52:55.135305||measurement||ad||2015-11-21 20:52:54.821760@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||0||1
+2015-11-21 20:52:55.265303||measurement||ad||2015-11-21 20:52:54.821760@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||0||1
+2015-11-21 20:52:55.407752||measurement||ad||2015-11-21 20:52:54.821760@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 20:52:55.407974||measurement||loadtime||0:00:10.307766||0||1
+2015-11-21 20:52:55.616202||measurement||ad||2015-11-21 20:52:54.169284@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:52:55.938711||measurement||ad||2015-11-21 20:52:54.169284@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:52:56.256251||measurement||ad||2015-11-21 20:52:55.553532@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:52:56.483154||measurement||ad||2015-11-21 20:52:55.553532@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:52:56.658859||measurement||ad||2015-11-21 20:52:55.553532@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 20:52:56.659135||measurement||loadtime||0:00:12.198364||1||1
+2015-11-21 20:52:56.778738||measurement||ad||2015-11-21 20:52:54.169284@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-21 20:52:56.778997||measurement||loadtime||0:00:03.617535||3||0
+2015-11-21 20:52:59.013496||measurement||ad||2015-11-21 20:52:57.493250@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||2||0
+2015-11-21 20:52:59.138281||measurement||ad||2015-11-21 20:52:57.493250@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 20:52:59.243194||measurement||ad||2015-11-21 20:52:57.493250@|Leaking Petroleum Tanks?@|rawlingsforestry.com@|Phytoremediation can clean-up and and remove petroleum hydrocarbons.||2||0
+2015-11-21 20:52:59.243466||measurement||loadtime||0:00:02.178467||2||0
+2015-11-21 20:53:04.567308||measurement||ad||2015-11-21 20:53:02.780656@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:53:04.839775||measurement||ad||2015-11-21 20:53:02.780656@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:53:05.475197||measurement||ad||2015-11-21 20:53:02.780656@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-21 20:53:05.475500||measurement||loadtime||0:00:03.694791||3||0
+2015-11-21 20:53:07.386360||measurement||ad||2015-11-21 20:53:05.546872@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||2||0
+2015-11-21 20:53:07.708452||measurement||ad||2015-11-21 20:53:05.546872@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||2||0
+2015-11-21 20:53:08.064262||measurement||ad||2015-11-21 20:53:05.546872@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:53:08.064615||measurement||loadtime||0:00:03.820144||2||0
+2015-11-21 20:53:09.859475||measurement||ad||2015-11-21 20:53:09.404343@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||0||1
+2015-11-21 20:53:09.940606||measurement||ad||2015-11-21 20:53:09.404343@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 20:53:10.108349||measurement||ad||2015-11-21 20:53:09.404343@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||0||1
+2015-11-21 20:53:10.108873||measurement||loadtime||0:00:09.697997||0||1
+2015-11-21 20:53:10.336287||measurement||ad||2015-11-21 20:53:10.059388@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:53:10.414641||measurement||ad||2015-11-21 20:53:10.059388@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||1
+2015-11-21 20:53:10.476747||measurement||ad||2015-11-21 20:53:10.059388@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 20:53:10.476974||measurement||loadtime||0:00:08.817288||1||1
+2015-11-21 20:53:12.263648||measurement||ad||2015-11-21 20:53:11.259278@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 20:53:12.341452||measurement||ad||2015-11-21 20:53:11.259278@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 20:53:12.480527||measurement||ad||2015-11-21 20:53:11.259278@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:53:12.480832||measurement||loadtime||0:00:02.004178||3||0
+2015-11-21 20:53:12.480993||event||progress-marker||measurement-end||3||0
+2015-11-21 20:53:15.327259||measurement||ad||2015-11-21 20:53:14.180670@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:53:15.415122||measurement||ad||2015-11-21 20:53:14.180670@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:53:15.703516||measurement||ad||2015-11-21 20:53:14.180670@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||2||0
+2015-11-21 20:53:15.703819||measurement||loadtime||0:00:02.638222||2||0
+2015-11-21 20:53:15.703932||event||progress-marker||measurement-end||2||0
+2015-11-21 20:53:20.522552||measurement||ad||2015-11-21 20:53:20.347494@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:53:20.641833||measurement||ad||2015-11-21 20:53:20.347494@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:53:20.735075||measurement||ad||2015-11-21 20:53:20.347494@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 20:53:20.735670||measurement||loadtime||0:00:05.257163||1||1
+2015-11-21 20:53:21.465906||measurement||ad||2015-11-21 20:53:21.139727@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||0||1
+2015-11-21 20:53:21.529739||measurement||ad||2015-11-21 20:53:21.139727@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||0||1
+2015-11-21 20:53:21.598463||measurement||ad||2015-11-21 20:53:21.139727@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 20:53:21.598764||measurement||loadtime||0:00:06.487975||0||1
+2015-11-21 20:53:30.964501||measurement||ad||2015-11-21 20:53:30.895869@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||0||1
+2015-11-21 20:53:31.043978||measurement||ad||2015-11-21 20:53:30.895869@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 20:53:31.096171||measurement||ad||2015-11-21 20:53:30.895869@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:53:31.096399||measurement||loadtime||0:00:04.496871||0||1
+2015-11-21 20:53:31.649416||measurement||ad||2015-11-21 20:53:31.529472@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:53:31.746213||measurement||ad||2015-11-21 20:53:31.529472@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:53:31.814067||measurement||ad||2015-11-21 20:53:31.529472@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 20:53:31.814368||measurement||loadtime||0:00:06.078101||1||1
+2015-11-21 20:53:41.076623||measurement||ad||2015-11-21 20:53:40.912327@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:53:41.152026||measurement||ad||2015-11-21 20:53:40.912327@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:53:41.216711||measurement||ad||2015-11-21 20:53:40.912327@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||0||1
+2015-11-21 20:53:41.216999||measurement||loadtime||0:00:05.119998||0||1
+2015-11-21 20:53:42.962423||measurement||ad||2015-11-21 20:53:42.153147@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 20:53:43.013240||measurement||ad||2015-11-21 20:53:42.153147@|Plant Sale + Free Ship@|www.onlineplantnursery.com@|Fast Shipping On All Garden Plants Trees, Shrubs, Ferns, Moss, Vines||1||1
+2015-11-21 20:53:43.077753||measurement||ad||2015-11-21 20:53:42.153147@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 20:53:43.077933||measurement||loadtime||0:00:06.262254||1||1
+2015-11-21 20:53:50.368228||measurement||ad||2015-11-21 20:53:50.249124@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:53:50.445073||measurement||ad||2015-11-21 20:53:50.249124@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:53:50.502609||measurement||ad||2015-11-21 20:53:50.249124@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||0||1
+2015-11-21 20:53:50.502855||measurement||loadtime||0:00:04.284738||0||1
+2015-11-21 20:53:50.873616||measurement||ad||2015-11-21 20:53:48.215180@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:53:50.938101||measurement||ad||2015-11-21 20:53:48.215180@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||1
+2015-11-21 20:53:50.991245||measurement||ad||2015-11-21 20:53:48.215180@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 20:53:50.991538||measurement||loadtime||0:00:02.912157||1||1
+2015-11-21 20:54:01.127131||measurement||ad||2015-11-21 20:54:00.686371@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||0||1
+2015-11-21 20:54:01.193891||measurement||ad||2015-11-21 20:54:00.686371@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 20:54:01.411979||measurement||ad||2015-11-21 20:54:00.686371@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:54:01.412248||measurement||loadtime||0:00:05.908900||0||1
+2015-11-21 20:54:01.412578||event||progress-marker||measurement-end||0||1
+2015-11-21 20:54:02.229000||measurement||ad||2015-11-21 20:54:02.135526@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 20:54:02.277831||measurement||ad||2015-11-21 20:54:02.135526@|Plant Sale + Free Ship@|www.onlineplantnursery.com@|Fast Shipping On All Garden Plants Trees, Shrubs, Ferns, Moss, Vines||1||1
+2015-11-21 20:54:02.324213||measurement||ad||2015-11-21 20:54:02.135526@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 20:54:02.324480||measurement||loadtime||0:00:06.332598||1||1
+2015-11-21 20:54:02.324565||event||progress-marker||measurement-end||1||1
+2015-11-21 20:54:02.603271||meta||block_id end||1
+2015-11-21 20:54:02.605024||meta||block_id start||2
+2015-11-21 20:54:02.605065||meta||assignment||2@|3@|1@|0
+2015-11-21 20:54:05.045838||event||progress-marker||training-start||3||0
+2015-11-21 20:54:05.046193||event||progress-marker||training-end||3||0
+2015-11-21 20:54:05.095060||event||progress-marker||training-start||2||0
+2015-11-21 20:54:05.095438||event||progress-marker||training-end||2||0
+2015-11-21 20:54:07.803875||event||progress-marker||training-start||0||1
+2015-11-21 20:54:07.804168||event||progress-marker||training-end||0||1
+2015-11-21 20:54:07.808732||event||progress-marker||training-start||1||1
+2015-11-21 20:54:07.808996||event||progress-marker||training-end||1||1
+2015-11-21 20:54:10.052587||event||progress-marker||measurement-start||3||0
+2015-11-21 20:54:10.101861||event||progress-marker||measurement-start||2||0
+2015-11-21 20:54:12.809331||event||progress-marker||measurement-start||0||1
+2015-11-21 20:54:12.814403||event||progress-marker||measurement-start||1||1
+2015-11-21 20:54:17.816392||measurement||ad||2015-11-21 20:54:16.670852@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:54:17.879934||measurement||ad||2015-11-21 20:54:16.667203@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:54:17.971013||measurement||ad||2015-11-21 20:54:16.670852@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||0
+2015-11-21 20:54:18.306564||measurement||ad||2015-11-21 20:54:16.670852@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||2||0
+2015-11-21 20:54:18.308007||measurement||loadtime||0:00:03.204876||2||0
+2015-11-21 20:54:18.357992||measurement||ad||2015-11-21 20:54:16.667203@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||3||0
+2015-11-21 20:54:18.461035||measurement||ad||2015-11-21 20:54:16.667203@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||0
+2015-11-21 20:54:18.461344||measurement||loadtime||0:00:03.407195||3||0
+2015-11-21 20:54:24.997649||error||collecting ads||Error||2||0
+2015-11-21 20:54:27.753038||measurement||ad||2015-11-21 20:54:25.380189@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:54:28.837768||measurement||ad||2015-11-21 20:54:25.380189@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 20:54:29.299330||measurement||ad||2015-11-21 20:54:28.281831@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:54:29.525344||measurement||ad||2015-11-21 20:54:28.281831@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||1||1
+2015-11-21 20:54:29.727270||measurement||ad||2015-11-21 20:54:28.281831@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||1
+2015-11-21 20:54:29.727549||measurement||loadtime||0:00:11.911953||1||1
+2015-11-21 20:54:30.044626||measurement||ad||2015-11-21 20:54:28.865187@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:54:30.187983||measurement||ad||2015-11-21 20:54:28.865187@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||0||1
+2015-11-21 20:54:30.414014||measurement||ad||2015-11-21 20:54:28.865187@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||0||1
+2015-11-21 20:54:30.415049||measurement||loadtime||0:00:12.604185||0||1
+2015-11-21 20:54:31.413302||error||collecting ads||Error||2||0
+2015-11-21 20:54:31.786396||measurement||ad||2015-11-21 20:54:25.380189@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||3||0
+2015-11-21 20:54:31.786882||measurement||loadtime||0:00:08.324995||3||0
+2015-11-21 20:54:37.814850||error||collecting ads||Error||2||0
+2015-11-21 20:54:39.560535||measurement||ad||2015-11-21 20:54:37.757060@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:54:40.883938||measurement||ad||2015-11-21 20:54:37.757060@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 20:54:43.072774||measurement||ad||2015-11-21 20:54:37.757060@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||3||0
+2015-11-21 20:54:43.073029||measurement||loadtime||0:00:06.285460||3||0
+2015-11-21 20:54:45.339748||measurement||ad||2015-11-21 20:54:45.048356@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:54:45.478487||measurement||ad||2015-11-21 20:54:45.048356@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:54:45.630155||measurement||ad||2015-11-21 20:54:45.048356@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||1
+2015-11-21 20:54:45.630392||measurement||loadtime||0:00:10.901535||1||1
+2015-11-21 20:54:46.008776||measurement||ad||2015-11-21 20:54:45.796855@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:54:46.080536||measurement||ad||2015-11-21 20:54:45.796855@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:54:46.171451||measurement||ad||2015-11-21 20:54:45.796855@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||0||1
+2015-11-21 20:54:46.171792||measurement||loadtime||0:00:10.755048||0||1
+2015-11-21 20:54:46.467548||measurement||ad||2015-11-21 20:54:44.557729@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:54:46.539519||measurement||ad||2015-11-21 20:54:44.557729@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||2||0
+2015-11-21 20:54:46.615264||measurement||ad||2015-11-21 20:54:44.557729@|Social Security Benefits@|www.socialsecurity.gov/MyAccount/@|Get your Social Security benefit verification letter, online now.||2||0
+2015-11-21 20:54:46.615487||measurement||loadtime||0:00:03.799882||2||0
+2015-11-21 20:54:49.772900||measurement||ad||2015-11-21 20:54:48.940701@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:54:49.966605||measurement||ad||2015-11-21 20:54:48.940701@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:54:50.426318||measurement||ad||2015-11-21 20:54:48.940701@|SanDisk Mobile Blog@|sandiskmobility.com@|Find the latest on mobile lifestyle News and trends. Check it out now!||3||0
+2015-11-21 20:54:50.426571||measurement||loadtime||0:00:02.352102||3||0
+2015-11-21 20:54:54.323361||measurement||ad||2015-11-21 20:54:52.654280@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:54:54.549572||measurement||ad||2015-11-21 20:54:52.654280@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:54:54.898063||measurement||ad||2015-11-21 20:54:52.654280@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||0
+2015-11-21 20:54:54.898396||measurement||loadtime||0:00:03.282391||2||0
+2015-11-21 20:54:59.146322||measurement||ad||2015-11-21 20:54:56.708990@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:54:59.926161||measurement||ad||2015-11-21 20:54:59.475054@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:55:00.061100||measurement||ad||2015-11-21 20:54:59.475054@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:55:00.143547||measurement||ad||2015-11-21 20:54:59.475054@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||1
+2015-11-21 20:55:00.143836||measurement||loadtime||0:00:09.512498||1||1
+2015-11-21 20:55:00.265417||measurement||ad||2015-11-21 20:54:56.708990@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 20:55:00.689828||measurement||ad||2015-11-21 20:54:56.708990@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||3||0
+2015-11-21 20:55:00.690087||measurement||loadtime||0:00:05.263043||3||0
+2015-11-21 20:55:01.975533||measurement||ad||2015-11-21 20:55:01.595683@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 20:55:02.158408||measurement||ad||2015-11-21 20:55:01.595683@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 20:55:02.373342||measurement||ad||2015-11-21 20:55:01.595683@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:55:02.373638||measurement||loadtime||0:00:11.201356||0||1
+2015-11-21 20:55:02.507441||measurement||ad||2015-11-21 20:55:00.620909@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:55:02.581755||measurement||ad||2015-11-21 20:55:00.620909@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||0
+2015-11-21 20:55:02.707135||measurement||ad||2015-11-21 20:55:00.620909@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:55:02.707428||measurement||loadtime||0:00:02.807826||2||0
+2015-11-21 20:55:07.785585||measurement||ad||2015-11-21 20:55:06.665116@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 20:55:08.031970||measurement||ad||2015-11-21 20:55:06.665116@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:55:08.856847||measurement||ad||2015-11-21 20:55:06.665116@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||0
+2015-11-21 20:55:08.857290||measurement||loadtime||0:00:03.166722||3||0
+2015-11-21 20:55:11.341852||measurement||ad||2015-11-21 20:55:08.373303@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:55:11.564955||measurement||ad||2015-11-21 20:55:08.373303@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||0
+2015-11-21 20:55:11.703243||measurement||ad||2015-11-21 20:55:08.373303@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||0
+2015-11-21 20:55:11.703532||measurement||loadtime||0:00:03.994823||2||0
+2015-11-21 20:55:13.507970||measurement||ad||2015-11-21 20:55:12.740139@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||1
+2015-11-21 20:55:13.593792||measurement||ad||2015-11-21 20:55:12.740139@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|Confession Of An Acid Reflux Victim "How I Woke Up From My Nightmare"||1||1
+2015-11-21 20:55:13.717577||measurement||ad||2015-11-21 20:55:12.740139@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||1||1
+2015-11-21 20:55:13.717909||measurement||loadtime||0:00:08.572614||1||1
+2015-11-21 20:55:16.064985||measurement||ad||2015-11-21 20:55:14.533121@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||0
+2015-11-21 20:55:16.183719||measurement||ad||2015-11-21 20:55:14.533121@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 20:55:16.439497||measurement||ad||2015-11-21 20:55:14.533121@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 20:55:16.439794||measurement||loadtime||0:00:02.581390||3||0
+2015-11-21 20:55:18.676003||measurement||ad||2015-11-21 20:55:18.485684@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 20:55:18.788630||measurement||ad||2015-11-21 20:55:18.485684@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 20:55:19.081677||measurement||ad||2015-11-21 20:55:18.485684@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:55:19.081952||measurement||loadtime||0:00:11.706931||0||1
+2015-11-21 20:55:19.697255||measurement||ad||2015-11-21 20:55:17.282802@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. Competitive Rates. Apply Online Now||2||0
+2015-11-21 20:55:19.874908||measurement||ad||2015-11-21 20:55:17.282802@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||0
+2015-11-21 20:55:20.024176||measurement||ad||2015-11-21 20:55:17.282802@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||0
+2015-11-21 20:55:20.024527||measurement||loadtime||0:00:03.319636||2||0
+2015-11-21 20:55:23.870956||measurement||ad||2015-11-21 20:55:22.236062@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:55:24.033589||measurement||ad||2015-11-21 20:55:22.236062@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||0
+2015-11-21 20:55:24.290761||measurement||ad||2015-11-21 20:55:22.236062@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||3||0
+2015-11-21 20:55:24.291060||measurement||loadtime||0:00:02.850730||3||0
+2015-11-21 20:55:26.928919||measurement||ad||2015-11-21 20:55:26.453575@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:55:27.170603||measurement||ad||2015-11-21 20:55:26.453575@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:55:27.259401||measurement||ad||2015-11-21 20:55:26.453575@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||1
+2015-11-21 20:55:27.259709||measurement||loadtime||0:00:08.539129||1||1
+2015-11-21 20:55:28.261165||measurement||ad||2015-11-21 20:55:26.270894@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:55:28.539278||measurement||ad||2015-11-21 20:55:26.270894@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:55:28.714484||measurement||ad||2015-11-21 20:55:26.270894@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 20:55:28.714871||measurement||loadtime||0:00:03.689298||2||0
+2015-11-21 20:55:28.715061||event||progress-marker||measurement-end||2||0
+2015-11-21 20:55:31.854631||measurement||ad||2015-11-21 20:55:30.587602@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 20:55:31.926720||measurement||ad||2015-11-21 20:55:30.587602@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 20:55:32.041016||measurement||ad||2015-11-21 20:55:30.587602@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||0
+2015-11-21 20:55:32.041344||measurement||loadtime||0:00:02.748404||3||0
+2015-11-21 20:55:32.678916||measurement||ad||2015-11-21 20:55:32.435557@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:55:32.864778||measurement||ad||2015-11-21 20:55:32.435557@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||0||1
+2015-11-21 20:55:33.003936||measurement||ad||2015-11-21 20:55:32.435557@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:55:33.004283||measurement||loadtime||0:00:08.921844||0||1
+2015-11-21 20:55:39.402054||measurement||ad||2015-11-21 20:55:37.731762@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 20:55:39.991355||measurement||ad||2015-11-21 20:55:37.731762@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||0
+2015-11-21 20:55:40.426100||measurement||ad||2015-11-21 20:55:37.731762@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||3||0
+2015-11-21 20:55:40.426347||measurement||loadtime||0:00:03.384592||3||0
+2015-11-21 20:55:40.426460||event||progress-marker||measurement-end||3||0
+2015-11-21 20:55:41.614173||measurement||ad||2015-11-21 20:55:41.386920@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:55:41.708721||measurement||ad||2015-11-21 20:55:41.386920@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 20:55:41.784175||measurement||ad||2015-11-21 20:55:41.386920@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||1
+2015-11-21 20:55:41.784466||measurement||loadtime||0:00:09.524286||1||1
+2015-11-21 20:55:43.238244||measurement||ad||2015-11-21 20:55:38.219626@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||0||1
+2015-11-21 20:55:43.311845||measurement||ad||2015-11-21 20:55:38.219626@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 20:55:43.363776||measurement||ad||2015-11-21 20:55:38.219626@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:55:43.364020||measurement||loadtime||0:00:05.358405||0||1
+2015-11-21 20:55:48.905917||measurement||ad||2015-11-21 20:55:46.912709@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:55:50.533321||measurement||ad||2015-11-21 20:55:46.912709@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:55:50.615551||measurement||ad||2015-11-21 20:55:46.912709@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||1
+2015-11-21 20:55:50.615867||measurement||loadtime||0:00:03.830572||1||1
+2015-11-21 20:55:53.345154||measurement||ad||2015-11-21 20:55:53.242048@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||0||1
+2015-11-21 20:55:53.427516||measurement||ad||2015-11-21 20:55:53.242048@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 20:55:53.500654||measurement||ad||2015-11-21 20:55:53.242048@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 20:55:53.500900||measurement||loadtime||0:00:05.136335||0||1
+2015-11-21 20:56:00.561731||measurement||ad||2015-11-21 20:56:00.311479@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|Confession Of An Acid Reflux Victim "How I Woke Up From My Nightmare"||1||1
+2015-11-21 20:56:00.746209||measurement||ad||2015-11-21 20:56:00.311479@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||1||1
+2015-11-21 20:56:00.950517||measurement||ad||2015-11-21 20:56:00.311479@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 20:56:00.951583||measurement||loadtime||0:00:05.334057||1||1
+2015-11-21 20:56:03.392596||measurement||ad||2015-11-21 20:56:03.191342@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||0||1
+2015-11-21 20:56:03.523807||measurement||ad||2015-11-21 20:56:03.191342@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 20:56:03.613678||measurement||ad||2015-11-21 20:56:03.191342@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 20:56:03.613961||measurement||loadtime||0:00:05.112404||0||1
+2015-11-21 20:56:10.549703||measurement||ad||2015-11-21 20:56:10.359463@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 20:56:10.613422||measurement||ad||2015-11-21 20:56:10.359463@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 20:56:10.683232||measurement||ad||2015-11-21 20:56:10.359463@|General Insurance $18/Mo@|www.general-insurance.com@|The Cheapest General Car Insurance. (Get General Rates from $18/Month!)||1||1
+2015-11-21 20:56:10.683546||measurement||loadtime||0:00:04.730287||1||1
+2015-11-21 20:56:12.868622||measurement||ad||2015-11-21 20:56:12.692985@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 20:56:12.968097||measurement||ad||2015-11-21 20:56:12.692985@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 20:56:13.078135||measurement||ad||2015-11-21 20:56:12.692985@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:56:13.078391||measurement||loadtime||0:00:04.464126||0||1
+2015-11-21 20:56:20.914900||measurement||ad||2015-11-21 20:56:20.056801@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Apply Online Now.||1||1
+2015-11-21 20:56:21.014992||measurement||ad||2015-11-21 20:56:20.056801@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 20:56:21.110879||measurement||ad||2015-11-21 20:56:20.056801@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||1
+2015-11-21 20:56:21.111135||measurement||loadtime||0:00:05.426028||1||1
+2015-11-21 20:56:21.111231||event||progress-marker||measurement-end||1||1
+2015-11-21 20:56:23.268137||measurement||ad||2015-11-21 20:56:23.131953@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:56:23.392802||measurement||ad||2015-11-21 20:56:23.131953@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:56:23.516739||measurement||ad||2015-11-21 20:56:23.131953@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||0||1
+2015-11-21 20:56:23.517070||measurement||loadtime||0:00:05.438136||0||1
+2015-11-21 20:56:23.517207||event||progress-marker||measurement-end||0||1
+2015-11-21 20:56:23.751620||meta||block_id end||2
+2015-11-21 20:56:23.752867||meta||block_id start||3
+2015-11-21 20:56:23.752907||meta||assignment||1@|2@|0@|3
+2015-11-21 20:56:26.101567||event||progress-marker||training-start||2||0
+2015-11-21 20:56:26.101898||event||progress-marker||training-end||2||0
+2015-11-21 20:56:26.147193||event||progress-marker||training-start||1||0
+2015-11-21 20:56:26.147633||event||progress-marker||training-end||1||0
+2015-11-21 20:56:28.939481||event||progress-marker||training-start||0||1
+2015-11-21 20:56:28.939471||event||progress-marker||training-start||3||1
+2015-11-21 20:56:28.939769||event||progress-marker||training-end||3||1
+2015-11-21 20:56:28.939812||event||progress-marker||training-end||0||1
+2015-11-21 20:56:31.109794||event||progress-marker||measurement-start||2||0
+2015-11-21 20:56:31.154924||event||progress-marker||measurement-start||1||0
+2015-11-21 20:56:33.946897||event||progress-marker||measurement-start||3||1
+2015-11-21 20:56:33.946971||event||progress-marker||measurement-start||0||1
+2015-11-21 20:56:38.436011||measurement||ad||2015-11-21 20:56:37.853792@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 20:56:38.921191||measurement||ad||2015-11-21 20:56:37.866435@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:56:39.386978||measurement||ad||2015-11-21 20:56:37.853792@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||0
+2015-11-21 20:56:39.586928||measurement||ad||2015-11-21 20:56:37.866435@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:56:39.713467||measurement||ad||2015-11-21 20:56:37.866435@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 20:56:39.713820||measurement||loadtime||0:00:03.602357||2||0
+2015-11-21 20:56:39.845111||measurement||ad||2015-11-21 20:56:37.853792@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 20:56:39.845408||measurement||loadtime||0:00:03.689748||1||0
+2015-11-21 20:56:48.427106||measurement||ad||2015-11-21 20:56:46.413613@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||1||0
+2015-11-21 20:56:48.427307||measurement||ad||2015-11-21 20:56:46.357461@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-21 20:56:48.593954||measurement||ad||2015-11-21 20:56:46.413613@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 20:56:48.649184||measurement||ad||2015-11-21 20:56:46.357461@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||2||0
+2015-11-21 20:56:48.751501||measurement||ad||2015-11-21 20:56:46.413613@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 20:56:48.751798||measurement||loadtime||0:00:03.905321||1||0
+2015-11-21 20:56:49.717111||measurement||ad||2015-11-21 20:56:48.969482@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 20:56:49.843626||measurement||ad||2015-11-21 20:56:48.969482@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 20:56:49.964402||measurement||ad||2015-11-21 20:56:48.969482@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 20:56:49.964703||measurement||loadtime||0:00:11.013929||0||1
+2015-11-21 20:56:50.143070||measurement||ad||2015-11-21 20:56:46.357461@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||0
+2015-11-21 20:56:50.148099||measurement||loadtime||0:00:05.432774||2||0
+2015-11-21 20:56:53.147071||measurement||ad||2015-11-21 20:56:50.755595@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:56:53.598707||measurement||ad||2015-11-21 20:56:50.755595@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 20:56:54.109372||measurement||ad||2015-11-21 20:56:50.755595@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||1
+2015-11-21 20:56:54.109856||measurement||loadtime||0:00:15.159115||3||1
+2015-11-21 20:56:57.120078||measurement||ad||2015-11-21 20:56:54.878512@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 20:56:57.246482||measurement||ad||2015-11-21 20:56:54.878512@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 20:56:57.742645||measurement||ad||2015-11-21 20:56:54.878512@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||1||0
+2015-11-21 20:56:57.742915||measurement||loadtime||0:00:03.990193||1||0
+2015-11-21 20:56:57.797500||measurement||ad||2015-11-21 20:56:56.513306@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:56:58.012382||measurement||ad||2015-11-21 20:56:56.513306@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:56:58.193081||measurement||ad||2015-11-21 20:56:56.513306@|Top 5 Wrinkle Creams@|www.iskincarereviews.com@|The best anti-aging creams of 2015 reviewed by customers like you!||2||0
+2015-11-21 20:56:58.193347||measurement||loadtime||0:00:03.044249||2||0
+2015-11-21 20:57:03.719152||measurement||ad||2015-11-21 20:57:03.237670@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||0||1
+2015-11-21 20:57:04.172706||measurement||ad||2015-11-21 20:57:03.237670@|$59 Miami Vacation Deal@|www.getawaydealz.com/Miami_Beach@|3 Days in Oceanfront Miami Beach Hotel From $59 - Not Per Night!||0||1
+2015-11-21 20:57:04.311667||measurement||ad||2015-11-21 20:57:03.237670@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||0||1
+2015-11-21 20:57:04.311974||measurement||loadtime||0:00:09.346613||0||1
+2015-11-21 20:57:05.931006||measurement||ad||2015-11-21 20:57:03.985223@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||1||0
+2015-11-21 20:57:06.186702||measurement||ad||2015-11-21 20:57:04.376762@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||2||0
+2015-11-21 20:57:06.186979||measurement||loadtime||0:00:02.993119||2||0
+2015-11-21 20:57:06.520102||measurement||ad||2015-11-21 20:57:03.985223@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 20:57:07.106087||measurement||ad||2015-11-21 20:57:03.985223@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 20:57:07.106471||measurement||loadtime||0:00:04.363117||1||0
+2015-11-21 20:57:13.607047||measurement||ad||2015-11-21 20:57:11.736006@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:57:13.761171||measurement||ad||2015-11-21 20:57:09.088832@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:57:13.847080||measurement||ad||2015-11-21 20:57:09.088832@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 20:57:13.918916||measurement||ad||2015-11-21 20:57:09.088832@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:57:13.919179||measurement||loadtime||0:00:14.808666||3||1
+2015-11-21 20:57:14.715706||measurement||ad||2015-11-21 20:57:11.736006@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||2||0
+2015-11-21 20:57:14.774021||measurement||ad||2015-11-21 20:57:13.230327@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 20:57:14.887015||measurement||ad||2015-11-21 20:57:13.230327@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 20:57:15.057392||measurement||ad||2015-11-21 20:57:13.230327@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||1||0
+2015-11-21 20:57:15.057683||measurement||loadtime||0:00:02.950451||1||0
+2015-11-21 20:57:15.062360||measurement||ad||2015-11-21 20:57:11.736006@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:57:15.062702||measurement||loadtime||0:00:03.875311||2||0
+2015-11-21 20:57:17.470030||measurement||ad||2015-11-21 20:57:16.948292@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||0||1
+2015-11-21 20:57:17.601303||measurement||ad||2015-11-21 20:57:16.948292@|$59 Miami Vacation Deal@|www.getawaydealz.com/Miami_Beach@|3 Days in Oceanfront Miami Beach Hotel From $59 - Not Per Night!||0||1
+2015-11-21 20:57:17.692425||measurement||ad||2015-11-21 20:57:16.948292@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||0||1
+2015-11-21 20:57:17.692805||measurement||loadtime||0:00:08.380099||0||1
+2015-11-21 20:57:22.387450||measurement||ad||2015-11-21 20:57:21.028847@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 20:57:22.742280||measurement||ad||2015-11-21 20:57:20.677469@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-21 20:57:23.894841||measurement||ad||2015-11-21 20:57:21.028847@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 20:57:25.177284||measurement||ad||2015-11-21 20:57:20.677469@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 20:57:25.363899||measurement||ad||2015-11-21 20:57:20.677469@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:57:25.364317||measurement||loadtime||0:00:05.300493||2||0
+2015-11-21 20:57:25.690523||measurement||ad||2015-11-21 20:57:21.028847@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||1||0
+2015-11-21 20:57:25.690887||measurement||loadtime||0:00:05.632611||1||0
+2015-11-21 20:57:26.872217||measurement||ad||2015-11-21 20:57:26.450443@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 20:57:26.981779||measurement||ad||2015-11-21 20:57:26.450443@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:57:27.061208||measurement||ad||2015-11-21 20:57:26.450443@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 20:57:27.061656||measurement||loadtime||0:00:08.141626||3||1
+2015-11-21 20:57:33.118823||measurement||ad||2015-11-21 20:57:31.391748@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:57:33.434223||measurement||ad||2015-11-21 20:57:31.391748@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:57:33.512218||measurement||ad||2015-11-21 20:57:31.449506@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||1||0
+2015-11-21 20:57:33.692263||measurement||ad||2015-11-21 20:57:31.449506@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 20:57:33.756847||measurement||ad||2015-11-21 20:57:31.391748@|Top 5 Wrinkle Creams@|www.iskincarereviews.com@|The best anti-aging creams of 2015 reviewed by customers like you!||2||0
+2015-11-21 20:57:33.757118||measurement||loadtime||0:00:03.392299||2||0
+2015-11-21 20:57:34.451373||measurement||ad||2015-11-21 20:57:31.449506@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 20:57:34.451707||measurement||loadtime||0:00:03.760045||1||0
+2015-11-21 20:57:35.686244||measurement||ad||2015-11-21 20:57:35.335981@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:57:35.789519||measurement||ad||2015-11-21 20:57:35.335981@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||0||1
+2015-11-21 20:57:35.993707||measurement||ad||2015-11-21 20:57:35.335981@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 20:57:35.993973||measurement||loadtime||0:00:13.300310||0||1
+2015-11-21 20:57:39.516439||measurement||ad||2015-11-21 20:57:38.716053@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:57:39.592681||measurement||ad||2015-11-21 20:57:38.716053@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:57:39.675870||measurement||ad||2015-11-21 20:57:38.716053@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||1
+2015-11-21 20:57:39.676167||measurement||loadtime||0:00:07.613663||3||1
+2015-11-21 20:57:41.137172||measurement||ad||2015-11-21 20:57:39.700690@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:57:41.312093||measurement||ad||2015-11-21 20:57:39.700690@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||2||0
+2015-11-21 20:57:41.819827||measurement||ad||2015-11-21 20:57:39.700690@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 20:57:41.820123||measurement||loadtime||0:00:03.062388||2||0
+2015-11-21 20:57:42.773909||measurement||ad||2015-11-21 20:57:40.488956@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 20:57:43.341930||measurement||ad||2015-11-21 20:57:40.488956@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 20:57:45.759786||measurement||ad||2015-11-21 20:57:40.488956@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||1||0
+2015-11-21 20:57:45.760401||measurement||loadtime||0:00:06.307799||1||0
+2015-11-21 20:57:50.237469||measurement||ad||2015-11-21 20:57:47.870006@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:57:51.174410||measurement||ad||2015-11-21 20:57:47.870006@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:57:51.389573||measurement||ad||2015-11-21 20:57:44.833709@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:57:51.747191||measurement||ad||2015-11-21 20:57:44.833709@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 20:57:52.050851||measurement||ad||2015-11-21 20:57:44.833709@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:57:52.051128||measurement||loadtime||0:00:07.373964||3||1
+2015-11-21 20:57:52.248329||measurement||ad||2015-11-21 20:57:51.179542@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 20:57:52.324908||measurement||ad||2015-11-21 20:57:47.870006@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||0
+2015-11-21 20:57:52.325679||measurement||loadtime||0:00:05.504507||2||0
+2015-11-21 20:57:53.225679||measurement||ad||2015-11-21 20:57:51.179542@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 20:57:54.276468||measurement||ad||2015-11-21 20:57:51.934962@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||1||0
+2015-11-21 20:57:54.321770||measurement||ad||2015-11-21 20:57:51.179542@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 20:57:54.322234||measurement||loadtime||0:00:13.327222||0||1
+2015-11-21 20:57:54.441217||measurement||ad||2015-11-21 20:57:51.934962@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||0
+2015-11-21 20:57:54.840947||measurement||ad||2015-11-21 20:57:51.934962@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 20:57:54.841253||measurement||loadtime||0:00:04.079730||1||0
+2015-11-21 20:58:00.550818||measurement||ad||2015-11-21 20:57:58.268466@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 20:58:00.792565||measurement||ad||2015-11-21 20:57:58.268466@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 20:58:01.973003||measurement||ad||2015-11-21 20:57:58.268466@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||0
+2015-11-21 20:58:01.973320||measurement||loadtime||0:00:04.646572||2||0
+2015-11-21 20:58:01.973515||event||progress-marker||measurement-end||2||0
+2015-11-21 20:58:02.827529||measurement||ad||2015-11-21 20:58:00.829385@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 20:58:03.044872||measurement||ad||2015-11-21 20:58:00.829385@|Drone Technology Advances@|analog.com/DJI-Drone-Technology@|ADI Helps DJI Create Drones Packed With Advanced Features. Read More.||1||0
+2015-11-21 20:58:03.253130||measurement||ad||2015-11-21 20:58:00.829385@|Masters in IT Management@|www.missouriwestern.edu/graduate@|Learn valuable business skills for IT professionals and get ahead||1||0
+2015-11-21 20:58:03.253369||measurement||loadtime||0:00:03.410752||1||0
+2015-11-21 20:58:03.253821||event||progress-marker||measurement-end||1||0
+2015-11-21 20:58:05.844747||measurement||ad||2015-11-21 20:58:05.213124@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 20:58:05.947168||measurement||ad||2015-11-21 20:58:05.213124@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 20:58:06.014639||measurement||ad||2015-11-21 20:58:05.213124@|Free Ecuador Fact Sheet@|www.internationalliving.com/Ecuador@|For people considering retiring, visiting, or living in Ecuador||3||1
+2015-11-21 20:58:06.014981||measurement||loadtime||0:00:08.962544||3||1
+2015-11-21 20:58:07.171960||measurement||ad||2015-11-21 20:58:06.962705@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:58:07.271241||measurement||ad||2015-11-21 20:58:06.962705@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:58:07.331301||measurement||ad||2015-11-21 20:58:06.962705@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||0||1
+2015-11-21 20:58:07.331530||measurement||loadtime||0:00:08.007810||0||1
+2015-11-21 20:58:15.984241||measurement||ad||2015-11-21 20:58:15.628189@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:58:16.224592||measurement||ad||2015-11-21 20:58:15.628189@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:58:16.462702||measurement||ad||2015-11-21 20:58:15.628189@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-21 20:58:16.462939||measurement||loadtime||0:00:05.446693||3||1
+2015-11-21 20:58:17.003562||measurement||ad||2015-11-21 20:58:16.909931@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:58:17.062341||measurement||ad||2015-11-21 20:58:16.909931@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:58:17.116939||measurement||ad||2015-11-21 20:58:16.909931@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||1
+2015-11-21 20:58:17.117213||measurement||loadtime||0:00:04.784554||0||1
+2015-11-21 20:58:25.138792||measurement||ad||2015-11-21 20:58:24.938780@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 20:58:25.215434||measurement||ad||2015-11-21 20:58:24.938780@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 20:58:25.293787||measurement||ad||2015-11-21 20:58:24.938780@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||1
+2015-11-21 20:58:25.294000||measurement||loadtime||0:00:03.830052||3||1
+2015-11-21 20:58:28.690695||measurement||ad||2015-11-21 20:58:28.355677@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:58:28.786051||measurement||ad||2015-11-21 20:58:28.355677@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 20:58:28.868623||measurement||ad||2015-11-21 20:58:28.355677@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||0||1
+2015-11-21 20:58:28.868889||measurement||loadtime||0:00:06.751106||0||1
+2015-11-21 20:58:36.088066||measurement||ad||2015-11-21 20:58:35.779340@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:58:36.205647||measurement||ad||2015-11-21 20:58:35.779340@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:58:36.290400||measurement||ad||2015-11-21 20:58:35.779340@|Apply for Passport Online@|expresspassport.com@|Don't Wait In Line - Apply Online Passports In As Little As 24 Hours.||3||1
+2015-11-21 20:58:36.290669||measurement||loadtime||0:00:05.995952||3||1
+2015-11-21 20:58:37.965263||measurement||ad||2015-11-21 20:58:37.347646@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-21 20:58:38.121384||measurement||ad||2015-11-21 20:58:37.347646@|$59 Miami Vacation Deal@|www.getawaydealz.com/Miami_Beach@|3 Days in Oceanfront Miami Beach Hotel From $59 - Not Per Night!||0||1
+2015-11-21 20:58:38.258958||measurement||ad||2015-11-21 20:58:37.347646@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||0||1
+2015-11-21 20:58:38.259310||measurement||loadtime||0:00:04.390002||0||1
+2015-11-21 20:58:46.911594||measurement||ad||2015-11-21 20:58:46.809800@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 20:58:47.017170||measurement||ad||2015-11-21 20:58:46.809800@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 20:58:47.078183||measurement||ad||2015-11-21 20:58:46.809800@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 20:58:47.078475||measurement||loadtime||0:00:05.787380||3||1
+2015-11-21 20:58:47.079177||event||progress-marker||measurement-end||3||1
+2015-11-21 20:58:48.432713||measurement||ad||2015-11-21 20:58:48.234165@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||0||1
+2015-11-21 20:58:48.508763||measurement||ad||2015-11-21 20:58:48.234165@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 20:58:48.556274||measurement||ad||2015-11-21 20:58:48.234165@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 20:58:48.556579||measurement||loadtime||0:00:05.296746||0||1
+2015-11-21 20:58:48.556747||event||progress-marker||measurement-end||0||1
+2015-11-21 20:58:48.813537||meta||block_id end||3
+2015-11-21 20:58:48.816146||meta||block_id start||4
+2015-11-21 20:58:48.816197||meta||assignment||2@|0@|1@|3
+2015-11-21 20:58:51.242898||event||progress-marker||training-start||2||0
+2015-11-21 20:58:51.243233||event||progress-marker||training-end||2||0
+2015-11-21 20:58:51.259304||event||progress-marker||training-start||0||0
+2015-11-21 20:58:51.259683||event||progress-marker||training-end||0||0
+2015-11-21 20:58:54.007659||event||progress-marker||training-start||3||1
+2015-11-21 20:58:54.007977||event||progress-marker||training-end||3||1
+2015-11-21 20:58:54.028308||event||progress-marker||training-start||1||1
+2015-11-21 20:58:54.028546||event||progress-marker||training-end||1||1
+2015-11-21 20:58:56.253688||event||progress-marker||measurement-start||2||0
+2015-11-21 20:58:56.269387||event||progress-marker||measurement-start||0||0
+2015-11-21 20:58:59.016548||event||progress-marker||measurement-start||3||1
+2015-11-21 20:58:59.037017||event||progress-marker||measurement-start||1||1
+2015-11-21 20:59:05.213431||measurement||ad||2015-11-21 20:59:03.490532@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:59:05.244848||measurement||ad||2015-11-21 20:59:03.430245@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 20:59:05.488865||measurement||ad||2015-11-21 20:59:03.490532@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||2||0
+2015-11-21 20:59:05.575693||measurement||ad||2015-11-21 20:59:03.430245@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 20:59:06.076998||measurement||ad||2015-11-21 20:59:03.490532@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||0
+2015-11-21 20:59:06.077309||measurement||loadtime||0:00:04.822055||2||0
+2015-11-21 20:59:06.155547||measurement||ad||2015-11-21 20:59:03.430245@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||0
+2015-11-21 20:59:06.155954||measurement||loadtime||0:00:04.886038||0||0
+2015-11-21 20:59:12.094867||error||collecting ads||Error||2||0
+2015-11-21 20:59:14.239092||measurement||ad||2015-11-21 20:59:13.518583@|Business Loan@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 20:59:14.450104||measurement||ad||2015-11-21 20:59:13.518583@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||1
+2015-11-21 20:59:14.459396||measurement||ad||2015-11-21 20:59:12.502098@|5 Dementia Warning Signs@|w3.blaylockwellness.com@|Know The 5 Warning Signs That May Lead To Dementia||0||0
+2015-11-21 20:59:14.871754||measurement||ad||2015-11-21 20:59:13.518583@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 20:59:14.872050||measurement||loadtime||0:00:10.854744||3||1
+2015-11-21 20:59:16.771273||measurement||ad||2015-11-21 20:59:12.502098@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-21 20:59:17.466797||measurement||ad||2015-11-21 20:59:15.494187@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 20:59:18.161579||measurement||ad||2015-11-21 20:59:15.494187@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||1
+2015-11-21 20:59:18.224011||measurement||ad||2015-11-21 20:59:12.502098@|Get In Now With Graphene@|outsiderclub.com/Graphene@|Money-Making Mineral Set To Launch Can Shape The World And Your Wealth||0||0
+2015-11-21 20:59:18.224426||measurement||loadtime||0:00:07.067496||0||0
+2015-11-21 20:59:18.346332||measurement||ad||2015-11-21 20:59:15.494187@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 20:59:18.346636||measurement||loadtime||0:00:14.309151||1||1
+2015-11-21 20:59:21.623173||measurement||ad||2015-11-21 20:59:18.752408@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:59:21.754677||measurement||ad||2015-11-21 20:59:18.752408@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 20:59:21.907064||measurement||ad||2015-11-21 20:59:18.752408@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:59:21.907367||measurement||loadtime||0:00:04.810361||2||0
+2015-11-21 20:59:26.591062||measurement||ad||2015-11-21 20:59:24.472160@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||0
+2015-11-21 20:59:27.067602||measurement||ad||2015-11-21 20:59:24.472160@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||0||0
+2015-11-21 20:59:27.726576||measurement||ad||2015-11-21 20:59:24.472160@|Graphene: Miracle Mineral@|outsiderclub.com/Graphene@|Graphene Will “Change The World” Find Out How You Can Invest Now.||0||0
+2015-11-21 20:59:27.726909||measurement||loadtime||0:00:04.501598||0||0
+2015-11-21 20:59:28.400015||measurement||ad||2015-11-21 20:59:27.721259@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 20:59:28.710418||measurement||ad||2015-11-21 20:59:27.721259@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 20:59:29.092356||measurement||ad||2015-11-21 20:59:27.721259@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 20:59:29.092638||measurement||loadtime||0:00:09.219987||3||1
+2015-11-21 20:59:30.266147||measurement||ad||2015-11-21 20:59:28.011431@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:59:30.380276||measurement||ad||2015-11-21 20:59:28.011431@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:59:30.844031||measurement||ad||2015-11-21 20:59:28.011431@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 20:59:30.844357||measurement||loadtime||0:00:03.935880||2||0
+2015-11-21 20:59:35.541994||measurement||ad||2015-11-21 20:59:33.693507@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 20:59:35.803636||measurement||ad||2015-11-21 20:59:33.693507@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 20:59:36.148470||measurement||ad||2015-11-21 20:59:33.693507@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||0||0
+2015-11-21 20:59:36.149202||measurement||loadtime||0:00:03.421792||0||0
+2015-11-21 20:59:38.575161||measurement||ad||2015-11-21 20:59:37.012978@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:59:38.865221||measurement||ad||2015-11-21 20:59:37.012978@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:59:39.099024||measurement||ad||2015-11-21 20:59:37.012978@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:59:39.099281||measurement||loadtime||0:00:03.254348||2||0
+2015-11-21 20:59:41.652217||measurement||ad||2015-11-21 20:59:41.129950@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 20:59:41.823581||measurement||ad||2015-11-21 20:59:41.129950@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 20:59:41.972939||measurement||ad||2015-11-21 20:59:41.129950@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 20:59:41.973246||measurement||loadtime||0:00:07.880000||3||1
+2015-11-21 20:59:43.067015||measurement||ad||2015-11-21 20:59:41.988808@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 20:59:43.204078||measurement||ad||2015-11-21 20:59:41.988808@|Purchase Order Financing@|www.kingtradecapital.com@|Fast - Largest PO Finance Provider Flexibility, Expertise and Capacity||0||0
+2015-11-21 20:59:43.307502||measurement||ad||2015-11-21 20:59:41.988808@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||0
+2015-11-21 20:59:43.307826||measurement||loadtime||0:00:02.157758||0||0
+2015-11-21 20:59:46.310534||measurement||ad||2015-11-21 20:59:44.972620@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 20:59:46.472778||measurement||ad||2015-11-21 20:59:44.972620@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 20:59:46.626597||measurement||ad||2015-11-21 20:59:44.972620@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 20:59:46.626918||measurement||loadtime||0:00:02.526016||2||0
+2015-11-21 20:59:49.489258||error||collecting ads||Error||0||0
+2015-11-21 20:59:54.962956||measurement||ad||2015-11-21 20:59:52.095800@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 20:59:55.124146||measurement||ad||2015-11-21 20:59:52.095800@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||2||0
+2015-11-21 20:59:55.289879||measurement||ad||2015-11-21 20:59:54.740723@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 20:59:55.450496||measurement||ad||2015-11-21 20:59:54.740723@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 20:59:55.665187||measurement||ad||2015-11-21 20:59:54.740723@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-21 20:59:55.665710||measurement||loadtime||0:00:08.691095||3||1
+2015-11-21 20:59:55.999825||error||collecting ads||Error||0||0
+2015-11-21 20:59:57.668911||measurement||ad||2015-11-21 20:59:52.095800@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||0
+2015-11-21 20:59:57.669813||measurement||loadtime||0:00:06.042148||2||0
+2015-11-21 21:00:04.060593||measurement||ad||2015-11-21 21:00:02.314590@|5 Dementia Warning Signs@|w3.blaylockwellness.com@|Know The 5 Warning Signs That May Lead To Dementia||0||0
+2015-11-21 21:00:04.295089||measurement||ad||2015-11-21 21:00:02.314590@|Get In Now With Graphene@|outsiderclub.com/Graphene@|Money-Making Mineral Set To Launch Can Shape The World And Your Wealth||0||0
+2015-11-21 21:00:05.144839||measurement||ad||2015-11-21 21:00:02.314590@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||0
+2015-11-21 21:00:05.145192||measurement||loadtime||0:00:04.143434||0||0
+2015-11-21 21:00:05.357731||measurement||ad||2015-11-21 21:00:03.505084@|Get Uber Discount Voucher@|get.uber.com/free_credit@|Start Riding Today, No Cash Needed. Get Credit for Uber. Sign Up Now!||2||0
+2015-11-21 21:00:05.551096||measurement||ad||2015-11-21 21:00:03.505084@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:00:05.698465||measurement||ad||2015-11-21 21:00:03.505084@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||2||0
+2015-11-21 21:00:05.698752||measurement||loadtime||0:00:03.027930||2||0
+2015-11-21 21:00:07.910295||measurement||ad||2015-11-21 21:00:07.589118@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:00:07.985550||measurement||ad||2015-11-21 21:00:07.589118@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:00:08.042849||measurement||ad||2015-11-21 21:00:07.589118@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:00:08.043164||measurement||loadtime||0:00:44.695785||1||1
+2015-11-21 21:00:09.203527||measurement||ad||2015-11-21 21:00:08.956950@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:00:09.360033||measurement||ad||2015-11-21 21:00:08.956950@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:00:09.421970||measurement||ad||2015-11-21 21:00:08.956950@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-21 21:00:09.422307||measurement||loadtime||0:00:08.755471||3||1
+2015-11-21 21:00:12.605955||measurement||ad||2015-11-21 21:00:10.741063@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:00:12.640351||measurement||ad||2015-11-21 21:00:11.388309@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:00:12.772326||measurement||ad||2015-11-21 21:00:10.741063@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||0||0
+2015-11-21 21:00:12.787993||measurement||ad||2015-11-21 21:00:11.388309@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:00:12.865280||measurement||ad||2015-11-21 21:00:10.741063@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||0
+2015-11-21 21:00:12.865603||measurement||loadtime||0:00:02.719277||0||0
+2015-11-21 21:00:12.868517||measurement||ad||2015-11-21 21:00:11.388309@|ENTACT Environmental@|www.entact.com@|Remediation Services  Solutions US, Canada, Mexico, International||2||0
+2015-11-21 21:00:12.868696||measurement||loadtime||0:00:02.168941||2||0
+2015-11-21 21:00:21.058571||measurement||ad||2015-11-21 21:00:19.198927@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||0
+2015-11-21 21:00:21.236243||measurement||ad||2015-11-21 21:00:19.407663@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:00:21.245327||measurement||ad||2015-11-21 21:00:19.198927@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||0||0
+2015-11-21 21:00:21.364147||measurement||ad||2015-11-21 21:00:19.407663@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. Competitive Rates. Apply Online Now||2||0
+2015-11-21 21:00:21.449231||measurement||ad||2015-11-21 21:00:19.198927@|Graphene: Miracle Mineral@|outsiderclub.com/Graphene@|Graphene Will “Change The World” Find Out How You Can Invest Now.||0||0
+2015-11-21 21:00:21.449554||measurement||loadtime||0:00:03.583490||0||0
+2015-11-21 21:00:21.449781||event||progress-marker||measurement-end||0||0
+2015-11-21 21:00:21.730730||measurement||ad||2015-11-21 21:00:19.407663@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||0
+2015-11-21 21:00:21.731038||measurement||loadtime||0:00:03.861937||2||0
+2015-11-21 21:00:21.731360||event||progress-marker||measurement-end||2||0
+2015-11-21 21:00:23.971433||measurement||ad||2015-11-21 21:00:23.036012@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 21:00:24.054069||measurement||ad||2015-11-21 21:00:23.036012@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:00:24.110345||measurement||ad||2015-11-21 21:00:23.036012@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:00:24.110623||measurement||loadtime||0:00:09.687401||3||1
+2015-11-21 21:00:33.479978||measurement||ad||2015-11-21 21:00:33.380392@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 21:00:33.574108||measurement||ad||2015-11-21 21:00:33.380392@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:00:33.624052||measurement||ad||2015-11-21 21:00:33.380392@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:00:33.624351||measurement||loadtime||0:00:04.512534||3||1
+2015-11-21 21:00:43.988018||measurement||ad||2015-11-21 21:00:43.886986@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:00:44.052721||measurement||ad||2015-11-21 21:00:43.886986@|Fora Financial@|forafinancial.com/Business+Credit+Loans@|Get Working Capital Up To $250K. Terms Up To 18 Months. Apply Now!||3||1
+2015-11-21 21:00:44.101206||measurement||ad||2015-11-21 21:00:43.886986@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:00:44.101455||measurement||loadtime||0:00:05.476637||3||1
+2015-11-21 21:00:51.018486||measurement||ad||2015-11-21 21:00:49.319000@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 21:00:51.341368||measurement||ad||2015-11-21 21:00:49.319000@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:00:51.566351||measurement||ad||2015-11-21 21:00:49.319000@|Clinical Research Classes@|www.cra-training.com@|Clinical Research Training CRA Education  Training Program||3||1
+2015-11-21 21:00:51.566607||measurement||loadtime||0:00:02.464203||3||1
+2015-11-21 21:01:00.538159||measurement||ad||2015-11-21 21:01:00.067097@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:01:00.644408||measurement||ad||2015-11-21 21:01:00.067097@|Clinical Research Classes@|www.cra-training.com@|Clinical Research Training CRA Education  Training Program||3||1
+2015-11-21 21:01:00.704179||measurement||ad||2015-11-21 21:01:00.067097@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-21 21:01:00.704452||measurement||loadtime||0:00:04.136392||3||1
+2015-11-21 21:01:00.704539||event||progress-marker||measurement-end||3||1
+2015-11-21 21:01:30.262759||measurement||ad||2015-11-21 21:00:22.608516@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||1
+2015-11-21 21:01:30.308209||measurement||ad||2015-11-21 21:00:22.608516@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:01:30.345940||measurement||ad||2015-11-21 21:00:22.608516@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:01:30.346167||measurement||loadtime||0:01:17.301342||1||1
+2015-11-21 21:01:40.391713||measurement||ad||2015-11-21 21:01:40.217067@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:01:40.480845||measurement||ad||2015-11-21 21:01:40.217067@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:01:40.540857||measurement||ad||2015-11-21 21:01:40.217067@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:01:40.541078||measurement||loadtime||0:00:05.193540||1||1
+2015-11-21 21:01:50.272443||measurement||ad||2015-11-21 21:01:50.198362@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:01:50.325633||measurement||ad||2015-11-21 21:01:50.198362@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:01:50.364260||measurement||ad||2015-11-21 21:01:50.198362@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:01:50.364537||measurement||loadtime||0:00:04.823150||1||1
+2015-11-21 21:01:59.070985||measurement||ad||2015-11-21 21:01:58.995718@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||1
+2015-11-21 21:01:59.071273||measurement||loadtime||0:00:03.705951||1||1
+2015-11-21 21:02:06.983571||measurement||ad||2015-11-21 21:02:06.851406@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||1
+2015-11-21 21:02:06.983766||measurement||loadtime||0:00:02.910992||1||1
+2015-11-21 21:02:13.504942||measurement||ad||2015-11-21 21:02:12.103897@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:02:13.603696||measurement||ad||2015-11-21 21:02:12.103897@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:02:14.757027||measurement||ad||2015-11-21 21:02:12.103897@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:02:14.757341||measurement||loadtime||0:00:02.772252||1||1
+2015-11-21 21:02:23.479463||measurement||ad||2015-11-21 21:02:23.310613@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:02:23.522318||measurement||ad||2015-11-21 21:02:23.310613@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:02:23.561186||measurement||ad||2015-11-21 21:02:23.310613@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||1||1
+2015-11-21 21:02:23.561451||measurement||loadtime||0:00:03.802714||1||1
+2015-11-21 21:02:31.902250||measurement||ad||2015-11-21 21:02:30.892837@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:02:31.972135||measurement||ad||2015-11-21 21:02:30.892837@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:02:32.031309||measurement||ad||2015-11-21 21:02:30.892837@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:02:32.031639||measurement||loadtime||0:00:03.468717||1||1
+2015-11-21 21:02:32.031736||event||progress-marker||measurement-end||1||1
+2015-11-21 21:02:32.305122||meta||block_id end||4
+2015-11-21 21:02:32.306586||meta||block_id start||5
+2015-11-21 21:02:32.306702||meta||assignment||1@|0@|3@|2
+2015-11-21 21:02:34.634825||event||progress-marker||training-start||0||0
+2015-11-21 21:02:34.635118||event||progress-marker||training-end||0||0
+2015-11-21 21:02:34.700553||event||progress-marker||training-start||1||0
+2015-11-21 21:02:34.700841||event||progress-marker||training-end||1||0
+2015-11-21 21:02:37.490968||event||progress-marker||training-start||3||1
+2015-11-21 21:02:37.491289||event||progress-marker||training-end||3||1
+2015-11-21 21:02:37.500213||event||progress-marker||training-start||2||1
+2015-11-21 21:02:37.500519||event||progress-marker||training-end||2||1
+2015-11-21 21:02:39.646707||event||progress-marker||measurement-start||0||0
+2015-11-21 21:02:39.713059||event||progress-marker||measurement-start||1||0
+2015-11-21 21:02:42.501003||event||progress-marker||measurement-start||3||1
+2015-11-21 21:02:42.508898||event||progress-marker||measurement-start||2||1
+2015-11-21 21:02:47.356410||measurement||ad||2015-11-21 21:02:46.331274@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:02:47.460560||measurement||ad||2015-11-21 21:02:46.226327@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:02:47.578282||measurement||ad||2015-11-21 21:02:46.226327@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||0||0
+2015-11-21 21:02:47.627520||measurement||ad||2015-11-21 21:02:46.331274@|Man Cracks Credit "Code"@|www.thecreditsolutionprogram.com@|This pro's "Shocking Little Trick" can boost credit score by 217 pts.||1||0
+2015-11-21 21:02:47.664603||measurement||ad||2015-11-21 21:02:46.226327@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||0
+2015-11-21 21:02:47.664878||measurement||loadtime||0:00:03.016655||0||0
+2015-11-21 21:02:47.708692||measurement||ad||2015-11-21 21:02:46.331274@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||1||0
+2015-11-21 21:02:47.709145||measurement||loadtime||0:00:02.995189||1||0
+2015-11-21 21:02:56.948510||measurement||ad||2015-11-21 21:02:54.470049@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:02:57.332690||measurement||ad||2015-11-21 21:02:53.572541@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:02:58.046044||measurement||ad||2015-11-21 21:02:54.470049@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:02:58.808464||measurement||ad||2015-11-21 21:02:53.572541@|$59 Miami Vacation Deal@|www.getawaydealz.com/Miami_Beach@|3 Days in Oceanfront Miami Beach Hotel From $59 - Not Per Night!||1||0
+2015-11-21 21:02:59.656783||measurement||ad||2015-11-21 21:02:54.470049@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||0
+2015-11-21 21:02:59.657109||measurement||loadtime||0:00:06.990913||0||0
+2015-11-21 21:03:00.227365||measurement||ad||2015-11-21 21:02:59.068593@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:03:01.148664||measurement||ad||2015-11-21 21:03:00.106085@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:03:01.340877||measurement||ad||2015-11-21 21:02:53.572541@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||1||0
+2015-11-21 21:03:01.341357||measurement||loadtime||0:00:08.631548||1||0
+2015-11-21 21:03:01.372688||measurement||ad||2015-11-21 21:02:59.068593@|Mobile Security@|pulsesecure.net/Mobile-Threat@|Our Mobile Threat Report Provides Valuable Insights - Download Now!||2||1
+2015-11-21 21:03:01.796894||measurement||ad||2015-11-21 21:02:59.068593@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||1
+2015-11-21 21:03:01.797279||measurement||loadtime||0:00:14.287686||2||1
+2015-11-21 21:03:01.808363||measurement||ad||2015-11-21 21:03:00.106085@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 21:03:02.177878||measurement||ad||2015-11-21 21:03:00.106085@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:03:02.178210||measurement||loadtime||0:00:14.675712||3||1
+2015-11-21 21:03:07.272110||measurement||ad||2015-11-21 21:03:05.595750@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:03:07.445539||measurement||ad||2015-11-21 21:03:05.595750@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:03:07.686501||measurement||ad||2015-11-21 21:03:05.595750@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||0
+2015-11-21 21:03:07.686808||measurement||loadtime||0:00:03.028830||0||0
+2015-11-21 21:03:09.275482||measurement||ad||2015-11-21 21:03:06.671702@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:03:11.387247||measurement||ad||2015-11-21 21:03:06.671702@|$59 Miami Vacation Deal@|www.getawaydealz.com/Miami_Beach@|3 Days in Oceanfront Miami Beach Hotel From $59 - Not Per Night!||1||0
+2015-11-21 21:03:13.883211||measurement||ad||2015-11-21 21:03:06.671702@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||1||0
+2015-11-21 21:03:13.883705||measurement||loadtime||0:00:07.540851||1||0
+2015-11-21 21:03:16.550777||measurement||ad||2015-11-21 21:03:13.708972@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:03:16.654946||measurement||ad||2015-11-21 21:03:13.708972@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:03:16.827405||measurement||ad||2015-11-21 21:03:13.708972@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||0
+2015-11-21 21:03:16.827776||measurement||loadtime||0:00:04.139616||0||0
+2015-11-21 21:03:19.400320||measurement||ad||2015-11-21 21:03:18.843095@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:03:19.425154||measurement||ad||2015-11-21 21:03:18.177305@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:03:19.527835||measurement||ad||2015-11-21 21:03:18.843095@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:03:19.605969||measurement||ad||2015-11-21 21:03:18.177305@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||2||1
+2015-11-21 21:03:19.668736||measurement||ad||2015-11-21 21:03:18.843095@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||1
+2015-11-21 21:03:19.669056||measurement||loadtime||0:00:12.490334||3||1
+2015-11-21 21:03:19.740550||measurement||ad||2015-11-21 21:03:18.177305@|International Calls@|www.keepcalling.com@|Cheapest Rates with KeepCalling. Find Out More!||2||1
+2015-11-21 21:03:19.740824||measurement||loadtime||0:00:12.942170||2||1
+2015-11-21 21:03:21.921873||measurement||ad||2015-11-21 21:03:20.064580@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:03:22.044081||measurement||ad||2015-11-21 21:03:20.064580@|Successful Investor Moves@|www.caseyresearch.com@|This Investor has Sold off Big Name Stocks. Learn Why Here.||1||0
+2015-11-21 21:03:22.215626||measurement||ad||2015-11-21 21:03:20.064580@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||1||0
+2015-11-21 21:03:22.215898||measurement||loadtime||0:00:03.331097||1||0
+2015-11-21 21:03:22.546564||error||collecting ads||Error||0||0
+2015-11-21 21:03:29.586847||error||collecting ads||Error||0||0
+2015-11-21 21:03:30.440828||measurement||ad||2015-11-21 21:03:28.350566@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:03:30.627724||measurement||ad||2015-11-21 21:03:28.350566@|Successful Investor Moves@|www.caseyresearch.com@|This Investor has Sold off Big Name Stocks. Learn Why Here.||1||0
+2015-11-21 21:03:31.018525||measurement||ad||2015-11-21 21:03:28.350566@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||1||0
+2015-11-21 21:03:31.018766||measurement||loadtime||0:00:03.801996||1||0
+2015-11-21 21:03:35.267749||measurement||ad||2015-11-21 21:03:34.545944@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-21 21:03:35.482875||measurement||ad||2015-11-21 21:03:34.545944@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||2||1
+2015-11-21 21:03:35.492321||measurement||ad||2015-11-21 21:03:35.082124@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||3||1
+2015-11-21 21:03:35.664757||measurement||ad||2015-11-21 21:03:34.545944@|5 Foods to never eat :@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:03:35.665612||measurement||loadtime||0:00:10.923202||2||1
+2015-11-21 21:03:35.789072||measurement||ad||2015-11-21 21:03:35.082124@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:03:36.402401||measurement||ad||2015-11-21 21:03:35.082124@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||1
+2015-11-21 21:03:36.402784||measurement||loadtime||0:00:11.733188||3||1
+2015-11-21 21:03:38.145202||measurement||ad||2015-11-21 21:03:35.977620@|Coach for Your Treatment@|mybreastcancercoach.org@|Expert Breast Cancer Guidance of Personalized Options w/Phone App!||0||0
+2015-11-21 21:03:38.238737||measurement||ad||2015-11-21 21:03:35.977620@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||0
+2015-11-21 21:03:38.240948||measurement||ad||2015-11-21 21:03:36.837035@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:03:38.318004||measurement||ad||2015-11-21 21:03:35.977620@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||0||0
+2015-11-21 21:03:38.318218||measurement||loadtime||0:00:03.730176||0||0
+2015-11-21 21:03:38.320996||measurement||ad||2015-11-21 21:03:36.837035@|$59 Miami Vacation Deal@|www.getawaydealz.com/Miami_Beach@|3 Days in Oceanfront Miami Beach Hotel From $59 - Not Per Night!||1||0
+2015-11-21 21:03:38.476307||measurement||ad||2015-11-21 21:03:36.837035@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||1||0
+2015-11-21 21:03:38.476678||measurement||loadtime||0:00:02.457181||1||0
+2015-11-21 21:03:46.223541||measurement||ad||2015-11-21 21:03:44.092568@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:03:46.419910||measurement||ad||2015-11-21 21:03:44.092568@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||0
+2015-11-21 21:03:47.212764||measurement||ad||2015-11-21 21:03:44.914425@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:03:47.357661||measurement||ad||2015-11-21 21:03:44.092568@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:03:47.357949||measurement||loadtime||0:00:04.039382||0||0
+2015-11-21 21:03:47.406539||measurement||ad||2015-11-21 21:03:44.914425@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:03:48.000673||measurement||ad||2015-11-21 21:03:44.914425@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||0
+2015-11-21 21:03:48.000942||measurement||loadtime||0:00:04.523198||1||0
+2015-11-21 21:03:51.253970||measurement||ad||2015-11-21 21:03:50.246247@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:03:51.377255||measurement||ad||2015-11-21 21:03:50.246247@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:03:51.506991||measurement||ad||2015-11-21 21:03:50.246247@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||1
+2015-11-21 21:03:51.507254||measurement||loadtime||0:00:10.103933||3||1
+2015-11-21 21:03:52.513135||measurement||ad||2015-11-21 21:03:51.888180@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:03:52.863317||measurement||ad||2015-11-21 21:03:51.888180@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||1
+2015-11-21 21:03:53.142507||measurement||ad||2015-11-21 21:03:51.888180@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||1
+2015-11-21 21:03:53.142778||measurement||loadtime||0:00:12.475350||2||1
+2015-11-21 21:03:55.638803||measurement||ad||2015-11-21 21:03:53.592887@|Coach for Your Treatment@|mybreastcancercoach.org@|Expert Breast Cancer Guidance of Personalized Options w/Phone App!||0||0
+2015-11-21 21:03:55.867944||measurement||ad||2015-11-21 21:03:54.111092@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:03:55.977723||measurement||ad||2015-11-21 21:03:54.111092@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:03:56.216057||measurement||ad||2015-11-21 21:03:54.111092@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||0
+2015-11-21 21:03:56.216379||measurement||loadtime||0:00:03.214011||1||0
+2015-11-21 21:03:56.417354||measurement||ad||2015-11-21 21:03:53.592887@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||0
+2015-11-21 21:03:57.705900||measurement||ad||2015-11-21 21:03:53.592887@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||0||0
+2015-11-21 21:03:57.706167||measurement||loadtime||0:00:05.347810||0||0
+2015-11-21 21:04:04.216475||measurement||ad||2015-11-21 21:04:02.112101@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:04:05.218974||measurement||ad||2015-11-21 21:04:02.112101@|Asbestos Testing Near You@|www.freecontractormatch.com@|Find Local Asbestos Testing Pros. Pre-Screened  Customer Rated!||1||0
+2015-11-21 21:04:05.927801||measurement||ad||2015-11-21 21:04:03.727633@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:04:06.120993||measurement||ad||2015-11-21 21:04:03.727633@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||0
+2015-11-21 21:04:06.145266||measurement||ad||2015-11-21 21:04:05.227221@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:04:06.201864||measurement||ad||2015-11-21 21:04:02.112101@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||1||0
+2015-11-21 21:04:06.202110||measurement||loadtime||0:00:04.982885||1||0
+2015-11-21 21:04:06.306113||measurement||ad||2015-11-21 21:04:03.727633@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:04:06.306408||measurement||loadtime||0:00:03.599043||0||0
+2015-11-21 21:04:06.306758||event||progress-marker||measurement-end||0||0
+2015-11-21 21:04:06.842426||measurement||ad||2015-11-21 21:04:05.227221@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:04:07.762368||measurement||ad||2015-11-21 21:04:05.227221@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:04:07.762670||measurement||loadtime||0:00:11.254859||3||1
+2015-11-21 21:04:07.983356||measurement||ad||2015-11-21 21:04:07.673454@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:04:08.152844||measurement||ad||2015-11-21 21:04:07.673454@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||1
+2015-11-21 21:04:08.240671||measurement||ad||2015-11-21 21:04:07.673454@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||1
+2015-11-21 21:04:08.240962||measurement||loadtime||0:00:10.097654||2||1
+2015-11-21 21:04:12.771552||measurement||ad||2015-11-21 21:04:11.532824@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:04:12.897147||measurement||ad||2015-11-21 21:04:11.532824@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:04:12.995782||measurement||ad||2015-11-21 21:04:11.532824@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||0
+2015-11-21 21:04:12.996117||measurement||loadtime||0:00:01.792531||1||0
+2015-11-21 21:04:12.996228||event||progress-marker||measurement-end||1||0
+2015-11-21 21:04:17.921958||measurement||ad||2015-11-21 21:04:17.668972@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:04:17.971119||measurement||ad||2015-11-21 21:04:17.668972@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:04:18.022472||measurement||ad||2015-11-21 21:04:17.668972@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:04:18.022745||measurement||loadtime||0:00:04.780465||2||1
+2015-11-21 21:04:18.494790||measurement||ad||2015-11-21 21:04:18.348669@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:04:18.544454||measurement||ad||2015-11-21 21:04:18.348669@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:04:18.600372||measurement||ad||2015-11-21 21:04:18.348669@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:04:18.600611||measurement||loadtime||0:00:05.836365||3||1
+2015-11-21 21:04:27.768705||measurement||ad||2015-11-21 21:04:27.639839@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-21 21:04:27.833482||measurement||ad||2015-11-21 21:04:27.639839@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||2||1
+2015-11-21 21:04:27.905132||measurement||ad||2015-11-21 21:04:27.639839@|5 Foods to never eat :@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:04:27.905399||measurement||loadtime||0:00:04.881781||2||1
+2015-11-21 21:04:30.179976||measurement||ad||2015-11-21 21:04:29.888186@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||1
+2015-11-21 21:04:30.180189||measurement||loadtime||0:00:06.579073||3||1
+2015-11-21 21:04:34.906116||measurement||ad||2015-11-21 21:04:33.007119@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:04:35.414642||measurement||ad||2015-11-21 21:04:33.007119@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:04:37.592039||measurement||ad||2015-11-21 21:04:33.007119@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:04:37.592272||measurement||loadtime||0:00:04.686120||2||1
+2015-11-21 21:04:39.545838||measurement||ad||2015-11-21 21:04:39.411942@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:04:39.637670||measurement||ad||2015-11-21 21:04:39.411942@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:04:39.747561||measurement||ad||2015-11-21 21:04:39.411942@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:04:39.747847||measurement||loadtime||0:00:04.567004||3||1
+2015-11-21 21:04:47.345246||measurement||ad||2015-11-21 21:04:46.966934@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-21 21:04:47.424674||measurement||ad||2015-11-21 21:04:46.966934@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||2||1
+2015-11-21 21:04:47.503214||measurement||ad||2015-11-21 21:04:46.966934@|5 Foods to never eat :@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:04:47.503521||measurement||loadtime||0:00:04.910753||2||1
+2015-11-21 21:04:50.066380||measurement||ad||2015-11-21 21:04:49.906654@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:04:50.133161||measurement||ad||2015-11-21 21:04:49.906654@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:04:50.208706||measurement||ad||2015-11-21 21:04:49.906654@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:04:50.208985||measurement||loadtime||0:00:05.459861||3||1
+2015-11-21 21:04:58.079628||measurement||ad||2015-11-21 21:04:55.654080@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||3||1
+2015-11-21 21:04:58.534096||measurement||ad||2015-11-21 21:04:55.654080@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:04:58.598839||measurement||ad||2015-11-21 21:04:55.654080@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:04:58.599092||measurement||loadtime||0:00:03.389452||3||1
+2015-11-21 21:04:58.599255||event||progress-marker||measurement-end||3||1
+2015-11-21 21:04:59.556835||measurement||ad||2015-11-21 21:04:59.445377@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:04:59.603590||measurement||ad||2015-11-21 21:04:59.445377@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||1
+2015-11-21 21:04:59.701065||measurement||ad||2015-11-21 21:04:59.445377@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||1
+2015-11-21 21:04:59.701335||measurement||loadtime||0:00:07.196421||2||1
+2015-11-21 21:04:59.701519||event||progress-marker||measurement-end||2||1
+2015-11-21 21:04:59.959066||meta||block_id end||5
+2015-11-21 21:04:59.961977||meta||block_id start||6
+2015-11-21 21:04:59.962112||meta||assignment||2@|3@|1@|0
+2015-11-21 21:05:02.372723||event||progress-marker||training-start||3||0
+2015-11-21 21:05:02.373035||event||progress-marker||training-end||3||0
+2015-11-21 21:05:02.438632||event||progress-marker||training-start||2||0
+2015-11-21 21:05:02.438974||event||progress-marker||training-end||2||0
+2015-11-21 21:05:05.155040||event||progress-marker||training-start||1||1
+2015-11-21 21:05:05.155337||event||progress-marker||training-end||1||1
+2015-11-21 21:05:05.160535||event||progress-marker||training-start||0||1
+2015-11-21 21:05:05.161433||event||progress-marker||training-end||0||1
+2015-11-21 21:05:07.387130||event||progress-marker||measurement-start||3||0
+2015-11-21 21:05:07.451870||event||progress-marker||measurement-start||2||0
+2015-11-21 21:05:10.169377||event||progress-marker||measurement-start||1||1
+2015-11-21 21:05:10.171546||event||progress-marker||measurement-start||0||1
+2015-11-21 21:05:15.119633||measurement||ad||2015-11-21 21:05:13.946136@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:05:15.479657||measurement||ad||2015-11-21 21:05:14.215266@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:05:15.507842||measurement||ad||2015-11-21 21:05:13.946136@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||2||0
+2015-11-21 21:05:15.761696||measurement||ad||2015-11-21 21:05:13.946136@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||2||0
+2015-11-21 21:05:15.762476||measurement||loadtime||0:00:03.309309||2||0
+2015-11-21 21:05:15.839651||measurement||ad||2015-11-21 21:05:14.215266@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:05:16.274803||measurement||ad||2015-11-21 21:05:14.215266@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||0
+2015-11-21 21:05:16.275080||measurement||loadtime||0:00:03.886421||3||0
+2015-11-21 21:05:22.838008||error||collecting ads||Error||2||0
+2015-11-21 21:05:25.794557||measurement||ad||2015-11-21 21:05:22.910723@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||0
+2015-11-21 21:05:26.260653||measurement||ad||2015-11-21 21:05:22.910723@|Oil Price Shock@|outsiderclub.com/Oil_Company@|Will Oil Return To $150/Barrel? Our 2015 Oil Outlook Rpt Tells All||3||0
+2015-11-21 21:05:27.126911||measurement||ad||2015-11-21 21:05:25.974722@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:05:27.362189||measurement||ad||2015-11-21 21:05:25.974722@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:05:27.561321||measurement||ad||2015-11-21 21:05:25.974722@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||0||1
+2015-11-21 21:05:27.561663||measurement||loadtime||0:00:12.388706||0||1
+2015-11-21 21:05:28.207179||measurement||ad||2015-11-21 21:05:22.910723@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||3||0
+2015-11-21 21:05:28.207504||measurement||loadtime||0:00:06.931671||3||0
+2015-11-21 21:05:30.439188||measurement||ad||2015-11-21 21:05:28.343290@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:05:31.046294||measurement||ad||2015-11-21 21:05:28.343290@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||1
+2015-11-21 21:05:31.224816||measurement||ad||2015-11-21 21:05:28.343290@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||1||1
+2015-11-21 21:05:31.225236||measurement||loadtime||0:00:16.055078||1||1
+2015-11-21 21:05:32.515475||measurement||ad||2015-11-21 21:05:29.813835@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:05:32.695009||measurement||ad||2015-11-21 21:05:29.813835@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:05:34.414283||measurement||ad||2015-11-21 21:05:29.813835@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||0
+2015-11-21 21:05:34.414979||measurement||loadtime||0:00:06.576136||2||0
+2015-11-21 21:05:36.662750||measurement||ad||2015-11-21 21:05:34.549972@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:05:36.888871||measurement||ad||2015-11-21 21:05:34.549972@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-21 21:05:38.195080||measurement||ad||2015-11-21 21:05:34.549972@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:05:38.195394||measurement||loadtime||0:00:04.987295||3||0
+2015-11-21 21:05:42.948773||measurement||ad||2015-11-21 21:05:40.707943@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||0
+2015-11-21 21:05:43.257847||measurement||ad||2015-11-21 21:05:40.707943@|Kill Bed Bugs  the Eggs@|bedroomguardian.com@|Complete Solutions To Get Rid of Bed Bugs From Your Home||2||0
+2015-11-21 21:05:43.949393||measurement||ad||2015-11-21 21:05:40.707943@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-21 21:05:43.949933||measurement||loadtime||0:00:04.533527||2||0
+2015-11-21 21:05:44.034218||measurement||ad||2015-11-21 21:05:43.118016@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:05:44.332650||measurement||ad||2015-11-21 21:05:43.118016@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:05:44.539972||measurement||ad||2015-11-21 21:05:43.118016@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||0||1
+2015-11-21 21:05:44.540227||measurement||loadtime||0:00:11.977427||0||1
+2015-11-21 21:05:46.696921||measurement||ad||2015-11-21 21:05:44.522814@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:05:47.076443||measurement||ad||2015-11-21 21:05:46.161500@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:05:47.230944||measurement||ad||2015-11-21 21:05:46.161500@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:05:47.309619||measurement||ad||2015-11-21 21:05:46.161500@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||1||1
+2015-11-21 21:05:47.309876||measurement||loadtime||0:00:11.083703||1||1
+2015-11-21 21:05:47.607742||measurement||ad||2015-11-21 21:05:44.522814@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:05:47.781279||measurement||ad||2015-11-21 21:05:44.522814@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:05:47.781593||measurement||loadtime||0:00:04.584870||3||0
+2015-11-21 21:05:52.029603||measurement||ad||2015-11-21 21:05:50.316106@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:05:52.239100||measurement||ad||2015-11-21 21:05:50.316106@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:05:52.458944||measurement||ad||2015-11-21 21:05:50.316106@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:05:52.459270||measurement||loadtime||0:00:03.507865||2||0
+2015-11-21 21:05:56.118871||measurement||ad||2015-11-21 21:05:54.019036@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:05:56.356084||measurement||ad||2015-11-21 21:05:54.019036@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:05:56.892692||measurement||ad||2015-11-21 21:05:54.019036@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-21 21:05:56.893035||measurement||loadtime||0:00:04.110417||3||0
+2015-11-21 21:05:59.995936||measurement||ad||2015-11-21 21:05:59.088027@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:06:00.151432||measurement||ad||2015-11-21 21:05:59.088027@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:06:00.306031||measurement||ad||2015-11-21 21:05:59.088027@|IT Help Desk Software@|freshservice.com/IT-Helpdesk-S/W@|Setup your IT Helpdesk in 2 mins. Hassle-free solution. Try now!||0||1
+2015-11-21 21:06:00.307123||measurement||loadtime||0:00:10.766033||0||1
+2015-11-21 21:06:00.507261||measurement||ad||2015-11-21 21:05:58.620800@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:06:00.608668||measurement||ad||2015-11-21 21:05:58.620800@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:06:00.993520||measurement||ad||2015-11-21 21:05:58.620800@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||0
+2015-11-21 21:06:00.993810||measurement||loadtime||0:00:03.533513||2||0
+2015-11-21 21:06:02.364279||measurement||ad||2015-11-21 21:06:01.969253@|Fora Financial@|forafinancial.com/Business+Credit+Loans@|Get Working Capital Up To $250K. Terms Up To 18 Months. Apply Now!||1||1
+2015-11-21 21:06:02.603242||measurement||ad||2015-11-21 21:06:01.969253@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:06:02.773004||measurement||ad||2015-11-21 21:06:01.969253@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:06:02.773832||measurement||loadtime||0:00:10.462809||1||1
+2015-11-21 21:06:04.130291||measurement||ad||2015-11-21 21:06:03.166057@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:06:04.222243||measurement||ad||2015-11-21 21:06:03.166057@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:06:04.448008||measurement||ad||2015-11-21 21:06:03.166057@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||3||0
+2015-11-21 21:06:04.448293||measurement||loadtime||0:00:02.554865||3||0
+2015-11-21 21:06:09.084727||measurement||ad||2015-11-21 21:06:07.035532@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:06:09.279398||measurement||ad||2015-11-21 21:06:07.035532@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:06:09.883588||measurement||ad||2015-11-21 21:06:07.035532@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||0
+2015-11-21 21:06:09.883869||measurement||loadtime||0:00:03.888719||2||0
+2015-11-21 21:06:12.519603||measurement||ad||2015-11-21 21:06:10.597458@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||0
+2015-11-21 21:06:12.882368||measurement||ad||2015-11-21 21:06:10.597458@|Oil Price Shock@|outsiderclub.com/Oil_Company@|Will Oil Return To $150/Barrel? Our 2015 Oil Outlook Rpt Tells All||3||0
+2015-11-21 21:06:13.149894||measurement||ad||2015-11-21 21:06:10.597458@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||3||0
+2015-11-21 21:06:13.150503||measurement||loadtime||0:00:03.699546||3||0
+2015-11-21 21:06:15.208168||measurement||ad||2015-11-21 21:06:14.820721@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:06:15.511490||measurement||ad||2015-11-21 21:06:14.820721@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:06:15.720955||measurement||ad||2015-11-21 21:06:14.820721@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||0||1
+2015-11-21 21:06:15.721703||measurement||loadtime||0:00:10.413680||0||1
+2015-11-21 21:06:15.880968||error||collecting ads||Error||2||0
+2015-11-21 21:06:18.103035||measurement||ad||2015-11-21 21:06:17.684147@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-21 21:06:18.192845||measurement||ad||2015-11-21 21:06:17.684147@|Treat  Remove Fissures@|www.amoils.com@|All Natural, Homeopathic. No Need For Prescriptions or Surgery!||1||1
+2015-11-21 21:06:18.278798||measurement||ad||2015-11-21 21:06:17.684147@|5 Best Fundamental Stocks@|www.stockaxis.com/@|Get 5 stocks for short term to long term investment via SMS. It's Free.||1||1
+2015-11-21 21:06:18.279066||measurement||loadtime||0:00:10.503560||1||1
+2015-11-21 21:06:18.989991||error||collecting ads||Error||3||0
+2015-11-21 21:06:23.355892||measurement||ad||2015-11-21 21:06:21.167990@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:06:23.645918||measurement||ad||2015-11-21 21:06:21.167990@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:06:23.800375||measurement||ad||2015-11-21 21:06:21.167990@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||2||0
+2015-11-21 21:06:23.800685||measurement||loadtime||0:00:02.919171||2||0
+2015-11-21 21:06:27.359664||measurement||ad||2015-11-21 21:06:24.436781@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||3||0
+2015-11-21 21:06:27.536880||measurement||ad||2015-11-21 21:06:24.436781@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:06:27.767865||measurement||ad||2015-11-21 21:06:24.436781@|Diabetes  Pet Ownership@|healio.com/diabetes@|Pet ownership may improve diabetes self-care in adolescents.||3||0
+2015-11-21 21:06:27.768216||measurement||loadtime||0:00:03.777293||3||0
+2015-11-21 21:06:30.891048||measurement||ad||2015-11-21 21:06:30.215266@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:06:30.966133||measurement||ad||2015-11-21 21:06:30.215266@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:06:31.970201||measurement||ad||2015-11-21 21:06:30.215266@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||0||1
+2015-11-21 21:06:31.970457||measurement||loadtime||0:00:11.247847||0||1
+2015-11-21 21:06:32.544804||measurement||ad||2015-11-21 21:06:29.885151@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:06:32.742325||measurement||ad||2015-11-21 21:06:29.885151@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:06:33.111995||measurement||ad||2015-11-21 21:06:29.885151@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||0
+2015-11-21 21:06:33.112293||measurement||loadtime||0:00:04.310891||2||0
+2015-11-21 21:06:33.112518||event||progress-marker||measurement-end||2||0
+2015-11-21 21:06:34.656721||measurement||ad||2015-11-21 21:06:32.820356@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:06:35.080364||measurement||ad||2015-11-21 21:06:32.820356@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||1||1
+2015-11-21 21:06:35.221597||measurement||ad||2015-11-21 21:06:32.820356@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:06:35.221966||measurement||loadtime||0:00:11.941806||1||1
+2015-11-21 21:06:35.716549||measurement||ad||2015-11-21 21:06:34.036634@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:06:35.786595||measurement||ad||2015-11-21 21:06:34.036634@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:06:36.246498||measurement||ad||2015-11-21 21:06:34.036634@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||0
+2015-11-21 21:06:36.246816||measurement||loadtime||0:00:03.478158||3||0
+2015-11-21 21:06:36.247032||event||progress-marker||measurement-end||3||0
+2015-11-21 21:06:43.388627||measurement||ad||2015-11-21 21:06:42.726194@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 21:06:43.528899||measurement||ad||2015-11-21 21:06:42.726194@|Moving the Giants@|www.movingthegiants.com@|Plant a Tree. Save the Planet Inspiring video on saving redwoods||0||1
+2015-11-21 21:06:43.616346||measurement||ad||2015-11-21 21:06:42.726194@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||0||1
+2015-11-21 21:06:43.616652||measurement||loadtime||0:00:06.645421||0||1
+2015-11-21 21:06:45.222947||measurement||ad||2015-11-21 21:06:44.828827@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:06:45.344611||measurement||ad||2015-11-21 21:06:44.828827@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:06:45.406063||measurement||ad||2015-11-21 21:06:44.828827@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||1
+2015-11-21 21:06:45.406351||measurement||loadtime||0:00:05.182988||1||1
+2015-11-21 21:06:52.688631||measurement||ad||2015-11-21 21:06:52.345935@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:06:52.770571||measurement||ad||2015-11-21 21:06:52.345935@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:06:52.837547||measurement||ad||2015-11-21 21:06:52.345935@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:06:52.837834||measurement||loadtime||0:00:04.219729||0||1
+2015-11-21 21:06:55.564274||measurement||ad||2015-11-21 21:06:55.427629@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:06:55.653502||measurement||ad||2015-11-21 21:06:55.427629@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:06:55.743156||measurement||ad||2015-11-21 21:06:55.427629@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||1
+2015-11-21 21:06:55.743921||measurement||loadtime||0:00:05.336655||1||1
+2015-11-21 21:07:03.005807||measurement||ad||2015-11-21 21:07:02.782539@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:07:03.083795||measurement||ad||2015-11-21 21:07:02.782539@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:07:03.141923||measurement||ad||2015-11-21 21:07:02.782539@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||0||1
+2015-11-21 21:07:03.142228||measurement||loadtime||0:00:05.303651||0||1
+2015-11-21 21:07:05.603472||measurement||ad||2015-11-21 21:07:05.501179@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:07:05.680714||measurement||ad||2015-11-21 21:07:05.501179@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:07:05.732325||measurement||ad||2015-11-21 21:07:05.501179@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||1||1
+2015-11-21 21:07:05.732657||measurement||loadtime||0:00:04.987791||1||1
+2015-11-21 21:07:14.400592||measurement||ad||2015-11-21 21:07:13.716235@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:07:14.709331||measurement||ad||2015-11-21 21:07:13.716235@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:07:15.473272||measurement||ad||2015-11-21 21:07:13.716235@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:07:15.473761||measurement||loadtime||0:00:07.330105||0||1
+2015-11-21 21:07:15.698790||measurement||ad||2015-11-21 21:07:15.520394@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:07:15.781757||measurement||ad||2015-11-21 21:07:15.520394@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||1
+2015-11-21 21:07:15.884706||measurement||ad||2015-11-21 21:07:15.520394@|Start Download@|free.convertanyfile.com@|File size: 487KB. Full Version. Rating: 5.0 Stars. ConvertAnyFile.||1||1
+2015-11-21 21:07:15.885004||measurement||loadtime||0:00:05.151696||1||1
+2015-11-21 21:07:23.614757||measurement||ad||2015-11-21 21:07:20.577493@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:07:23.886906||measurement||ad||2015-11-21 21:07:20.577493@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:07:23.996260||measurement||ad||2015-11-21 21:07:20.577493@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 21:07:23.996572||measurement||loadtime||0:00:03.521402||0||1
+2015-11-21 21:07:23.996780||event||progress-marker||measurement-end||0||1
+2015-11-21 21:07:24.208788||measurement||ad||2015-11-21 21:07:20.943950@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:07:24.579618||measurement||ad||2015-11-21 21:07:20.943950@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||1||1
+2015-11-21 21:07:26.954271||measurement||ad||2015-11-21 21:07:20.943950@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:07:26.954521||measurement||loadtime||0:00:06.068907||1||1
+2015-11-21 21:07:26.954659||event||progress-marker||measurement-end||1||1
+2015-11-21 21:07:27.198361||meta||block_id end||6
+2015-11-21 21:07:27.200365||meta||block_id start||7
+2015-11-21 21:07:27.200404||meta||assignment||1@|3@|2@|0
+2015-11-21 21:07:29.543105||event||progress-marker||training-start||3||0
+2015-11-21 21:07:29.543503||event||progress-marker||training-end||3||0
+2015-11-21 21:07:29.719603||event||progress-marker||training-start||1||0
+2015-11-21 21:07:29.719963||event||progress-marker||training-end||1||0
+2015-11-21 21:07:32.378854||event||progress-marker||training-start||2||1
+2015-11-21 21:07:32.379246||event||progress-marker||training-end||2||1
+2015-11-21 21:07:32.382342||event||progress-marker||training-start||0||1
+2015-11-21 21:07:32.382577||event||progress-marker||training-end||0||1
+2015-11-21 21:07:34.558730||event||progress-marker||measurement-start||3||0
+2015-11-21 21:07:34.734973||event||progress-marker||measurement-start||1||0
+2015-11-21 21:07:37.392168||event||progress-marker||measurement-start||2||1
+2015-11-21 21:07:37.393417||event||progress-marker||measurement-start||0||1
+2015-11-21 21:07:41.454079||measurement||ad||2015-11-21 21:07:41.225895@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:07:41.711686||measurement||ad||2015-11-21 21:07:41.225895@|Man Cracks Credit "Code"@|www.thecreditsolutionprogram.com@|This pro's "Shocking Little Trick" can boost credit score by 217 pts.||3||0
+2015-11-21 21:07:42.599607||measurement||ad||2015-11-21 21:07:41.312569@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:07:42.694540||measurement||ad||2015-11-21 21:07:41.225895@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||3||0
+2015-11-21 21:07:42.695255||measurement||loadtime||0:00:03.134878||3||0
+2015-11-21 21:07:42.762689||measurement||ad||2015-11-21 21:07:41.312569@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||1||0
+2015-11-21 21:07:42.891935||measurement||ad||2015-11-21 21:07:41.312569@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||0
+2015-11-21 21:07:42.892743||measurement||loadtime||0:00:03.156745||1||0
+2015-11-21 21:07:48.970363||error||collecting ads||Error||1||0
+2015-11-21 21:07:51.930993||measurement||ad||2015-11-21 21:07:49.968253@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||3||0
+2015-11-21 21:07:52.211842||measurement||ad||2015-11-21 21:07:49.968253@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||0
+2015-11-21 21:07:52.741497||measurement||ad||2015-11-21 21:07:49.968253@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:07:52.742006||measurement||loadtime||0:00:05.046068||3||0
+2015-11-21 21:07:57.841746||measurement||ad||2015-11-21 21:07:54.778274@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:07:58.250634||measurement||ad||2015-11-21 21:07:55.427583@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:07:58.504496||measurement||ad||2015-11-21 21:07:55.427583@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:07:58.700626||measurement||ad||2015-11-21 21:07:55.427583@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||1||0
+2015-11-21 21:07:58.700897||measurement||loadtime||0:00:04.728913||1||0
+2015-11-21 21:07:59.768285||measurement||ad||2015-11-21 21:07:54.778274@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||2||1
+2015-11-21 21:08:01.257750||measurement||ad||2015-11-21 21:07:58.933143@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:01.408302||measurement||ad||2015-11-21 21:07:58.933143@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:08:01.489212||measurement||ad||2015-11-21 21:07:54.778274@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||1
+2015-11-21 21:08:01.489525||measurement||loadtime||0:00:19.096834||2||1
+2015-11-21 21:08:01.691977||measurement||ad||2015-11-21 21:07:57.566674@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:08:02.924907||measurement||ad||2015-11-21 21:07:58.933143@|Start Download@|free.convertanyfile.com@|File size: 487KB. Full Version. Rating: 5.0 Stars. ConvertAnyFile.||3||0
+2015-11-21 21:08:02.925215||measurement||loadtime||0:00:05.182620||3||0
+2015-11-21 21:08:03.365077||measurement||ad||2015-11-21 21:07:57.566674@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:08:04.933711||measurement||ad||2015-11-21 21:07:57.566674@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||0||1
+2015-11-21 21:08:04.934795||measurement||loadtime||0:00:22.540658||0||1
+2015-11-21 21:08:06.755099||measurement||ad||2015-11-21 21:08:04.641334@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:08:06.858675||measurement||ad||2015-11-21 21:08:04.641334@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||0
+2015-11-21 21:08:07.018043||measurement||ad||2015-11-21 21:08:04.641334@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||0
+2015-11-21 21:08:07.018369||measurement||loadtime||0:00:03.316105||1||0
+2015-11-21 21:08:10.908384||measurement||ad||2015-11-21 21:08:08.943132@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:11.261266||measurement||ad||2015-11-21 21:08:08.943132@|6 Stocks Set to Soar@|profitabletrading.com@|Proprietary stock-ranking system signals: "buy these 6 stocks now".||3||0
+2015-11-21 21:08:12.881481||measurement||ad||2015-11-21 21:08:08.943132@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||3||0
+2015-11-21 21:08:12.881780||measurement||loadtime||0:00:04.955956||3||0
+2015-11-21 21:08:14.997841||measurement||ad||2015-11-21 21:08:13.160481@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:08:15.525200||measurement||ad||2015-11-21 21:08:14.748072@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:08:16.004609||measurement||ad||2015-11-21 21:08:14.748072@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:08:16.105236||measurement||ad||2015-11-21 21:08:13.160481@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:08:16.208441||measurement||ad||2015-11-21 21:08:14.748072@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||2||1
+2015-11-21 21:08:16.208715||measurement||loadtime||0:00:09.718275||2||1
+2015-11-21 21:08:17.968940||measurement||ad||2015-11-21 21:08:13.160481@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||1||0
+2015-11-21 21:08:17.969630||measurement||loadtime||0:00:05.948514||1||0
+2015-11-21 21:08:20.664682||measurement||ad||2015-11-21 21:08:18.501323@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:20.780303||measurement||ad||2015-11-21 21:08:18.501323@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:08:20.883268||measurement||ad||2015-11-21 21:08:18.501323@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||3||0
+2015-11-21 21:08:20.883529||measurement||loadtime||0:00:03.001391||3||0
+2015-11-21 21:08:21.785615||measurement||ad||2015-11-21 21:08:21.144421@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:08:21.936014||measurement||ad||2015-11-21 21:08:21.144421@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:08:22.043257||measurement||ad||2015-11-21 21:08:21.144421@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:08:22.043591||measurement||loadtime||0:00:12.108046||0||1
+2015-11-21 21:08:26.452628||measurement||ad||2015-11-21 21:08:23.984821@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:08:26.659052||measurement||ad||2015-11-21 21:08:23.984821@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:08:27.827615||measurement||ad||2015-11-21 21:08:23.984821@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||1||0
+2015-11-21 21:08:27.827922||measurement||loadtime||0:00:04.857418||1||0
+2015-11-21 21:08:29.295762||measurement||ad||2015-11-21 21:08:27.392041@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:29.476224||measurement||ad||2015-11-21 21:08:27.392041@|6 Stocks Set to Soar@|profitabletrading.com@|Proprietary stock-ranking system signals: "buy these 6 stocks now".||3||0
+2015-11-21 21:08:30.516091||measurement||ad||2015-11-21 21:08:27.392041@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:08:30.516569||measurement||loadtime||0:00:04.632436||3||0
+2015-11-21 21:08:34.158722||measurement||ad||2015-11-21 21:08:32.529611@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Fall 2015 Top Offers!||2||1
+2015-11-21 21:08:34.745678||measurement||ad||2015-11-21 21:08:32.529611@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:08:34.983118||measurement||ad||2015-11-21 21:08:32.529611@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-21 21:08:34.983531||measurement||loadtime||0:00:13.773464||2||1
+2015-11-21 21:08:36.333407||measurement||ad||2015-11-21 21:08:33.991264@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:08:37.645433||measurement||ad||2015-11-21 21:08:37.150564@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:08:37.785203||measurement||ad||2015-11-21 21:08:33.991264@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||0
+2015-11-21 21:08:38.000813||measurement||ad||2015-11-21 21:08:36.411043@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:38.043840||measurement||ad||2015-11-21 21:08:37.150564@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:08:38.186973||measurement||ad||2015-11-21 21:08:37.150564@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||0||1
+2015-11-21 21:08:38.187307||measurement||loadtime||0:00:11.143243||0||1
+2015-11-21 21:08:38.412175||measurement||ad||2015-11-21 21:08:36.411043@|6 Stocks Set to Soar@|profitabletrading.com@|Proprietary stock-ranking system signals: "buy these 6 stocks now".||3||0
+2015-11-21 21:08:38.736935||measurement||ad||2015-11-21 21:08:33.991264@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||0
+2015-11-21 21:08:38.737249||measurement||loadtime||0:00:05.908188||1||0
+2015-11-21 21:08:39.544549||measurement||ad||2015-11-21 21:08:36.411043@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:08:39.544880||measurement||loadtime||0:00:04.027914||3||0
+2015-11-21 21:08:47.104155||measurement||ad||2015-11-21 21:08:44.702923@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:08:47.625374||measurement||ad||2015-11-21 21:08:45.559599@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:47.974257||measurement||ad||2015-11-21 21:08:45.559599@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:08:48.756156||measurement||ad||2015-11-21 21:08:45.559599@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||3||0
+2015-11-21 21:08:48.756496||measurement||loadtime||0:00:04.210765||3||0
+2015-11-21 21:08:48.765828||measurement||ad||2015-11-21 21:08:44.702923@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||1||0
+2015-11-21 21:08:49.503925||measurement||ad||2015-11-21 21:08:44.702923@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 21:08:49.504331||measurement||loadtime||0:00:05.766484||1||0
+2015-11-21 21:08:50.093504||measurement||ad||2015-11-21 21:08:48.799408@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||2||1
+2015-11-21 21:08:50.439457||measurement||ad||2015-11-21 21:08:48.799408@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:08:51.483395||measurement||ad||2015-11-21 21:08:48.799408@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-21 21:08:51.483683||measurement||loadtime||0:00:11.499210||2||1
+2015-11-21 21:08:53.042347||measurement||ad||2015-11-21 21:08:52.776644@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:08:53.318608||measurement||ad||2015-11-21 21:08:52.776644@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:08:53.451686||measurement||ad||2015-11-21 21:08:52.776644@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-21 21:08:53.452053||measurement||loadtime||0:00:10.263497||0||1
+2015-11-21 21:08:56.331473||measurement||ad||2015-11-21 21:08:54.311281@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:08:56.565415||measurement||ad||2015-11-21 21:08:54.311281@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:08:57.294351||measurement||ad||2015-11-21 21:08:54.311281@|Start Download@|free.convertanyfile.com@|File size: 487KB. Full Version. Rating: 5.0 Stars. ConvertAnyFile.||3||0
+2015-11-21 21:08:57.294727||measurement||loadtime||0:00:03.537599||3||0
+2015-11-21 21:08:57.629070||measurement||ad||2015-11-21 21:08:55.722723@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:08:57.803978||measurement||ad||2015-11-21 21:08:55.722723@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||1||0
+2015-11-21 21:08:57.991408||measurement||ad||2015-11-21 21:08:55.722723@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 21:08:57.991692||measurement||loadtime||0:00:03.486774||1||0
+2015-11-21 21:09:05.180357||measurement||ad||2015-11-21 21:09:03.010710@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:09:05.344784||measurement||ad||2015-11-21 21:09:03.010710@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:09:05.970220||measurement||ad||2015-11-21 21:09:03.010710@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||3||0
+2015-11-21 21:09:05.970535||measurement||loadtime||0:00:03.674428||3||0
+2015-11-21 21:09:05.970739||event||progress-marker||measurement-end||3||0
+2015-11-21 21:09:06.860290||measurement||ad||2015-11-21 21:09:03.391858@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:09:06.959347||measurement||ad||2015-11-21 21:09:06.520631@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:09:06.990975||measurement||ad||2015-11-21 21:09:03.391858@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||1||0
+2015-11-21 21:09:07.143651||measurement||ad||2015-11-21 21:09:06.520631@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:09:07.174271||measurement||ad||2015-11-21 21:09:03.391858@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:09:07.174652||measurement||loadtime||0:00:04.180831||1||0
+2015-11-21 21:09:07.174883||event||progress-marker||measurement-end||1||0
+2015-11-21 21:09:07.486867||measurement||ad||2015-11-21 21:09:06.520631@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||2||1
+2015-11-21 21:09:07.487524||measurement||loadtime||0:00:11.002359||2||1
+2015-11-21 21:09:08.587044||measurement||ad||2015-11-21 21:09:08.397730@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:09:08.652616||measurement||ad||2015-11-21 21:09:08.397730@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:09:08.719044||measurement||ad||2015-11-21 21:09:08.397730@|General Insurance $18/Mo@|www.general-insurance.com@|Get the Cheapest Rate on General Car Insurance  Save Up to 72% Now!||0||1
+2015-11-21 21:09:08.719423||measurement||loadtime||0:00:10.266267||0||1
+2015-11-21 21:09:15.662835||measurement||ad||2015-11-21 21:09:13.995806@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:09:15.761496||measurement||ad||2015-11-21 21:09:13.995806@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:09:15.978307||measurement||ad||2015-11-21 21:09:13.995806@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||0||1
+2015-11-21 21:09:15.978608||measurement||loadtime||0:00:02.258012||0||1
+2015-11-21 21:09:16.987577||measurement||ad||2015-11-21 21:09:16.743831@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Fall 2015 Top Offers!||2||1
+2015-11-21 21:09:17.078988||measurement||ad||2015-11-21 21:09:16.743831@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:09:17.200544||measurement||ad||2015-11-21 21:09:16.743831@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-21 21:09:17.201037||measurement||loadtime||0:00:04.712694||2||1
+2015-11-21 21:09:24.632753||measurement||ad||2015-11-21 21:09:22.297073@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:09:24.738697||measurement||ad||2015-11-21 21:09:22.297073@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:09:24.818350||measurement||ad||2015-11-21 21:09:22.297073@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||2||1
+2015-11-21 21:09:24.818634||measurement||loadtime||0:00:02.616570||2||1
+2015-11-21 21:09:26.007327||measurement||ad||2015-11-21 21:09:25.752008@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:09:26.109197||measurement||ad||2015-11-21 21:09:25.752008@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:09:26.201712||measurement||ad||2015-11-21 21:09:25.752008@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||1
+2015-11-21 21:09:26.201991||measurement||loadtime||0:00:05.221934||0||1
+2015-11-21 21:09:31.929211||measurement||ad||2015-11-21 21:09:29.921200@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:09:32.085576||measurement||ad||2015-11-21 21:09:29.921200@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:09:33.478268||measurement||ad||2015-11-21 21:09:29.921200@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||2||1
+2015-11-21 21:09:33.478557||measurement||loadtime||0:00:03.658479||2||1
+2015-11-21 21:09:36.376202||measurement||ad||2015-11-21 21:09:36.261595@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:09:36.442910||measurement||ad||2015-11-21 21:09:36.261595@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:09:36.508458||measurement||ad||2015-11-21 21:09:36.261595@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:09:36.508809||measurement||loadtime||0:00:05.305301||0||1
+2015-11-21 21:09:42.929146||measurement||ad||2015-11-21 21:09:42.605041@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Fall 2015 Top Offers!||2||1
+2015-11-21 21:09:43.021266||measurement||ad||2015-11-21 21:09:42.605041@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:09:43.105235||measurement||ad||2015-11-21 21:09:42.605041@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-21 21:09:43.106291||measurement||loadtime||0:00:04.626786||2||1
+2015-11-21 21:09:45.473300||measurement||ad||2015-11-21 21:09:45.276572@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:09:45.543394||measurement||ad||2015-11-21 21:09:45.276572@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:09:45.602103||measurement||ad||2015-11-21 21:09:45.276572@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 21:09:45.602419||measurement||loadtime||0:00:04.092612||0||1
+2015-11-21 21:09:57.973667||measurement||ad||2015-11-21 21:09:56.864882@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:09:57.992081||measurement||ad||2015-11-21 21:09:56.768786@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:09:58.047063||measurement||ad||2015-11-21 21:09:56.864882@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:09:58.077982||measurement||ad||2015-11-21 21:09:56.768786@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:09:58.109405||measurement||ad||2015-11-21 21:09:56.864882@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||1
+2015-11-21 21:09:58.109826||measurement||loadtime||0:00:10.002018||2||1
+2015-11-21 21:09:58.110078||event||progress-marker||measurement-end||2||1
+2015-11-21 21:09:58.152264||measurement||ad||2015-11-21 21:09:56.768786@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||0||1
+2015-11-21 21:09:58.152671||measurement||loadtime||0:00:07.549792||0||1
+2015-11-21 21:09:58.152890||event||progress-marker||measurement-end||0||1
+2015-11-21 21:09:58.511034||meta||block_id end||7
+2015-11-21 21:09:58.512418||meta||block_id start||8
+2015-11-21 21:09:58.512453||meta||assignment||1@|3@|0@|2
+2015-11-21 21:10:00.796286||event||progress-marker||training-start||1||0
+2015-11-21 21:10:00.796665||event||progress-marker||training-end||1||0
+2015-11-21 21:10:01.008508||event||progress-marker||training-start||3||0
+2015-11-21 21:10:01.008866||event||progress-marker||training-end||3||0
+2015-11-21 21:10:03.717298||event||progress-marker||training-start||0||1
+2015-11-21 21:10:03.717578||event||progress-marker||training-end||0||1
+2015-11-21 21:10:03.744143||event||progress-marker||training-start||2||1
+2015-11-21 21:10:03.744424||event||progress-marker||training-end||2||1
+2015-11-21 21:10:05.834526||event||progress-marker||measurement-start||1||0
+2015-11-21 21:10:06.024847||event||progress-marker||measurement-start||3||0
+2015-11-21 21:10:08.730346||event||progress-marker||measurement-start||0||1
+2015-11-21 21:10:08.757402||event||progress-marker||measurement-start||2||1
+2015-11-21 21:10:13.599456||measurement||ad||2015-11-21 21:10:12.439166@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:10:13.756459||measurement||ad||2015-11-21 21:10:12.439166@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||1||0
+2015-11-21 21:10:14.024978||measurement||ad||2015-11-21 21:10:12.803939@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:10:14.126179||measurement||ad||2015-11-21 21:10:12.439166@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||1||0
+2015-11-21 21:10:14.126519||measurement||loadtime||0:00:03.290485||1||0
+2015-11-21 21:10:14.149214||measurement||ad||2015-11-21 21:10:12.803939@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||3||0
+2015-11-21 21:10:14.246798||measurement||ad||2015-11-21 21:10:12.803939@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||3||0
+2015-11-21 21:10:14.247257||measurement||loadtime||0:00:03.221856||3||0
+2015-11-21 21:10:21.332053||error||collecting ads||Error||1||0
+2015-11-21 21:10:23.967911||measurement||ad||2015-11-21 21:10:20.703386@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:10:24.087606||measurement||ad||2015-11-21 21:10:20.703386@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||3||0
+2015-11-21 21:10:24.283299||measurement||ad||2015-11-21 21:10:20.703386@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||0
+2015-11-21 21:10:24.283583||measurement||loadtime||0:00:05.034883||3||0
+2015-11-21 21:10:25.323759||measurement||ad||2015-11-21 21:10:24.812057@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:10:25.624206||measurement||ad||2015-11-21 21:10:24.812057@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||0||1
+2015-11-21 21:10:25.825925||measurement||ad||2015-11-21 21:10:24.812057@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||0||1
+2015-11-21 21:10:25.826195||measurement||loadtime||0:00:12.095350||0||1
+2015-11-21 21:10:27.223371||measurement||ad||2015-11-21 21:10:25.158063@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:10:27.895561||measurement||ad||2015-11-21 21:10:25.158063@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-21 21:10:28.511605||measurement||ad||2015-11-21 21:10:25.158063@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||2||1
+2015-11-21 21:10:28.511965||measurement||loadtime||0:00:14.753506||2||1
+2015-11-21 21:10:31.772119||measurement||ad||2015-11-21 21:10:28.370065@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||1||0
+2015-11-21 21:10:31.940803||measurement||ad||2015-11-21 21:10:28.370065@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:10:32.182950||measurement||ad||2015-11-21 21:10:28.370065@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:10:32.183421||measurement||loadtime||0:00:05.850098||1||0
+2015-11-21 21:10:32.753100||measurement||ad||2015-11-21 21:10:30.605147@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:10:35.145570||measurement||ad||2015-11-21 21:10:30.605147@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||3||0
+2015-11-21 21:10:36.854324||measurement||ad||2015-11-21 21:10:30.605147@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||3||0
+2015-11-21 21:10:36.854623||measurement||loadtime||0:00:07.570275||3||0
+2015-11-21 21:10:40.550481||measurement||ad||2015-11-21 21:10:38.403121@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 21:10:40.699993||measurement||ad||2015-11-21 21:10:38.403121@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:10:41.203112||measurement||ad||2015-11-21 21:10:38.403121@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 21:10:41.203408||measurement||loadtime||0:00:04.018769||1||0
+2015-11-21 21:10:41.569309||measurement||ad||2015-11-21 21:10:41.164225@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:10:41.726424||measurement||ad||2015-11-21 21:10:41.164225@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||0||1
+2015-11-21 21:10:41.831592||measurement||ad||2015-11-21 21:10:41.164225@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:10:41.831851||measurement||loadtime||0:00:11.005056||0||1
+2015-11-21 21:10:44.308912||measurement||ad||2015-11-21 21:10:43.056865@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:10:44.343449||measurement||ad||2015-11-21 21:10:43.903059@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||2||1
+2015-11-21 21:10:44.493771||measurement||ad||2015-11-21 21:10:43.056865@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||3||0
+2015-11-21 21:10:44.538218||measurement||ad||2015-11-21 21:10:43.903059@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||2||1
+2015-11-21 21:10:44.657523||measurement||ad||2015-11-21 21:10:43.056865@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||3||0
+2015-11-21 21:10:44.657813||measurement||loadtime||0:00:02.802734||3||0
+2015-11-21 21:10:44.661001||measurement||ad||2015-11-21 21:10:43.903059@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:10:44.661364||measurement||loadtime||0:00:11.148734||2||1
+2015-11-21 21:10:48.296269||measurement||ad||2015-11-21 21:10:46.827616@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 21:10:48.469205||measurement||ad||2015-11-21 21:10:46.827616@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:10:48.565219||measurement||ad||2015-11-21 21:10:46.827616@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 21:10:48.565733||measurement||loadtime||0:00:02.361005||1||0
+2015-11-21 21:10:53.210109||measurement||ad||2015-11-21 21:10:51.209557@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:10:53.975054||measurement||ad||2015-11-21 21:10:51.209557@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:10:55.044868||measurement||ad||2015-11-21 21:10:51.209557@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||0
+2015-11-21 21:10:55.045180||measurement||loadtime||0:00:05.386758||3||0
+2015-11-21 21:10:56.315581||measurement||ad||2015-11-21 21:10:55.932778@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:10:56.456379||measurement||ad||2015-11-21 21:10:55.932778@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:10:56.612554||measurement||ad||2015-11-21 21:10:55.932778@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:10:56.613009||measurement||loadtime||0:00:09.779780||0||1
+2015-11-21 21:10:57.864231||measurement||ad||2015-11-21 21:10:55.328664@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:10:58.039009||measurement||ad||2015-11-21 21:10:55.328664@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||1||0
+2015-11-21 21:10:58.167576||measurement||ad||2015-11-21 21:10:55.328664@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||0
+2015-11-21 21:10:58.167901||measurement||loadtime||0:00:04.601200||1||0
+2015-11-21 21:11:01.353094||measurement||ad||2015-11-21 21:10:59.985284@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:11:01.937855||measurement||ad||2015-11-21 21:10:59.985284@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:11:02.184550||measurement||ad||2015-11-21 21:10:59.985284@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||2||1
+2015-11-21 21:11:02.184830||measurement||loadtime||0:00:12.522697||2||1
+2015-11-21 21:11:03.758715||measurement||ad||2015-11-21 21:11:00.511620@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:11:03.918118||measurement||ad||2015-11-21 21:11:00.511620@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:11:04.462402||measurement||ad||2015-11-21 21:11:00.511620@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||3||0
+2015-11-21 21:11:04.462689||measurement||loadtime||0:00:04.417103||3||0
+2015-11-21 21:11:06.098192||measurement||ad||2015-11-21 21:11:04.222726@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 21:11:06.237397||measurement||ad||2015-11-21 21:11:04.222726@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:11:06.539702||measurement||ad||2015-11-21 21:11:04.222726@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 21:11:06.540021||measurement||loadtime||0:00:03.371231||1||0
+2015-11-21 21:11:10.971519||measurement||ad||2015-11-21 21:11:10.756001@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:11:11.105667||measurement||ad||2015-11-21 21:11:10.756001@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:11:11.229187||measurement||ad||2015-11-21 21:11:10.756001@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:11:11.229543||measurement||loadtime||0:00:09.615679||0||1
+2015-11-21 21:11:12.374003||measurement||ad||2015-11-21 21:11:10.494732@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:11:12.639017||measurement||ad||2015-11-21 21:11:10.494732@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||3||0
+2015-11-21 21:11:12.833357||measurement||ad||2015-11-21 21:11:10.494732@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||3||0
+2015-11-21 21:11:12.833652||measurement||loadtime||0:00:03.369687||3||0
+2015-11-21 21:11:14.615989||measurement||ad||2015-11-21 21:11:12.259824@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||0
+2015-11-21 21:11:14.616311||measurement||loadtime||0:00:03.075713||1||0
+2015-11-21 21:11:16.104160||measurement||ad||2015-11-21 21:11:15.403087@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:11:16.227444||measurement||ad||2015-11-21 21:11:15.403087@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:11:16.776745||measurement||ad||2015-11-21 21:11:15.403087@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||2||1
+2015-11-21 21:11:16.777417||measurement||loadtime||0:00:09.591976||2||1
+2015-11-21 21:11:20.512044||measurement||ad||2015-11-21 21:11:18.814559@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:11:20.616821||measurement||ad||2015-11-21 21:11:18.814559@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||3||0
+2015-11-21 21:11:20.716154||measurement||ad||2015-11-21 21:11:18.814559@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||3||0
+2015-11-21 21:11:20.716393||measurement||loadtime||0:00:02.882313||3||0
+2015-11-21 21:11:22.252945||measurement||ad||2015-11-21 21:11:20.417400@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||1||0
+2015-11-21 21:11:22.565580||measurement||ad||2015-11-21 21:11:20.417400@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:11:22.703856||measurement||ad||2015-11-21 21:11:20.417400@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:11:22.704112||measurement||loadtime||0:00:03.086363||1||0
+2015-11-21 21:11:25.916631||measurement||ad||2015-11-21 21:11:25.117131@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:11:26.206747||measurement||ad||2015-11-21 21:11:25.117131@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:11:26.503368||measurement||ad||2015-11-21 21:11:25.117131@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-21 21:11:26.503621||measurement||loadtime||0:00:10.273217||0||1
+2015-11-21 21:11:28.375990||error||collecting ads||Error||1||0
+2015-11-21 21:11:28.376229||event||progress-marker||measurement-end||1||0
+2015-11-21 21:11:28.690811||measurement||ad||2015-11-21 21:11:26.768395@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||0
+2015-11-21 21:11:28.691123||measurement||loadtime||0:00:02.972978||3||0
+2015-11-21 21:11:29.983319||measurement||ad||2015-11-21 21:11:29.835971@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||2||1
+2015-11-21 21:11:30.069047||measurement||ad||2015-11-21 21:11:29.835971@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:11:30.152051||measurement||ad||2015-11-21 21:11:29.835971@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||2||1
+2015-11-21 21:11:30.152315||measurement||loadtime||0:00:08.374476||2||1
+2015-11-21 21:11:35.273692||measurement||ad||2015-11-21 21:11:34.287060@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:11:35.463208||measurement||ad||2015-11-21 21:11:34.287060@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:11:35.581222||measurement||ad||2015-11-21 21:11:34.287060@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:11:35.581558||measurement||loadtime||0:00:01.889713||3||0
+2015-11-21 21:11:35.581690||event||progress-marker||measurement-end||3||0
+2015-11-21 21:11:36.357275||measurement||ad||2015-11-21 21:11:35.165380@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:11:36.460444||measurement||ad||2015-11-21 21:11:35.165380@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:11:36.552857||measurement||ad||2015-11-21 21:11:35.165380@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-21 21:11:36.553152||measurement||loadtime||0:00:05.048163||0||1
+2015-11-21 21:11:40.017975||measurement||ad||2015-11-21 21:11:39.771345@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:11:40.137056||measurement||ad||2015-11-21 21:11:39.771345@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:11:40.248874||measurement||ad||2015-11-21 21:11:39.771345@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||2||1
+2015-11-21 21:11:40.249207||measurement||loadtime||0:00:05.096214||2||1
+2015-11-21 21:11:47.278367||measurement||ad||2015-11-21 21:11:47.138867@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:11:47.358653||measurement||ad||2015-11-21 21:11:47.138867@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:11:47.444768||measurement||ad||2015-11-21 21:11:47.138867@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:11:47.445411||measurement||loadtime||0:00:05.890827||0||1
+2015-11-21 21:11:50.862960||measurement||ad||2015-11-21 21:11:50.674207@|Infinity: Better Lending.@|infinityels.com/loan_products.html@|Save Money on Loan Software Easy to use lending software||2||1
+2015-11-21 21:11:50.916002||measurement||ad||2015-11-21 21:11:50.674207@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:11:50.965522||measurement||ad||2015-11-21 21:11:50.674207@|Online Finance Courses@|www.bizflix.com@|Unlimited access to thousands of courses. Start a risk free trial!||2||1
+2015-11-21 21:11:50.965759||measurement||loadtime||0:00:05.715132||2||1
+2015-11-21 21:11:56.143744||measurement||ad||2015-11-21 21:11:55.802385@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:11:56.211953||measurement||ad||2015-11-21 21:11:55.802385@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:11:56.296414||measurement||ad||2015-11-21 21:11:55.802385@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-21 21:11:56.296650||measurement||loadtime||0:00:03.850545||0||1
+2015-11-21 21:12:00.953884||measurement||ad||2015-11-21 21:12:00.763234@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:12:01.009954||measurement||ad||2015-11-21 21:12:00.763234@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:12:01.072370||measurement||ad||2015-11-21 21:12:00.763234@|MS. I.T.@|cjaka07.com@|tech blog for women educational resources tech||2||1
+2015-11-21 21:12:01.072540||measurement||loadtime||0:00:05.105247||2||1
+2015-11-21 21:12:02.664682||measurement||ad||2015-11-21 21:12:01.397054@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:12:02.716420||measurement||ad||2015-11-21 21:12:01.397054@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:12:02.761462||measurement||ad||2015-11-21 21:12:01.397054@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:12:02.761795||measurement||loadtime||0:00:01.464328||0||1
+2015-11-21 21:12:08.412355||measurement||ad||2015-11-21 21:12:06.157885@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||2||1
+2015-11-21 21:12:08.763842||measurement||ad||2015-11-21 21:12:06.157885@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||2||1
+2015-11-21 21:12:10.403510||measurement||ad||2015-11-21 21:12:06.157885@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:12:10.404047||measurement||loadtime||0:00:04.330426||2||1
+2015-11-21 21:12:14.035477||measurement||ad||2015-11-21 21:12:13.862052@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:12:14.152588||measurement||ad||2015-11-21 21:12:13.862052@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-21 21:12:14.349235||measurement||ad||2015-11-21 21:12:13.862052@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:12:14.349589||measurement||loadtime||0:00:06.587011||0||1
+2015-11-21 21:12:14.349746||event||progress-marker||measurement-end||0||1
+2015-11-21 21:12:19.408546||measurement||ad||2015-11-21 21:12:19.285568@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||2||1
+2015-11-21 21:12:19.462722||measurement||ad||2015-11-21 21:12:19.285568@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||2||1
+2015-11-21 21:12:19.507330||measurement||ad||2015-11-21 21:12:19.285568@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:12:19.507570||measurement||loadtime||0:00:04.101607||2||1
+2015-11-21 21:12:19.507659||event||progress-marker||measurement-end||2||1
+2015-11-21 21:12:19.739846||meta||block_id end||8
+2015-11-21 21:12:19.740369||meta||block_id start||9
+2015-11-21 21:12:19.740386||meta||assignment||1@|3@|0@|2
+2015-11-21 21:12:22.307875||event||progress-marker||training-start||3||0
+2015-11-21 21:12:22.308194||event||progress-marker||training-end||3||0
+2015-11-21 21:12:22.356762||event||progress-marker||training-start||1||0
+2015-11-21 21:12:22.357179||event||progress-marker||training-end||1||0
+2015-11-21 21:12:24.962595||event||progress-marker||training-start||0||1
+2015-11-21 21:12:24.962846||event||progress-marker||training-end||0||1
+2015-11-21 21:12:24.963590||event||progress-marker||training-start||2||1
+2015-11-21 21:12:24.963917||event||progress-marker||training-end||2||1
+2015-11-21 21:12:27.326970||event||progress-marker||measurement-start||3||0
+2015-11-21 21:12:27.375359||event||progress-marker||measurement-start||1||0
+2015-11-21 21:12:29.977141||event||progress-marker||measurement-start||0||1
+2015-11-21 21:12:29.977285||event||progress-marker||measurement-start||2||1
+2015-11-21 21:12:36.863310||measurement||ad||2015-11-21 21:12:34.385638@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:12:37.099252||measurement||ad||2015-11-21 21:12:34.931026@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:12:37.251457||measurement||ad||2015-11-21 21:12:34.385638@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||1||0
+2015-11-21 21:12:37.534528||measurement||ad||2015-11-21 21:12:34.931026@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||3||0
+2015-11-21 21:12:37.741919||measurement||ad||2015-11-21 21:12:34.931026@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 21:12:37.742306||measurement||loadtime||0:00:05.413821||3||0
+2015-11-21 21:12:40.977664||measurement||ad||2015-11-21 21:12:34.385638@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||0
+2015-11-21 21:12:40.979627||measurement||loadtime||0:00:08.603677||1||0
+2015-11-21 21:12:43.972402||error||collecting ads||Error||3||0
+2015-11-21 21:12:47.765518||measurement||ad||2015-11-21 21:12:46.495270@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:12:47.881106||measurement||ad||2015-11-21 21:12:46.495270@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:12:48.049544||measurement||ad||2015-11-21 21:12:46.495270@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As much as $25,000 from 6.04% APR Easy Process, Free Quotes. Act Now!||2||1
+2015-11-21 21:12:48.049816||measurement||loadtime||0:00:13.071185||2||1
+2015-11-21 21:12:48.053154||measurement||ad||2015-11-21 21:12:47.409032@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:12:48.127035||measurement||ad||2015-11-21 21:12:47.409032@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:12:48.233728||measurement||ad||2015-11-21 21:12:47.409032@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||0||1
+2015-11-21 21:12:48.234063||measurement||loadtime||0:00:13.256267||0||1
+2015-11-21 21:12:49.915845||measurement||ad||2015-11-21 21:12:46.296845@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:12:50.131127||measurement||ad||2015-11-21 21:12:46.296845@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:12:50.911474||error||collecting ads||Error||3||0
+2015-11-21 21:12:51.524301||measurement||ad||2015-11-21 21:12:46.296845@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-21 21:12:51.524606||measurement||loadtime||0:00:05.544209||1||0
+2015-11-21 21:13:00.065137||measurement||ad||2015-11-21 21:12:57.717136@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:13:00.274679||measurement||ad||2015-11-21 21:12:57.717136@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:13:00.493565||measurement||ad||2015-11-21 21:12:56.782158@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 21:13:02.015998||measurement||ad||2015-11-21 21:12:56.782158@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||3||0
+2015-11-21 21:13:02.547656||measurement||ad||2015-11-21 21:12:57.717136@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 21:13:02.548223||measurement||loadtime||0:00:06.022510||1||0
+2015-11-21 21:13:03.626287||measurement||ad||2015-11-21 21:12:56.782158@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||3||0
+2015-11-21 21:13:03.626632||measurement||loadtime||0:00:07.714643||3||0
+2015-11-21 21:13:05.003751||measurement||ad||2015-11-21 21:13:03.873114@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:13:05.131876||measurement||ad||2015-11-21 21:13:03.873114@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:13:05.282671||measurement||ad||2015-11-21 21:13:03.873114@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:13:05.284010||measurement||loadtime||0:00:12.232770||2||1
+2015-11-21 21:13:06.972515||measurement||ad||2015-11-21 21:13:06.588951@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||0||1
+2015-11-21 21:13:07.041284||measurement||ad||2015-11-21 21:13:06.588951@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:13:07.137445||measurement||ad||2015-11-21 21:13:06.588951@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||0||1
+2015-11-21 21:13:07.137618||measurement||loadtime||0:00:13.902928||0||1
+2015-11-21 21:13:09.703351||measurement||ad||2015-11-21 21:13:08.283631@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||1||0
+2015-11-21 21:13:09.819169||measurement||ad||2015-11-21 21:13:08.283631@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||0
+2015-11-21 21:13:09.909152||measurement||ad||2015-11-21 21:13:08.283631@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||1||0
+2015-11-21 21:13:09.909475||measurement||loadtime||0:00:02.357759||1||0
+2015-11-21 21:13:10.752491||measurement||ad||2015-11-21 21:13:09.242313@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:13:10.902544||measurement||ad||2015-11-21 21:13:09.242313@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:13:11.071704||measurement||ad||2015-11-21 21:13:09.242313@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||0
+2015-11-21 21:13:11.071973||measurement||loadtime||0:00:02.444826||3||0
+2015-11-21 21:13:18.333674||measurement||ad||2015-11-21 21:13:16.441451@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:13:18.732668||measurement||ad||2015-11-21 21:13:16.441451@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||0
+2015-11-21 21:13:19.553161||measurement||ad||2015-11-21 21:13:17.240637@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:13:19.586826||measurement||ad||2015-11-21 21:13:18.998284@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:13:19.763883||measurement||ad||2015-11-21 21:13:16.441451@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||1||0
+2015-11-21 21:13:19.764192||measurement||loadtime||0:00:04.853392||1||0
+2015-11-21 21:13:19.770781||measurement||ad||2015-11-21 21:13:17.240637@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:13:19.858849||measurement||ad||2015-11-21 21:13:18.998284@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:13:20.040712||measurement||ad||2015-11-21 21:13:18.998284@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:13:20.041009||measurement||loadtime||0:00:09.755440||2||1
+2015-11-21 21:13:20.286665||measurement||ad||2015-11-21 21:13:17.240637@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||0
+2015-11-21 21:13:20.287064||measurement||loadtime||0:00:04.214553||3||0
+2015-11-21 21:13:22.595858||measurement||ad||2015-11-21 21:13:22.083369@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:13:22.762907||measurement||ad||2015-11-21 21:13:22.083369@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:13:22.850025||measurement||ad||2015-11-21 21:13:22.083369@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:13:22.850310||measurement||loadtime||0:00:10.711441||0||1
+2015-11-21 21:13:27.281214||error||collecting ads||Error||3||0
+2015-11-21 21:13:30.580815||measurement||ad||2015-11-21 21:13:27.083144@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:13:32.330522||measurement||ad||2015-11-21 21:13:27.083144@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||1||0
+2015-11-21 21:13:32.453253||measurement||ad||2015-11-21 21:13:32.249309@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:13:32.525118||measurement||ad||2015-11-21 21:13:32.249309@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:13:32.606008||measurement||ad||2015-11-21 21:13:32.249309@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:13:32.606291||measurement||loadtime||0:00:07.564063||2||1
+2015-11-21 21:13:33.928009||measurement||ad||2015-11-21 21:13:27.083144@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:13:33.930179||measurement||loadtime||0:00:09.164907||1||0
+2015-11-21 21:13:34.100372||measurement||ad||2015-11-21 21:13:33.202978@|16 Biggest Dogs Ever@|pressroomvip.com/16-Biggest-Dogs@|See the Biggest Dogs of All Time! You'll Never Believe #6.||0||1
+2015-11-21 21:13:34.237158||measurement||ad||2015-11-21 21:13:33.202978@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||0||1
+2015-11-21 21:13:34.418682||measurement||ad||2015-11-21 21:13:33.202978@|All Electric Car Bargains@|shopperstop.us/All-Electric-Car@|Top Cyber Monday 2015 Daily Deals! Find All Electric Car  Save Big||0||1
+2015-11-21 21:13:34.418992||measurement||loadtime||0:00:06.567168||0||1
+2015-11-21 21:13:34.785773||error||collecting ads||Error||3||0
+2015-11-21 21:13:39.939741||measurement||ad||2015-11-21 21:13:37.899181@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:13:40.208899||measurement||ad||2015-11-21 21:13:37.899181@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:13:41.476383||error||collecting ads||Error||1||0
+2015-11-21 21:13:42.318299||measurement||ad||2015-11-21 21:13:37.899181@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:13:42.318566||measurement||loadtime||0:00:04.710971||2||1
+2015-11-21 21:13:45.180003||error||collecting ads||Error||3||0
+2015-11-21 21:13:46.168309||measurement||ad||2015-11-21 21:13:46.062950@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:13:46.269123||measurement||ad||2015-11-21 21:13:46.062950@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:13:46.356434||measurement||ad||2015-11-21 21:13:46.062950@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||0||1
+2015-11-21 21:13:46.356754||measurement||loadtime||0:00:06.935799||0||1
+2015-11-21 21:13:48.484761||error||collecting ads||Error||1||0
+2015-11-21 21:13:51.573897||measurement||ad||2015-11-21 21:13:51.331320@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:13:51.689157||measurement||ad||2015-11-21 21:13:51.331320@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:13:51.787408||measurement||ad||2015-11-21 21:13:51.331320@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||1
+2015-11-21 21:13:51.787729||measurement||loadtime||0:00:04.467729||2||1
+2015-11-21 21:13:55.377942||measurement||ad||2015-11-21 21:13:52.185456@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:13:56.833868||measurement||ad||2015-11-21 21:13:52.185456@|6 Stocks Set to Soar@|profitabletrading.com@|Proprietary stock-ranking system signals: "buy these 6 stocks now".||3||0
+2015-11-21 21:13:57.538680||error||collecting ads||Error||1||0
+2015-11-21 21:13:59.474485||measurement||ad||2015-11-21 21:13:58.633750@|16 Biggest Dogs Ever@|pressroomvip.com/16-Biggest-Dogs@|See the Biggest Dogs of All Time! You'll Never Believe #6.||0||1
+2015-11-21 21:13:59.654296||measurement||ad||2015-11-21 21:13:58.633750@|All Electric Car Bargains@|shopperstop.us/All-Electric-Car@|Top Cyber Monday 2015 Daily Deals! Find All Electric Car  Save Big||0||1
+2015-11-21 21:13:59.813116||measurement||ad||2015-11-21 21:13:58.633750@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-21 21:13:59.813380||measurement||loadtime||0:00:08.455932||0||1
+2015-11-21 21:14:01.256501||measurement||ad||2015-11-21 21:13:52.185456@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||0
+2015-11-21 21:14:01.256845||measurement||loadtime||0:00:11.075412||3||0
+2015-11-21 21:14:01.257080||event||progress-marker||measurement-end||3||0
+2015-11-21 21:14:04.151611||measurement||ad||2015-11-21 21:14:03.869639@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:14:04.297511||measurement||ad||2015-11-21 21:14:03.869639@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:14:04.406154||measurement||ad||2015-11-21 21:14:03.869639@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:14:04.406458||measurement||loadtime||0:00:07.618276||2||1
+2015-11-21 21:14:05.533898||measurement||ad||2015-11-21 21:14:03.107623@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:14:06.233386||measurement||ad||2015-11-21 21:14:03.107623@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:14:07.025516||measurement||ad||2015-11-21 21:14:03.107623@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 21:14:07.025799||measurement||loadtime||0:00:04.486294||1||0
+2015-11-21 21:14:07.025981||event||progress-marker||measurement-end||1||0
+2015-11-21 21:14:08.752127||measurement||ad||2015-11-21 21:14:04.993013@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:14:09.300641||measurement||ad||2015-11-21 21:14:04.993013@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:14:09.378471||measurement||ad||2015-11-21 21:14:04.993013@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:14:09.378976||measurement||loadtime||0:00:04.564407||0||1
+2015-11-21 21:14:14.436338||measurement||ad||2015-11-21 21:14:14.322698@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:14:14.524550||measurement||ad||2015-11-21 21:14:14.322698@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:14:14.601576||measurement||ad||2015-11-21 21:14:14.322698@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:14:14.601877||measurement||loadtime||0:00:05.194882||2||1
+2015-11-21 21:14:18.699120||measurement||ad||2015-11-21 21:14:18.511104@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:14:18.760367||measurement||ad||2015-11-21 21:14:18.511104@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:14:18.821829||measurement||ad||2015-11-21 21:14:18.511104@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||0||1
+2015-11-21 21:14:18.822132||measurement||loadtime||0:00:04.442256||0||1
+2015-11-21 21:14:24.657954||measurement||ad||2015-11-21 21:14:24.519012@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:14:24.764857||measurement||ad||2015-11-21 21:14:24.519012@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:14:24.903243||measurement||ad||2015-11-21 21:14:24.519012@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||1
+2015-11-21 21:14:24.903534||measurement||loadtime||0:00:05.300112||2||1
+2015-11-21 21:14:28.270503||measurement||ad||2015-11-21 21:14:28.118563@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:14:28.345782||measurement||ad||2015-11-21 21:14:28.118563@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:14:28.430256||measurement||ad||2015-11-21 21:14:28.118563@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:14:28.430583||measurement||loadtime||0:00:04.607343||0||1
+2015-11-21 21:14:35.521887||measurement||ad||2015-11-21 21:14:35.219498@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:14:35.928180||measurement||ad||2015-11-21 21:14:35.219498@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:14:36.101243||measurement||ad||2015-11-21 21:14:35.219498@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||1
+2015-11-21 21:14:36.102874||measurement||loadtime||0:00:06.197817||2||1
+2015-11-21 21:14:36.103185||event||progress-marker||measurement-end||2||1
+2015-11-21 21:14:38.009839||measurement||ad||2015-11-21 21:14:37.945968@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:14:38.053019||measurement||ad||2015-11-21 21:14:37.945968@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:14:38.095698||measurement||ad||2015-11-21 21:14:37.945968@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:14:38.095953||measurement||loadtime||0:00:04.663518||0||1
+2015-11-21 21:14:38.096136||event||progress-marker||measurement-end||0||1
+2015-11-21 21:14:38.339248||meta||block_id end||9
+2015-11-21 21:14:38.341195||meta||block_id start||10
+2015-11-21 21:14:38.341244||meta||assignment||0@|1@|2@|3
+2015-11-21 21:14:40.782718||event||progress-marker||training-start||0||0
+2015-11-21 21:14:40.783040||event||progress-marker||training-end||0||0
+2015-11-21 21:14:40.839035||event||progress-marker||training-start||1||0
+2015-11-21 21:14:40.839524||event||progress-marker||training-end||1||0
+2015-11-21 21:14:43.527777||event||progress-marker||training-start||2||1
+2015-11-21 21:14:43.528116||event||progress-marker||training-end||2||1
+2015-11-21 21:14:43.570065||event||progress-marker||training-start||3||1
+2015-11-21 21:14:43.570295||event||progress-marker||training-end||3||1
+2015-11-21 21:14:45.804595||event||progress-marker||measurement-start||0||0
+2015-11-21 21:14:45.926618||event||progress-marker||measurement-start||1||0
+2015-11-21 21:14:48.545380||event||progress-marker||measurement-start||2||1
+2015-11-21 21:14:48.585504||event||progress-marker||measurement-start||3||1
+2015-11-21 21:14:53.209314||measurement||ad||2015-11-21 21:14:52.344491@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:14:53.808022||measurement||ad||2015-11-21 21:14:52.565521@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:14:54.055804||measurement||ad||2015-11-21 21:14:52.344491@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||0||0
+2015-11-21 21:14:54.167227||measurement||ad||2015-11-21 21:14:52.565521@|Meds: Osteoporosis@|everydayhealth.com/Osteoporosis@|Learn About Osteoporosis Drugs and Other Helpful Treatments.||1||0
+2015-11-21 21:14:54.545703||measurement||ad||2015-11-21 21:14:52.565521@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||1||0
+2015-11-21 21:14:54.548588||measurement||loadtime||0:00:03.620186||1||0
+2015-11-21 21:14:55.990477||measurement||ad||2015-11-21 21:14:52.344491@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||0||0
+2015-11-21 21:14:55.990803||measurement||loadtime||0:00:05.184708||0||0
+2015-11-21 21:15:02.432529||error||collecting ads||Error||0||0
+2015-11-21 21:15:04.274967||measurement||ad||2015-11-21 21:15:02.689450@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:15:04.692893||measurement||ad||2015-11-21 21:15:02.689450@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:15:04.772019||measurement||ad||2015-11-21 21:15:04.011113@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:15:05.015910||measurement||ad||2015-11-21 21:15:04.011113@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:15:05.117602||measurement||ad||2015-11-21 21:15:04.011113@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:15:05.117865||measurement||loadtime||0:00:11.571462||2||1
+2015-11-21 21:15:05.473349||measurement||ad||2015-11-21 21:15:02.689450@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-21 21:15:05.473683||measurement||loadtime||0:00:05.923282||1||0
+2015-11-21 21:15:07.802287||measurement||ad||2015-11-21 21:15:06.490728@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:15:08.172826||measurement||ad||2015-11-21 21:15:06.490728@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||3||1
+2015-11-21 21:15:08.413548||measurement||ad||2015-11-21 21:15:06.490728@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||3||1
+2015-11-21 21:15:08.413878||measurement||loadtime||0:00:14.826873||3||1
+2015-11-21 21:15:09.990687||error||collecting ads||Error||0||0
+2015-11-21 21:15:11.993156||error||collecting ads||Error||1||0
+2015-11-21 21:15:17.768143||measurement||ad||2015-11-21 21:15:16.233645@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:15:17.975724||measurement||ad||2015-11-21 21:15:16.233645@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||0
+2015-11-21 21:15:18.190187||measurement||ad||2015-11-21 21:15:16.233645@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||0||0
+2015-11-21 21:15:18.190478||measurement||loadtime||0:00:03.199155||0||0
+2015-11-21 21:15:18.916283||error||collecting ads||Error||1||0
+2015-11-21 21:15:23.769878||error||collecting ads||Error||0||0
+2015-11-21 21:15:25.881828||error||collecting ads||Error||1||0
+2015-11-21 21:15:26.542344||measurement||ad||2015-11-21 21:15:25.405711@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:15:26.712371||measurement||ad||2015-11-21 21:15:25.405711@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:15:26.988289||measurement||ad||2015-11-21 21:15:25.405711@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 21:15:26.988901||measurement||loadtime||0:00:13.573650||3||1
+2015-11-21 21:15:27.772736||measurement||ad||2015-11-21 21:15:20.222912@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:15:27.817288||measurement||ad||2015-11-21 21:15:20.222912@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:15:27.862644||measurement||ad||2015-11-21 21:15:20.222912@|SanDisk Mobile Blog@|sandiskmobility.com@|Find the latest on mobile lifestyle News and trends. Check it out now!||2||1
+2015-11-21 21:15:27.863317||measurement||loadtime||0:00:17.744110||2||1
+2015-11-21 21:15:31.276197||measurement||ad||2015-11-21 21:15:29.520727@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:15:31.432852||measurement||ad||2015-11-21 21:15:29.520727@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:15:31.620303||measurement||ad||2015-11-21 21:15:29.520727@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-21 21:15:31.620706||measurement||loadtime||0:00:02.849725||0||0
+2015-11-21 21:15:33.164660||measurement||ad||2015-11-21 21:15:31.660779@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:15:33.390800||measurement||ad||2015-11-21 21:15:31.660779@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:15:33.619339||measurement||ad||2015-11-21 21:15:31.660779@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||0
+2015-11-21 21:15:33.619612||measurement||loadtime||0:00:02.736292||1||0
+2015-11-21 21:15:37.337525||error||collecting ads||Error||0||0
+2015-11-21 21:15:40.769353||measurement||ad||2015-11-21 21:15:39.785403@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||1||0
+2015-11-21 21:15:41.008269||measurement||ad||2015-11-21 21:15:39.785403@|Orkin® Pest Control@|www.pestremovalzone.com@|Protect Your Home, Call The Experts And Schedule Service Now!||1||0
+2015-11-21 21:15:41.175198||measurement||ad||2015-11-21 21:15:39.785403@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||1||0
+2015-11-21 21:15:41.175664||measurement||loadtime||0:00:02.554718||1||0
+2015-11-21 21:15:43.292607||measurement||ad||2015-11-21 21:15:41.781350@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:15:43.591706||measurement||ad||2015-11-21 21:15:41.781350@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:15:43.928482||measurement||ad||2015-11-21 21:15:41.781350@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 21:15:43.928800||measurement||loadtime||0:00:11.939092||3||1
+2015-11-21 21:15:44.229800||measurement||ad||2015-11-21 21:15:42.949809@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||0
+2015-11-21 21:15:44.380511||measurement||ad||2015-11-21 21:15:42.949809@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:15:44.518598||measurement||ad||2015-11-21 21:15:42.949809@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||0
+2015-11-21 21:15:44.519025||measurement||loadtime||0:00:02.180846||0||0
+2015-11-21 21:15:48.225463||measurement||ad||2015-11-21 21:15:46.697284@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:15:48.536888||measurement||ad||2015-11-21 21:15:46.697284@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:15:49.478710||measurement||ad||2015-11-21 21:15:46.697284@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||0
+2015-11-21 21:15:49.479781||measurement||loadtime||0:00:03.302677||1||0
+2015-11-21 21:15:51.187158||measurement||ad||2015-11-21 21:15:50.623813@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||0
+2015-11-21 21:15:51.365872||measurement||ad||2015-11-21 21:15:50.623813@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:15:51.584013||measurement||ad||2015-11-21 21:15:50.623813@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||0
+2015-11-21 21:15:51.585055||measurement||loadtime||0:00:02.064566||0||0
+2015-11-21 21:15:54.447725||measurement||ad||2015-11-21 21:15:50.102280@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:15:55.524369||error||collecting ads||Error||1||0
+2015-11-21 21:15:56.595141||measurement||ad||2015-11-21 21:15:50.102280@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:15:56.793355||measurement||ad||2015-11-21 21:15:50.102280@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 21:15:56.793606||measurement||loadtime||0:00:07.861826||3||1
+2015-11-21 21:15:57.148972||measurement||ad||2015-11-21 21:15:56.758992@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:15:57.252906||measurement||ad||2015-11-21 21:15:56.758992@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||2||1
+2015-11-21 21:15:57.353342||measurement||ad||2015-11-21 21:15:56.758992@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||1
+2015-11-21 21:15:57.354714||measurement||loadtime||0:00:24.490143||2||1
+2015-11-21 21:15:58.834515||measurement||ad||2015-11-21 21:15:57.879138@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:15:59.234797||measurement||ad||2015-11-21 21:15:57.879138@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||0
+2015-11-21 21:15:59.526376||measurement||ad||2015-11-21 21:15:57.879138@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||0||0
+2015-11-21 21:15:59.526799||measurement||loadtime||0:00:02.941003||0||0
+2015-11-21 21:15:59.526982||event||progress-marker||measurement-end||0||0
+2015-11-21 21:16:01.092542||error||collecting ads||Error||1||0
+2015-11-21 21:16:01.092776||event||progress-marker||measurement-end||1||0
+2015-11-21 21:16:08.213120||measurement||ad||2015-11-21 21:16:07.963440@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:16:08.281780||measurement||ad||2015-11-21 21:16:07.610226@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||3||1
+2015-11-21 21:16:08.389225||measurement||ad||2015-11-21 21:16:07.963440@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||2||1
+2015-11-21 21:16:08.489795||measurement||ad||2015-11-21 21:16:07.963440@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:16:08.490082||measurement||loadtime||0:00:06.133505||2||1
+2015-11-21 21:16:08.497173||measurement||ad||2015-11-21 21:16:07.610226@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||3||1
+2015-11-21 21:16:08.605560||measurement||ad||2015-11-21 21:16:07.610226@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:16:08.605915||measurement||loadtime||0:00:06.810985||3||1
+2015-11-21 21:16:19.537663||measurement||ad||2015-11-21 21:16:19.368919@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||2||1
+2015-11-21 21:16:19.628582||measurement||ad||2015-11-21 21:16:19.368919@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||1
+2015-11-21 21:16:19.735394||measurement||ad||2015-11-21 21:16:19.368919@|6 Stocks Set to Soar@|profitabletrading.com@|Proprietary stock-ranking system signals: "buy these 6 stocks now".||2||1
+2015-11-21 21:16:19.735702||measurement||loadtime||0:00:06.245062||2||1
+2015-11-21 21:16:21.293164||measurement||ad||2015-11-21 21:16:20.854501@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:16:21.371341||measurement||ad||2015-11-21 21:16:20.854501@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:16:21.437147||measurement||ad||2015-11-21 21:16:20.854501@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:16:21.437468||measurement||loadtime||0:00:07.830622||3||1
+2015-11-21 21:16:30.951641||measurement||ad||2015-11-21 21:16:30.867561@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:16:31.014240||measurement||ad||2015-11-21 21:16:30.867561@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:16:31.074808||measurement||ad||2015-11-21 21:16:30.867561@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||1
+2015-11-21 21:16:31.075137||measurement||loadtime||0:00:06.337989||2||1
+2015-11-21 21:16:32.716364||measurement||ad||2015-11-21 21:16:32.600461@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:16:32.815941||measurement||ad||2015-11-21 21:16:32.600461@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:16:32.913409||measurement||ad||2015-11-21 21:16:32.600461@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:16:32.913683||measurement||loadtime||0:00:06.475775||3||1
+2015-11-21 21:16:41.156270||measurement||ad||2015-11-21 21:16:40.838317@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:16:41.307254||measurement||ad||2015-11-21 21:16:40.838317@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||1
+2015-11-21 21:16:41.408835||measurement||ad||2015-11-21 21:16:40.838317@|Start Download@|free.convertanyfile.com@|File size: 487KB. Full Version. Rating: 5.0 Stars. ConvertAnyFile.||2||1
+2015-11-21 21:16:41.410306||measurement||loadtime||0:00:05.334590||2||1
+2015-11-21 21:16:44.128523||measurement||ad||2015-11-21 21:16:43.877684@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:16:44.316713||measurement||ad||2015-11-21 21:16:43.877684@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:16:44.448484||measurement||ad||2015-11-21 21:16:43.877684@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 21:16:44.448735||measurement||loadtime||0:00:06.533697||3||1
+2015-11-21 21:16:50.581508||measurement||ad||2015-11-21 21:16:50.480923@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:16:50.644276||measurement||ad||2015-11-21 21:16:50.480923@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||1
+2015-11-21 21:16:50.694888||measurement||ad||2015-11-21 21:16:50.480923@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:16:50.695167||measurement||loadtime||0:00:04.283429||2||1
+2015-11-21 21:16:54.305859||measurement||ad||2015-11-21 21:16:54.215503@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||3||1
+2015-11-21 21:16:54.364036||measurement||ad||2015-11-21 21:16:54.215503@|Signs Of Osteoporosis@|everydayhealth.com/Osteoporosis@|Visit Our Osteoporosis Center to Learn Symptoms, Treatments And More||3||1
+2015-11-21 21:16:54.420997||measurement||ad||2015-11-21 21:16:54.215503@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||3||1
+2015-11-21 21:16:54.421300||measurement||loadtime||0:00:04.971357||3||1
+2015-11-21 21:16:59.914733||measurement||ad||2015-11-21 21:16:59.549363@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:17:00.039701||measurement||ad||2015-11-21 21:16:59.549363@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:17:00.109269||measurement||ad||2015-11-21 21:16:59.549363@|Restaurnt Coupons@|listscoop.com/Coupons@|Top 5 Printable Restaurant Coupons November 2015 Hottest Deals, Hurry!||2||1
+2015-11-21 21:17:00.109577||measurement||loadtime||0:00:04.413181||2||1
+2015-11-21 21:17:04.131522||measurement||ad||2015-11-21 21:17:04.054089@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:17:04.188956||measurement||ad||2015-11-21 21:17:04.054089@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 21:17:04.242039||measurement||ad||2015-11-21 21:17:04.054089@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||1
+2015-11-21 21:17:04.242432||measurement||loadtime||0:00:04.820717||3||1
+2015-11-21 21:17:04.242590||event||progress-marker||measurement-end||3||1
+2015-11-21 21:17:09.208989||measurement||ad||2015-11-21 21:17:09.088947@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||2||1
+2015-11-21 21:17:09.262313||measurement||ad||2015-11-21 21:17:09.088947@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||1
+2015-11-21 21:17:09.305213||measurement||ad||2015-11-21 21:17:09.088947@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||2||1
+2015-11-21 21:17:09.305545||measurement||loadtime||0:00:04.194605||2||1
+2015-11-21 21:17:09.305714||event||progress-marker||measurement-end||2||1
+2015-11-21 21:17:09.541530||meta||block_id end||10
+2015-11-21 21:17:09.542409||meta||block_id start||11
+2015-11-21 21:17:09.542439||meta||assignment||2@|0@|1@|3
+2015-11-21 21:17:11.876876||event||progress-marker||training-start||2||0
+2015-11-21 21:17:11.877190||event||progress-marker||training-end||2||0
+2015-11-21 21:17:12.013021||event||progress-marker||training-start||0||0
+2015-11-21 21:17:12.013344||event||progress-marker||training-end||0||0
+2015-11-21 21:17:14.727878||event||progress-marker||training-start||1||1
+2015-11-21 21:17:14.728149||event||progress-marker||training-end||1||1
+2015-11-21 21:17:14.730396||event||progress-marker||training-start||3||1
+2015-11-21 21:17:14.730772||event||progress-marker||training-end||3||1
+2015-11-21 21:17:16.898442||event||progress-marker||measurement-start||2||0
+2015-11-21 21:17:17.040367||event||progress-marker||measurement-start||0||0
+2015-11-21 21:17:19.746530||event||progress-marker||measurement-start||1||1
+2015-11-21 21:17:19.747827||event||progress-marker||measurement-start||3||1
+2015-11-21 21:17:24.107890||measurement||ad||2015-11-21 21:17:23.702889@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||0
+2015-11-21 21:17:24.304027||measurement||ad||2015-11-21 21:17:23.890813@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:17:25.435864||measurement||ad||2015-11-21 21:17:23.702889@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||0
+2015-11-21 21:17:25.601749||measurement||ad||2015-11-21 21:17:23.702889@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||0||0
+2015-11-21 21:17:25.602080||measurement||loadtime||0:00:03.560299||0||0
+2015-11-21 21:17:25.648526||measurement||ad||2015-11-21 21:17:23.890813@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:17:25.727460||measurement||ad||2015-11-21 21:17:23.890813@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 21:17:25.727681||measurement||loadtime||0:00:03.827660||2||0
+2015-11-21 21:17:33.146205||error||collecting ads||Error||2||0
+2015-11-21 21:17:33.922183||measurement||ad||2015-11-21 21:17:31.927823@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-21 21:17:34.118132||measurement||ad||2015-11-21 21:17:31.927823@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||0
+2015-11-21 21:17:34.672579||measurement||ad||2015-11-21 21:17:31.927823@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||0||0
+2015-11-21 21:17:34.672855||measurement||loadtime||0:00:04.069688||0||0
+2015-11-21 21:17:40.723832||measurement||ad||2015-11-21 21:17:39.151881@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:17:40.866940||measurement||ad||2015-11-21 21:17:39.151881@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:17:41.097903||measurement||ad||2015-11-21 21:17:39.151881@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:17:41.098361||measurement||loadtime||0:00:02.951642||2||0
+2015-11-21 21:17:41.618959||measurement||ad||2015-11-21 21:17:40.770460@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:17:41.740418||measurement||ad||2015-11-21 21:17:40.770460@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:17:41.877497||measurement||ad||2015-11-21 21:17:40.770460@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||0||0
+2015-11-21 21:17:41.877759||measurement||loadtime||0:00:02.204465||0||0
+2015-11-21 21:17:41.985970||measurement||ad||2015-11-21 21:17:41.267445@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:17:42.090388||measurement||ad||2015-11-21 21:17:41.267445@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||3||1
+2015-11-21 21:17:42.228176||measurement||ad||2015-11-21 21:17:41.267445@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||3||1
+2015-11-21 21:17:42.228540||measurement||loadtime||0:00:17.480213||3||1
+2015-11-21 21:17:42.409670||measurement||ad||2015-11-21 21:17:41.157771@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:17:42.509228||measurement||ad||2015-11-21 21:17:41.157771@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||1
+2015-11-21 21:17:42.568691||measurement||ad||2015-11-21 21:17:41.157771@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||1||1
+2015-11-21 21:17:42.569001||measurement||loadtime||0:00:17.821011||1||1
+2015-11-21 21:17:47.503572||measurement||ad||2015-11-21 21:17:46.686670@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:17:47.670948||measurement||ad||2015-11-21 21:17:46.686670@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:17:47.774668||measurement||ad||2015-11-21 21:17:46.686670@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:17:47.775015||measurement||loadtime||0:00:01.675931||2||0
+2015-11-21 21:17:48.503481||measurement||ad||2015-11-21 21:17:47.636388@|Cheaply Remove Bed Bugs@|bedroomguardian.com/@|Finally a Solution to Get Rid Of Bed Bugs. Attract, Traps  Kills!||0||0
+2015-11-21 21:17:48.641669||measurement||ad||2015-11-21 21:17:47.636388@|Power Plant@|livelocal.net/Power-Plant@|All the Information in One Place. Updated one minute ago!||0||0
+2015-11-21 21:17:48.771256||measurement||ad||2015-11-21 21:17:47.636388@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||0
+2015-11-21 21:17:48.771525||measurement||loadtime||0:00:01.893412||0||0
+2015-11-21 21:17:54.715985||measurement||ad||2015-11-21 21:17:53.805006@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:17:54.854304||measurement||ad||2015-11-21 21:17:53.805006@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||2||0
+2015-11-21 21:17:55.026906||measurement||ad||2015-11-21 21:17:53.805006@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-21 21:17:55.027157||measurement||loadtime||0:00:02.250715||2||0
+2015-11-21 21:17:55.455200||measurement||ad||2015-11-21 21:17:54.617246@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:17:55.599152||measurement||ad||2015-11-21 21:17:54.617246@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||0
+2015-11-21 21:17:55.712580||measurement||ad||2015-11-21 21:17:54.617246@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:17:55.712918||measurement||loadtime||0:00:01.940260||0||0
+2015-11-21 21:18:00.062689||measurement||ad||2015-11-21 21:17:59.300838@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:18:00.779437||measurement||ad||2015-11-21 21:17:59.300838@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:18:01.276606||measurement||ad||2015-11-21 21:17:59.300838@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 21:18:01.278201||measurement||loadtime||0:00:13.708022||1||1
+2015-11-21 21:18:02.402668||measurement||ad||2015-11-21 21:18:00.793197@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:18:02.527116||measurement||ad||2015-11-21 21:18:00.793197@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:18:02.659374||measurement||ad||2015-11-21 21:18:01.777607@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:18:02.659769||measurement||ad||2015-11-21 21:18:00.793197@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||2||0
+2015-11-21 21:18:02.659995||measurement||loadtime||0:00:02.632089||2||0
+2015-11-21 21:18:02.987387||measurement||ad||2015-11-21 21:18:01.777607@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:18:03.189848||measurement||ad||2015-11-21 21:18:01.777607@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:18:03.190149||measurement||loadtime||0:00:02.476469||0||0
+2015-11-21 21:18:03.480530||measurement||ad||2015-11-21 21:18:02.997159@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:18:03.639836||measurement||ad||2015-11-21 21:18:02.997159@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:18:03.773085||measurement||ad||2015-11-21 21:18:02.997159@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:18:03.773342||measurement||loadtime||0:00:16.541596||3||1
+2015-11-21 21:18:09.282626||measurement||ad||2015-11-21 21:18:08.576299@|Mould Testing Laboratory@|Canada and US Labs@|Fast Lab Results ||2||0
+2015-11-21 21:18:09.283267||measurement||loadtime||0:00:01.622707||2||0
+2015-11-21 21:18:10.210480||measurement||ad||2015-11-21 21:18:08.572162@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:18:10.674994||measurement||ad||2015-11-21 21:18:08.572162@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||0
+2015-11-21 21:18:11.058139||measurement||ad||2015-11-21 21:18:08.572162@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:18:11.058522||measurement||loadtime||0:00:02.867949||0||0
+2015-11-21 21:18:16.036103||measurement||ad||2015-11-21 21:18:14.835332@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:18:16.166284||measurement||ad||2015-11-21 21:18:14.835332@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:18:16.407682||measurement||ad||2015-11-21 21:18:14.835332@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:18:16.408093||measurement||loadtime||0:00:02.124416||2||0
+2015-11-21 21:18:17.984338||measurement||ad||2015-11-21 21:18:17.254805@|Real World Grad Programs@|www.pointpark.edu/Graduate@|Dynamic Downtown Pittsburgh Campus Now Enrolling. Apply Online Free.||1||1
+2015-11-21 21:18:18.058537||measurement||ad||2015-11-21 21:18:16.493482@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:18:18.161395||measurement||ad||2015-11-21 21:18:17.254805@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||1||1
+2015-11-21 21:18:18.262694||measurement||ad||2015-11-21 21:18:16.493482@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||0||0
+2015-11-21 21:18:18.353230||measurement||ad||2015-11-21 21:18:17.254805@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||1||1
+2015-11-21 21:18:18.353480||measurement||loadtime||0:00:12.074844||1||1
+2015-11-21 21:18:18.415963||measurement||ad||2015-11-21 21:18:16.493482@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:18:18.416285||measurement||loadtime||0:00:02.356739||0||0
+2015-11-21 21:18:20.575959||measurement||ad||2015-11-21 21:18:20.303518@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:18:20.633635||measurement||ad||2015-11-21 21:18:20.303518@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:18:20.749750||measurement||ad||2015-11-21 21:18:20.303518@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:18:20.750112||measurement||loadtime||0:00:11.976114||3||1
+2015-11-21 21:18:22.570995||measurement||ad||2015-11-21 21:18:21.916133@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:18:22.679859||measurement||ad||2015-11-21 21:18:21.916133@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||2||0
+2015-11-21 21:18:22.781707||measurement||ad||2015-11-21 21:18:21.916133@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:18:22.781920||measurement||loadtime||0:00:01.372708||2||0
+2015-11-21 21:18:24.097438||error||collecting ads||Error||0||0
+2015-11-21 21:18:30.181154||error||collecting ads||Error||2||0
+2015-11-21 21:18:30.181442||event||progress-marker||measurement-end||2||0
+2015-11-21 21:18:31.556314||measurement||ad||2015-11-21 21:18:30.164397@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||1
+2015-11-21 21:18:31.807347||measurement||ad||2015-11-21 21:18:30.164397@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 21:18:31.895497||measurement||ad||2015-11-21 21:18:30.164397@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:18:31.895803||measurement||loadtime||0:00:08.541516||1||1
+2015-11-21 21:18:32.168248||error||collecting ads||Error||0||0
+2015-11-21 21:18:32.168530||event||progress-marker||measurement-end||0||0
+2015-11-21 21:18:34.731985||measurement||ad||2015-11-21 21:18:34.162775@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:18:34.867522||measurement||ad||2015-11-21 21:18:34.162775@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:18:35.037513||measurement||ad||2015-11-21 21:18:34.162775@|Off Grid Compost Toilet@|www.natureshead.net@|No Septic, No Water, No Chemicals. Best designed environmental toilet||3||1
+2015-11-21 21:18:35.037864||measurement||loadtime||0:00:09.287354||3||1
+2015-11-21 21:18:45.855088||measurement||ad||2015-11-21 21:18:45.637425@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:18:46.040396||measurement||ad||2015-11-21 21:18:45.637425@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:18:46.202060||measurement||ad||2015-11-21 21:18:45.637425@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 21:18:46.203666||measurement||loadtime||0:00:09.306447||1||1
+2015-11-21 21:18:47.916012||measurement||ad||2015-11-21 21:18:47.616017@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:18:47.973901||measurement||ad||2015-11-21 21:18:47.616017@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:18:48.113332||measurement||ad||2015-11-21 21:18:47.616017@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:18:48.113633||measurement||loadtime||0:00:08.074669||3||1
+2015-11-21 21:18:57.664526||measurement||ad||2015-11-21 21:18:57.485600@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||1
+2015-11-21 21:18:57.811849||measurement||ad||2015-11-21 21:18:57.485600@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 21:18:57.948466||measurement||ad||2015-11-21 21:18:57.485600@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:18:57.948773||measurement||loadtime||0:00:06.743595||1||1
+2015-11-21 21:18:59.060481||measurement||ad||2015-11-21 21:18:58.529668@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:18:59.156549||measurement||ad||2015-11-21 21:18:58.529668@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:18:59.221098||measurement||ad||2015-11-21 21:18:58.529668@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:18:59.221424||measurement||loadtime||0:00:06.106314||3||1
+2015-11-21 21:19:07.172168||measurement||ad||2015-11-21 21:19:06.912315@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-21 21:19:07.277183||measurement||ad||2015-11-21 21:19:06.912315@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-21 21:19:07.424104||measurement||ad||2015-11-21 21:19:06.912315@|Advance Your Career@|www.pointpark.edu/Graduate@|Learn more about Graduate programs that fit your schedule  budget.||1||1
+2015-11-21 21:19:07.424347||measurement||loadtime||0:00:04.474974||1||1
+2015-11-21 21:19:11.099635||measurement||ad||2015-11-21 21:19:10.980563@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:19:11.269262||measurement||ad||2015-11-21 21:19:10.980563@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:19:11.404564||measurement||ad||2015-11-21 21:19:10.980563@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:19:11.404926||measurement||loadtime||0:00:07.182102||3||1
+2015-11-21 21:19:17.799506||measurement||ad||2015-11-21 21:19:17.667779@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:19:17.868557||measurement||ad||2015-11-21 21:19:17.667779@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:19:17.922262||measurement||ad||2015-11-21 21:19:17.667779@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:19:17.922569||measurement||loadtime||0:00:05.497532||1||1
+2015-11-21 21:19:20.479790||measurement||ad||2015-11-21 21:19:20.371632@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:19:20.537141||measurement||ad||2015-11-21 21:19:20.371632@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:19:20.583294||measurement||ad||2015-11-21 21:19:20.371632@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:19:20.583546||measurement||loadtime||0:00:04.178151||3||1
+2015-11-21 21:19:27.986036||measurement||ad||2015-11-21 21:19:27.790484@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:19:28.026269||measurement||ad||2015-11-21 21:19:25.752732@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:19:28.202609||measurement||ad||2015-11-21 21:19:27.790484@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:19:28.263719||measurement||ad||2015-11-21 21:19:27.790484@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 21:19:28.263985||measurement||loadtime||0:00:05.340960||1||1
+2015-11-21 21:19:28.635059||measurement||ad||2015-11-21 21:19:25.752732@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:19:29.925407||measurement||ad||2015-11-21 21:19:25.752732@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:19:29.925731||measurement||loadtime||0:00:04.338895||3||1
+2015-11-21 21:19:36.573292||measurement||ad||2015-11-21 21:19:33.376886@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:19:37.797745||measurement||ad||2015-11-21 21:19:33.376886@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:19:38.017403||measurement||ad||2015-11-21 21:19:33.376886@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||1||1
+2015-11-21 21:19:38.017755||measurement||loadtime||0:00:04.753433||1||1
+2015-11-21 21:19:38.017945||event||progress-marker||measurement-end||1||1
+2015-11-21 21:19:40.139840||measurement||ad||2015-11-21 21:19:40.059622@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:19:40.206450||measurement||ad||2015-11-21 21:19:40.059622@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:19:40.262527||measurement||ad||2015-11-21 21:19:40.059622@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:19:40.262824||measurement||loadtime||0:00:05.331603||3||1
+2015-11-21 21:19:40.263062||event||progress-marker||measurement-end||3||1
+2015-11-21 21:19:40.475247||meta||block_id end||11
+2015-11-21 21:19:40.476510||meta||block_id start||12
+2015-11-21 21:19:40.476541||meta||assignment||0@|2@|1@|3
+2015-11-21 21:19:42.851725||event||progress-marker||training-start||0||0
+2015-11-21 21:19:42.852059||event||progress-marker||training-end||0||0
+2015-11-21 21:19:43.039952||event||progress-marker||training-start||2||0
+2015-11-21 21:19:43.040239||event||progress-marker||training-end||2||0
+2015-11-21 21:19:45.656777||event||progress-marker||training-start||3||1
+2015-11-21 21:19:45.657098||event||progress-marker||training-end||3||1
+2015-11-21 21:19:45.669022||event||progress-marker||training-start||1||1
+2015-11-21 21:19:45.669303||event||progress-marker||training-end||1||1
+2015-11-21 21:19:47.877950||event||progress-marker||measurement-start||0||0
+2015-11-21 21:19:48.063379||event||progress-marker||measurement-start||2||0
+2015-11-21 21:19:50.675399||event||progress-marker||measurement-start||3||1
+2015-11-21 21:19:50.684405||event||progress-marker||measurement-start||1||1
+2015-11-21 21:19:56.101628||measurement||ad||2015-11-21 21:19:55.215024@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:19:57.672091||measurement||ad||2015-11-21 21:19:55.233209@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||0
+2015-11-21 21:19:58.156315||measurement||ad||2015-11-21 21:19:55.233209@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||0
+2015-11-21 21:19:58.253261||measurement||ad||2015-11-21 21:19:55.215024@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||0
+2015-11-21 21:19:59.050944||measurement||ad||2015-11-21 21:19:55.215024@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||2||0
+2015-11-21 21:19:59.051217||measurement||loadtime||0:00:05.986373||2||0
+2015-11-21 21:19:59.983831||measurement||ad||2015-11-21 21:19:55.233209@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||0
+2015-11-21 21:19:59.984127||measurement||loadtime||0:00:07.105586||0||0
+2015-11-21 21:20:08.025953||error||collecting ads||Error||0||0
+2015-11-21 21:20:11.117151||measurement||ad||2015-11-21 21:20:06.083153@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:20:11.670967||measurement||ad||2015-11-21 21:20:06.083153@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:20:12.983504||measurement||ad||2015-11-21 21:20:10.507613@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:20:13.208246||measurement||ad||2015-11-21 21:20:12.410218@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:20:13.554226||measurement||ad||2015-11-21 21:20:10.507613@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||1
+2015-11-21 21:20:13.697527||measurement||ad||2015-11-21 21:20:12.410218@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:20:13.917216||measurement||ad||2015-11-21 21:20:10.507613@|Meds: Osteoporosis@|everydayhealth.com/Osteoporosis@|Learn About Osteoporosis Drugs and Other Helpful Treatments.||1||1
+2015-11-21 21:20:13.917544||measurement||loadtime||0:00:18.232384||1||1
+2015-11-21 21:20:13.964895||measurement||ad||2015-11-21 21:20:12.410218@|Meds: Osteoporosis@|everydayhealth.com/Osteoporosis@|Learn About Osteoporosis Drugs and Other Helpful Treatments.||3||1
+2015-11-21 21:20:13.965169||measurement||loadtime||0:00:18.289230||3||1
+2015-11-21 21:20:13.990230||measurement||ad||2015-11-21 21:20:06.083153@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:20:13.991603||measurement||loadtime||0:00:09.939318||2||0
+2015-11-21 21:20:18.535831||measurement||ad||2015-11-21 21:20:15.811089@|Sharefile®@|99% of Fortune 500 companies use it@|Secure file sharing and storage. ||0||0
+2015-11-21 21:20:18.537028||measurement||loadtime||0:00:05.509971||0||0
+2015-11-21 21:20:23.430375||measurement||ad||2015-11-21 21:20:20.934442@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:20:24.930597||error||collecting ads||Error||0||0
+2015-11-21 21:20:26.694382||measurement||ad||2015-11-21 21:20:20.934442@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 21:20:28.931620||measurement||ad||2015-11-21 21:20:20.934442@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:20:28.933110||measurement||loadtime||0:00:09.940282||2||0
+2015-11-21 21:20:32.986060||error||collecting ads||Error||0||0
+2015-11-21 21:20:34.853187||measurement||ad||2015-11-21 21:20:34.385687@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:20:34.918570||measurement||ad||2015-11-21 21:20:34.502234@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:20:34.994906||measurement||ad||2015-11-21 21:20:34.385687@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:20:35.110921||measurement||ad||2015-11-21 21:20:34.385687@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||3||1
+2015-11-21 21:20:35.111177||measurement||loadtime||0:00:16.144966||3||1
+2015-11-21 21:20:35.156565||measurement||ad||2015-11-21 21:20:34.502234@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:20:35.352952||measurement||ad||2015-11-21 21:20:34.502234@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||1||1
+2015-11-21 21:20:35.353504||measurement||loadtime||0:00:16.433828||1||1
+2015-11-21 21:20:37.178444||measurement||ad||2015-11-21 21:20:35.586065@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:20:37.333829||measurement||ad||2015-11-21 21:20:35.586065@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:20:37.777915||measurement||ad||2015-11-21 21:20:35.586065@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:20:37.778214||measurement||loadtime||0:00:03.844656||2||0
+2015-11-21 21:20:39.659848||error||collecting ads||Error||0||0
+2015-11-21 21:20:44.158297||error||collecting ads||Error||2||0
+2015-11-21 21:20:46.173238||error||collecting ads||Error||0||0
+2015-11-21 21:20:50.675680||error||collecting ads||Error||2||0
+2015-11-21 21:20:51.056597||measurement||ad||2015-11-21 21:20:50.832971@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:20:51.138922||measurement||ad||2015-11-21 21:20:50.832971@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:20:51.214933||measurement||ad||2015-11-21 21:20:50.832971@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||3||1
+2015-11-21 21:20:51.215287||measurement||loadtime||0:00:11.102607||3||1
+2015-11-21 21:20:51.570180||measurement||ad||2015-11-21 21:20:51.247087@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:20:51.664755||measurement||ad||2015-11-21 21:20:51.247087@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||1||1
+2015-11-21 21:20:51.734628||measurement||ad||2015-11-21 21:20:51.247087@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||1
+2015-11-21 21:20:51.734904||measurement||loadtime||0:00:11.380731||1||1
+2015-11-21 21:20:52.051418||error||collecting ads||Error||0||0
+2015-11-21 21:20:58.354934||error||collecting ads||Error||2||0
+2015-11-21 21:20:58.421353||error||collecting ads||Error||0||0
+2015-11-21 21:21:04.632782||error||collecting ads||Error||2||0
+2015-11-21 21:21:06.202564||measurement||ad||2015-11-21 21:21:05.690599@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:21:06.320690||measurement||ad||2015-11-21 21:21:05.690599@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||1||1
+2015-11-21 21:21:06.452061||measurement||ad||2015-11-21 21:21:05.690599@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||1
+2015-11-21 21:21:06.452363||measurement||loadtime||0:00:09.716384||1||1
+2015-11-21 21:21:07.894522||measurement||ad||2015-11-21 21:21:07.422094@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:21:07.974799||measurement||ad||2015-11-21 21:21:07.422094@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:21:08.006707||measurement||ad||2015-11-21 21:21:04.815369@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:21:08.311385||measurement||ad||2015-11-21 21:21:07.422094@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||3||1
+2015-11-21 21:21:08.311690||measurement||loadtime||0:00:12.095733||3||1
+2015-11-21 21:21:08.395576||measurement||ad||2015-11-21 21:21:04.815369@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:21:08.723770||measurement||ad||2015-11-21 21:21:04.815369@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||0
+2015-11-21 21:21:08.724078||measurement||loadtime||0:00:05.301253||0||0
+2015-11-21 21:21:08.724334||event||progress-marker||measurement-end||0||0
+2015-11-21 21:21:10.731231||error||collecting ads||Error||2||0
+2015-11-21 21:21:18.722000||measurement||ad||2015-11-21 21:21:18.541912@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:21:18.837835||measurement||ad||2015-11-21 21:21:18.541912@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||1||1
+2015-11-21 21:21:19.081127||measurement||ad||2015-11-21 21:21:18.541912@|5 Foods to never eat :@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||1||1
+2015-11-21 21:21:19.081447||measurement||loadtime||0:00:07.627715||1||1
+2015-11-21 21:21:19.489023||measurement||ad||2015-11-21 21:21:16.723076@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:21:19.568043||measurement||ad||2015-11-21 21:21:16.723076@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:21:19.689166||measurement||ad||2015-11-21 21:21:16.723076@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:21:19.689498||measurement||loadtime||0:00:03.957711||2||0
+2015-11-21 21:21:19.690184||event||progress-marker||measurement-end||2||0
+2015-11-21 21:21:21.745772||measurement||ad||2015-11-21 21:21:21.660027@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:21:21.806628||measurement||ad||2015-11-21 21:21:21.660027@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||1
+2015-11-21 21:21:21.885219||measurement||ad||2015-11-21 21:21:21.660027@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:21:21.885486||measurement||loadtime||0:00:08.573121||3||1
+2015-11-21 21:21:29.549659||measurement||ad||2015-11-21 21:21:24.283421@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:21:29.609312||measurement||ad||2015-11-21 21:21:24.283421@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||1||1
+2015-11-21 21:21:29.687928||measurement||ad||2015-11-21 21:21:24.283421@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||1||1
+2015-11-21 21:21:29.688223||measurement||loadtime||0:00:05.605493||1||1
+2015-11-21 21:21:31.464987||measurement||ad||2015-11-21 21:21:31.366765@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:21:31.527059||measurement||ad||2015-11-21 21:21:31.366765@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:21:31.576183||measurement||ad||2015-11-21 21:21:31.366765@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||1
+2015-11-21 21:21:31.576510||measurement||loadtime||0:00:04.690620||3||1
+2015-11-21 21:21:41.104166||measurement||ad||2015-11-21 21:21:40.977730@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:21:41.176754||measurement||ad||2015-11-21 21:21:40.977730@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:21:41.246300||measurement||ad||2015-11-21 21:21:40.977730@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||1
+2015-11-21 21:21:41.246582||measurement||loadtime||0:00:06.557028||1||1
+2015-11-21 21:21:44.681460||measurement||ad||2015-11-21 21:21:44.513816@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||1
+2015-11-21 21:21:44.681657||measurement||loadtime||0:00:08.104324||3||1
+2015-11-21 21:21:54.211002||measurement||ad||2015-11-21 21:21:53.780120@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:21:54.327249||measurement||ad||2015-11-21 21:21:53.780120@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:21:54.400965||measurement||ad||2015-11-21 21:21:53.780120@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||1
+2015-11-21 21:21:54.401274||measurement||loadtime||0:00:08.153521||1||1
+2015-11-21 21:21:58.752752||measurement||ad||2015-11-21 21:21:58.418057@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:21:58.814224||measurement||ad||2015-11-21 21:21:58.418057@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||1
+2015-11-21 21:21:58.873445||measurement||ad||2015-11-21 21:21:58.418057@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:21:58.873740||measurement||loadtime||0:00:09.191043||3||1
+2015-11-21 21:22:07.957520||measurement||ad||2015-11-21 21:22:07.550420@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||1
+2015-11-21 21:22:07.957937||measurement||loadtime||0:00:08.555911||1||1
+2015-11-21 21:22:11.297218||measurement||ad||2015-11-21 21:22:11.159276@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:22:11.358444||measurement||ad||2015-11-21 21:22:11.159276@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:22:11.424552||measurement||ad||2015-11-21 21:22:11.159276@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||3||1
+2015-11-21 21:22:11.424811||measurement||loadtime||0:00:07.550440||3||1
+2015-11-21 21:22:18.852405||measurement||ad||2015-11-21 21:22:18.593506@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:22:18.959208||measurement||ad||2015-11-21 21:22:18.593506@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||1
+2015-11-21 21:22:19.171245||measurement||ad||2015-11-21 21:22:18.593506@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:22:19.171752||measurement||loadtime||0:00:06.213214||1||1
+2015-11-21 21:22:19.171985||event||progress-marker||measurement-end||1||1
+2015-11-21 21:22:26.451522||measurement||ad||2015-11-21 21:22:26.050941@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||1
+2015-11-21 21:22:26.550593||measurement||ad||2015-11-21 21:22:26.050941@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||1
+2015-11-21 21:22:26.638105||measurement||ad||2015-11-21 21:22:26.050941@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:22:26.639269||measurement||loadtime||0:00:10.213391||3||1
+2015-11-21 21:22:26.640793||event||progress-marker||measurement-end||3||1
+2015-11-21 21:22:26.966888||meta||block_id end||12
+2015-11-21 21:22:26.968911||meta||block_id start||13
+2015-11-21 21:22:26.969037||meta||assignment||2@|3@|1@|0
+2015-11-21 21:22:29.523600||event||progress-marker||training-start||3||0
+2015-11-21 21:22:29.523918||event||progress-marker||training-end||3||0
+2015-11-21 21:22:29.549835||event||progress-marker||training-start||2||0
+2015-11-21 21:22:29.550112||event||progress-marker||training-end||2||0
+2015-11-21 21:22:32.658392||event||progress-marker||training-start||0||1
+2015-11-21 21:22:32.658704||event||progress-marker||training-end||0||1
+2015-11-21 21:22:33.169286||event||progress-marker||training-start||1||1
+2015-11-21 21:22:33.169548||event||progress-marker||training-end||1||1
+2015-11-21 21:22:34.572911||event||progress-marker||measurement-start||3||0
+2015-11-21 21:22:34.574100||event||progress-marker||measurement-start||2||0
+2015-11-21 21:22:37.679932||event||progress-marker||measurement-start||0||1
+2015-11-21 21:22:38.191565||event||progress-marker||measurement-start||1||1
+2015-11-21 21:22:42.539060||measurement||ad||2015-11-21 21:22:41.354712@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:22:42.586372||measurement||ad||2015-11-21 21:22:41.433111@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:22:42.630956||measurement||ad||2015-11-21 21:22:41.354712@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:22:42.675379||measurement||ad||2015-11-21 21:22:41.433111@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||3||0
+2015-11-21 21:22:42.711770||measurement||ad||2015-11-21 21:22:41.354712@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 21:22:42.712074||measurement||loadtime||0:00:03.137406||2||0
+2015-11-21 21:22:42.762033||measurement||ad||2015-11-21 21:22:41.433111@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||3||0
+2015-11-21 21:22:42.762293||measurement||loadtime||0:00:03.187849||3||0
+2015-11-21 21:22:48.878264||error||collecting ads||Error||2||0
+2015-11-21 21:22:49.564631||error||collecting ads||Error||3||0
+2015-11-21 21:22:54.124366||measurement||ad||2015-11-21 21:22:52.914532@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:22:54.257971||measurement||ad||2015-11-21 21:22:52.914532@|Fora Financial® Loans@|forafinancial.com/@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||1||1
+2015-11-21 21:22:54.350731||measurement||ad||2015-11-21 21:22:52.914532@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:22:54.351046||measurement||loadtime||0:00:11.158464||1||1
+2015-11-21 21:22:54.673359||measurement||ad||2015-11-21 21:22:53.037203@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:22:54.805976||measurement||ad||2015-11-21 21:22:53.037203@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:22:54.875744||measurement||ad||2015-11-21 21:22:53.037203@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||0||1
+2015-11-21 21:22:54.876081||measurement||loadtime||0:00:12.195264||0||1
+2015-11-21 21:22:57.993367||measurement||ad||2015-11-21 21:22:55.187145@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:22:58.156239||measurement||ad||2015-11-21 21:22:55.187145@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:22:58.846551||measurement||ad||2015-11-21 21:22:55.187145@|Advance Your Career@|www.pointpark.edu/Graduate@|Learn more about Graduate programs that fit your schedule  budget.||2||0
+2015-11-21 21:22:58.846824||measurement||loadtime||0:00:04.967892||2||0
+2015-11-21 21:22:59.675347||measurement||ad||2015-11-21 21:22:56.839474@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:23:01.306781||measurement||ad||2015-11-21 21:22:56.839474@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 21:23:03.812162||measurement||ad||2015-11-21 21:22:56.839474@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||3||0
+2015-11-21 21:23:03.812753||measurement||loadtime||0:00:09.246553||3||0
+2015-11-21 21:23:09.299244||measurement||ad||2015-11-21 21:23:05.356834@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:23:13.205713||measurement||ad||2015-11-21 21:23:05.356834@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:23:13.658936||measurement||ad||2015-11-21 21:23:11.656833@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:23:13.942864||measurement||ad||2015-11-21 21:23:05.356834@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:23:13.943368||measurement||loadtime||0:00:10.093496||2||0
+2015-11-21 21:23:14.162972||measurement||ad||2015-11-21 21:23:10.268011@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:23:14.294731||measurement||ad||2015-11-21 21:23:11.656833@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-21 21:23:14.781828||measurement||ad||2015-11-21 21:23:11.656833@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-21 21:23:14.782547||measurement||loadtime||0:00:15.430091||1||1
+2015-11-21 21:23:16.048195||measurement||ad||2015-11-21 21:23:10.268011@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 21:23:17.223110||measurement||ad||2015-11-21 21:23:14.646075@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:23:17.313152||measurement||ad||2015-11-21 21:23:14.646075@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||0||1
+2015-11-21 21:23:17.432660||measurement||ad||2015-11-21 21:23:14.646075@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:23:17.432948||measurement||loadtime||0:00:17.556205||0||1
+2015-11-21 21:23:18.385422||measurement||ad||2015-11-21 21:23:10.268011@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||3||0
+2015-11-21 21:23:18.385867||measurement||loadtime||0:00:09.572578||3||0
+2015-11-21 21:23:21.696414||measurement||ad||2015-11-21 21:23:20.252494@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:23:23.227143||measurement||ad||2015-11-21 21:23:20.252494@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:23:25.963095||measurement||ad||2015-11-21 21:23:20.252494@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||2||0
+2015-11-21 21:23:25.963496||measurement||loadtime||0:00:07.019697||2||0
+2015-11-21 21:23:27.916945||measurement||ad||2015-11-21 21:23:24.611421@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:23:29.350698||measurement||ad||2015-11-21 21:23:24.611421@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:23:29.897419||measurement||ad||2015-11-21 21:23:24.611421@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||0
+2015-11-21 21:23:29.897705||measurement||loadtime||0:00:06.510968||3||0
+2015-11-21 21:23:30.737402||measurement||ad||2015-11-21 21:23:29.862877@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:23:30.814835||measurement||ad||2015-11-21 21:23:29.862877@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:23:30.889042||measurement||ad||2015-11-21 21:23:29.862877@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:23:30.889356||measurement||loadtime||0:00:11.106173||1||1
+2015-11-21 21:23:33.686214||measurement||ad||2015-11-21 21:23:32.901658@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:23:34.032231||measurement||ad||2015-11-21 21:23:32.901658@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:23:34.271503||measurement||ad||2015-11-21 21:23:32.901658@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:23:34.271876||measurement||loadtime||0:00:11.838466||0||1
+2015-11-21 21:23:34.783045||measurement||ad||2015-11-21 21:23:32.098610@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:23:34.885114||measurement||ad||2015-11-21 21:23:32.098610@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:23:35.041475||measurement||ad||2015-11-21 21:23:32.098610@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:23:35.041793||measurement||loadtime||0:00:04.076910||2||0
+2015-11-21 21:23:37.494644||measurement||ad||2015-11-21 21:23:36.124567@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:23:37.603084||measurement||ad||2015-11-21 21:23:36.124567@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:23:37.768135||measurement||ad||2015-11-21 21:23:36.124567@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||0
+2015-11-21 21:23:37.768486||measurement||loadtime||0:00:02.870336||3||0
+2015-11-21 21:23:43.005968||measurement||ad||2015-11-21 21:23:41.242686@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:23:43.215311||measurement||ad||2015-11-21 21:23:41.242686@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:23:45.931883||measurement||ad||2015-11-21 21:23:39.833325@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:23:45.988159||measurement||ad||2015-11-21 21:23:41.242686@|Advance Your Career@|www.pointpark.edu/Graduate@|Learn more about Graduate programs that fit your schedule  budget.||2||0
+2015-11-21 21:23:45.988432||measurement||loadtime||0:00:05.946190||2||0
+2015-11-21 21:23:46.042289||measurement||ad||2015-11-21 21:23:39.833325@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:23:47.749954||measurement||ad||2015-11-21 21:23:39.833325@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:23:47.750337||measurement||loadtime||0:00:08.477860||0||1
+2015-11-21 21:23:48.637618||measurement||ad||2015-11-21 21:23:43.554116@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:23:49.498029||measurement||ad||2015-11-21 21:23:43.554116@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:23:50.352839||measurement||ad||2015-11-21 21:23:43.554116@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||0
+2015-11-21 21:23:50.353237||measurement||loadtime||0:00:07.583646||3||0
+2015-11-21 21:23:51.452302||measurement||ad||2015-11-21 21:23:51.240426@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:23:51.596509||measurement||ad||2015-11-21 21:23:51.240426@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:23:51.747256||measurement||ad||2015-11-21 21:23:51.240426@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:23:51.747533||measurement||loadtime||0:00:15.857114||1||1
+2015-11-21 21:23:51.991239||error||collecting ads||Error||2||0
+2015-11-21 21:23:58.108470||measurement||ad||2015-11-21 21:23:56.457544@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:23:58.853643||error||collecting ads||Error||2||0
+2015-11-21 21:23:58.957641||measurement||ad||2015-11-21 21:23:56.457544@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:24:00.100963||measurement||ad||2015-11-21 21:23:56.457544@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||0
+2015-11-21 21:24:00.101315||measurement||loadtime||0:00:04.746642||3||0
+2015-11-21 21:24:02.427658||measurement||ad||2015-11-21 21:24:01.757058@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:24:02.896842||measurement||ad||2015-11-21 21:24:01.757058@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:24:03.122012||measurement||ad||2015-11-21 21:24:01.757058@|Is Bitcoin A Buy Or Not?@|outsiderclub.com/Bitcoin_Investing@|Don’t Simply Guess. Get The Facts. Free, Comprehensive Guide Is Here.||0||1
+2015-11-21 21:24:03.122541||measurement||loadtime||0:00:10.371820||0||1
+2015-11-21 21:24:07.833608||measurement||ad||2015-11-21 21:24:06.819204@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:24:08.027509||measurement||ad||2015-11-21 21:24:06.819204@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-21 21:24:08.176905||measurement||ad||2015-11-21 21:24:06.819204@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||1||1
+2015-11-21 21:24:08.177202||measurement||loadtime||0:00:11.428564||1||1
+2015-11-21 21:24:08.305608||measurement||ad||2015-11-21 21:24:04.857441@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:24:09.286832||measurement||ad||2015-11-21 21:24:06.656147@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:24:09.300483||measurement||ad||2015-11-21 21:24:04.857441@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:24:09.679037||measurement||ad||2015-11-21 21:24:04.857441@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:24:09.679421||measurement||loadtime||0:00:05.825273||2||0
+2015-11-21 21:24:09.679670||event||progress-marker||measurement-end||2||0
+2015-11-21 21:24:10.192653||measurement||ad||2015-11-21 21:24:06.656147@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 21:24:11.830933||measurement||ad||2015-11-21 21:24:06.656147@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||3||0
+2015-11-21 21:24:11.831231||measurement||loadtime||0:00:06.729259||3||0
+2015-11-21 21:24:15.553942||measurement||ad||2015-11-21 21:24:14.596382@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:24:15.656120||measurement||ad||2015-11-21 21:24:14.596382@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:24:15.768947||measurement||ad||2015-11-21 21:24:14.596382@|Is Bitcoin A Buy Or Not?@|outsiderclub.com/Bitcoin_Investing@|Don’t Simply Guess. Get The Facts. Free, Comprehensive Guide Is Here.||0||1
+2015-11-21 21:24:15.769280||measurement||loadtime||0:00:07.645398||0||1
+2015-11-21 21:24:20.530867||measurement||ad||2015-11-21 21:24:17.980525@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:24:20.690560||measurement||ad||2015-11-21 21:24:17.980525@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||3||0
+2015-11-21 21:24:21.216167||measurement||ad||2015-11-21 21:24:17.980525@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||3||0
+2015-11-21 21:24:21.216531||measurement||loadtime||0:00:04.383941||3||0
+2015-11-21 21:24:21.216960||event||progress-marker||measurement-end||3||0
+2015-11-21 21:24:26.740253||measurement||ad||2015-11-21 21:24:25.400656@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:24:27.228440||measurement||ad||2015-11-21 21:24:25.400656@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:24:27.408065||measurement||ad||2015-11-21 21:24:25.400656@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||1||1
+2015-11-21 21:24:27.409140||measurement||loadtime||0:00:14.231360||1||1
+2015-11-21 21:24:29.300865||measurement||ad||2015-11-21 21:24:29.001019@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:24:29.396600||measurement||ad||2015-11-21 21:24:29.001019@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:24:29.492920||measurement||ad||2015-11-21 21:24:29.001019@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:24:29.493556||measurement||loadtime||0:00:08.723751||0||1
+2015-11-21 21:24:34.038649||measurement||ad||2015-11-21 21:24:32.493792@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:24:34.155643||measurement||ad||2015-11-21 21:24:32.493792@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:24:34.233848||measurement||ad||2015-11-21 21:24:32.493792@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||1||1
+2015-11-21 21:24:34.234863||measurement||loadtime||0:00:01.824041||1||1
+2015-11-21 21:24:39.226791||measurement||ad||2015-11-21 21:24:39.022969@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:24:39.303316||measurement||ad||2015-11-21 21:24:39.022969@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:24:39.383853||measurement||ad||2015-11-21 21:24:39.022969@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:24:39.384160||measurement||loadtime||0:00:04.890089||0||1
+2015-11-21 21:24:43.618727||measurement||ad||2015-11-21 21:24:43.511353@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:24:43.688796||measurement||ad||2015-11-21 21:24:43.511353@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:24:43.743482||measurement||ad||2015-11-21 21:24:43.511353@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||1||1
+2015-11-21 21:24:43.743762||measurement||loadtime||0:00:04.507212||1||1
+2015-11-21 21:24:50.699246||measurement||ad||2015-11-21 21:24:50.182175@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:24:50.817167||measurement||ad||2015-11-21 21:24:50.182175@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:24:50.906468||measurement||ad||2015-11-21 21:24:50.182175@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:24:50.906806||measurement||loadtime||0:00:06.521238||0||1
+2015-11-21 21:24:52.143887||measurement||ad||2015-11-21 21:24:52.042158@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:24:52.210394||measurement||ad||2015-11-21 21:24:52.042158@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:24:52.257043||measurement||ad||2015-11-21 21:24:52.042158@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||1||1
+2015-11-21 21:24:52.257350||measurement||loadtime||0:00:03.512192||1||1
+2015-11-21 21:25:01.276201||measurement||ad||2015-11-21 21:25:01.042381@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||0||1
+2015-11-21 21:25:01.341301||measurement||ad||2015-11-21 21:25:01.042381@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:25:01.433240||measurement||ad||2015-11-21 21:25:01.042381@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:25:01.433541||measurement||loadtime||0:00:05.525155||0||1
+2015-11-21 21:25:01.433737||event||progress-marker||measurement-end||0||1
+2015-11-21 21:25:02.574961||measurement||ad||2015-11-21 21:25:02.398209@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:25:02.623485||measurement||ad||2015-11-21 21:25:02.398209@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||1||1
+2015-11-21 21:25:02.676263||measurement||ad||2015-11-21 21:25:02.398209@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:25:02.676454||measurement||loadtime||0:00:05.418012||1||1
+2015-11-21 21:25:02.676771||event||progress-marker||measurement-end||1||1
+2015-11-21 21:25:02.890128||meta||block_id end||13
+2015-11-21 21:25:02.891420||meta||block_id start||14
+2015-11-21 21:25:02.891501||meta||assignment||1@|2@|0@|3
+2015-11-21 21:25:05.292380||event||progress-marker||training-start||1||0
+2015-11-21 21:25:05.292891||event||progress-marker||training-end||1||0
+2015-11-21 21:25:05.295192||event||progress-marker||training-start||2||0
+2015-11-21 21:25:05.295582||event||progress-marker||training-end||2||0
+2015-11-21 21:25:08.088975||event||progress-marker||training-start||3||1
+2015-11-21 21:25:08.089260||event||progress-marker||training-end||3||1
+2015-11-21 21:25:08.092347||event||progress-marker||training-start||0||1
+2015-11-21 21:25:08.092674||event||progress-marker||training-end||0||1
+2015-11-21 21:25:10.377827||event||progress-marker||measurement-start||2||0
+2015-11-21 21:25:10.379173||event||progress-marker||measurement-start||1||0
+2015-11-21 21:25:13.108760||event||progress-marker||measurement-start||3||1
+2015-11-21 21:25:13.110647||event||progress-marker||measurement-start||0||1
+2015-11-21 21:25:17.335494||measurement||ad||2015-11-21 21:25:16.927297@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:25:17.895091||measurement||ad||2015-11-21 21:25:16.927297@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||0
+2015-11-21 21:25:17.962101||measurement||ad||2015-11-21 21:25:16.927297@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||0
+2015-11-21 21:25:17.962418||measurement||loadtime||0:00:02.582949||2||0
+2015-11-21 21:25:26.264157||measurement||ad||2015-11-21 21:25:24.674318@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:25:26.467128||measurement||ad||2015-11-21 21:25:24.674318@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:25:26.575062||measurement||ad||2015-11-21 21:25:26.029558@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:25:26.646321||measurement||ad||2015-11-21 21:25:26.029558@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||3||1
+2015-11-21 21:25:26.658194||measurement||ad||2015-11-21 21:25:24.674318@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Apply Online Now.||2||0
+2015-11-21 21:25:26.658513||measurement||loadtime||0:00:03.694626||2||0
+2015-11-21 21:25:26.710318||measurement||ad||2015-11-21 21:25:26.029558@|Meds: Osteoporosis@|everydayhealth.com/Osteoporosis@|Learn About Osteoporosis Drugs and Other Helpful Treatments.||3||1
+2015-11-21 21:25:26.710648||measurement||loadtime||0:00:08.600330||3||1
+2015-11-21 21:25:28.959257||measurement||ad||2015-11-21 21:25:28.653876@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:25:29.226913||measurement||ad||2015-11-21 21:25:28.653876@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||0||1
+2015-11-21 21:25:29.279244||measurement||ad||2015-11-21 21:25:28.653876@|Meds: Osteoporosis@|everydayhealth.com/Osteoporosis@|Learn About Osteoporosis Drugs and Other Helpful Treatments.||0||1
+2015-11-21 21:25:29.279596||measurement||loadtime||0:00:11.168514||0||1
+2015-11-21 21:25:33.614358||measurement||ad||2015-11-21 21:25:32.702248@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:25:33.703772||measurement||ad||2015-11-21 21:25:32.702248@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:25:33.857934||measurement||ad||2015-11-21 21:25:32.702248@|Sign In To Your Email@|loginfaster.com/new@|One-Click Access To All Your Email! Send  Receive Email w/App Now.||2||0
+2015-11-21 21:25:33.858180||measurement||loadtime||0:00:02.198772||2||0
+2015-11-21 21:25:35.415972||error||collecting ads||Error||1||0
+2015-11-21 21:25:38.643688||measurement||ad||2015-11-21 21:25:38.297727@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-21 21:25:38.721747||measurement||ad||2015-11-21 21:25:38.297727@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:25:38.783205||measurement||ad||2015-11-21 21:25:38.297727@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:25:38.783553||measurement||loadtime||0:00:07.071649||3||1
+2015-11-21 21:25:40.701909||measurement||ad||2015-11-21 21:25:39.838809@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:25:40.777021||measurement||ad||2015-11-21 21:25:39.838809@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:25:40.863872||measurement||ad||2015-11-21 21:25:39.838809@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:25:40.864233||measurement||loadtime||0:00:02.005646||2||0
+2015-11-21 21:25:41.922250||measurement||ad||2015-11-21 21:25:41.526490@|Study Sustainability@|onlineprograms.usf.edu/@|MA Degree In Sustainability Get Started At USF Online Today||0||1
+2015-11-21 21:25:42.005595||measurement||ad||2015-11-21 21:25:41.526490@|Top 7 Adult Diapers@|comparestores.net/Adult-Diapers@|Compare Latest Offers  Save on Bestselling Adult Diapers!||0||1
+2015-11-21 21:25:42.089648||measurement||ad||2015-11-21 21:25:41.526490@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||0||1
+2015-11-21 21:25:42.089913||measurement||loadtime||0:00:07.809282||0||1
+2015-11-21 21:25:48.119111||measurement||ad||2015-11-21 21:25:46.774495@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:25:48.282380||measurement||ad||2015-11-21 21:25:46.774495@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:25:48.388392||measurement||ad||2015-11-21 21:25:46.774495@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||2||0
+2015-11-21 21:25:48.388745||measurement||loadtime||0:00:02.524058||2||0
+2015-11-21 21:25:49.494611||measurement||ad||2015-11-21 21:25:49.015771@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:25:49.584569||measurement||ad||2015-11-21 21:25:49.015771@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:25:49.728287||measurement||ad||2015-11-21 21:25:49.015771@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||1
+2015-11-21 21:25:49.728594||measurement||loadtime||0:00:05.944268||3||1
+2015-11-21 21:25:55.285873||measurement||ad||2015-11-21 21:25:54.270297@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:25:55.350690||measurement||ad||2015-11-21 21:25:54.270297@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:25:55.445625||measurement||ad||2015-11-21 21:25:54.270297@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||2||0
+2015-11-21 21:25:55.445945||measurement||loadtime||0:00:02.055871||2||0
+2015-11-21 21:26:00.436945||error||collecting ads||Error||1||0
+2015-11-21 21:26:01.694449||measurement||ad||2015-11-21 21:26:01.393717@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:26:01.925852||measurement||ad||2015-11-21 21:26:01.393717@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:26:02.090215||measurement||ad||2015-11-21 21:26:01.393717@|General Insurance $18/Mo@|www.general-insurance.com@|Get the Cheapest Rate on General Car Insurance  Save Up to 72% Now!||3||1
+2015-11-21 21:26:02.090504||measurement||loadtime||0:00:07.360586||3||1
+2015-11-21 21:26:02.377847||measurement||ad||2015-11-21 21:26:01.108218@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:26:02.465384||measurement||ad||2015-11-21 21:26:01.108218@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Apply Online Now.||2||0
+2015-11-21 21:26:02.625209||measurement||ad||2015-11-21 21:26:01.108218@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||0
+2015-11-21 21:26:02.625849||measurement||loadtime||0:00:02.179479||2||0
+2015-11-21 21:26:09.533605||measurement||ad||2015-11-21 21:26:08.608422@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:26:09.742035||measurement||ad||2015-11-21 21:26:08.608422@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:26:09.844661||measurement||ad||2015-11-21 21:26:08.608422@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||0
+2015-11-21 21:26:09.845062||measurement||loadtime||0:00:02.217302||2||0
+2015-11-21 21:26:13.560250||measurement||ad||2015-11-21 21:26:13.403399@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:26:13.663660||measurement||ad||2015-11-21 21:26:13.403399@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||1
+2015-11-21 21:26:13.804080||measurement||ad||2015-11-21 21:26:13.403399@|General Insurance $18/Mo@|www.general-insurance.com@|Get the Cheapest Rate on General Car Insurance  Save Up to 72% Now!||3||1
+2015-11-21 21:26:13.804370||measurement||loadtime||0:00:06.712366||3||1
+2015-11-21 21:26:16.144833||measurement||ad||2015-11-21 21:26:15.126369@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:26:16.311490||measurement||ad||2015-11-21 21:26:15.126369@|Social Security Account@|www.socialsecurity.gov/MyAccount/@|Plan, manage  estimate your Social Security benefits. Get started now.||2||0
+2015-11-21 21:26:16.558951||measurement||ad||2015-11-21 21:26:15.126369@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||2||0
+2015-11-21 21:26:16.559324||measurement||loadtime||0:00:01.713729||2||0
+2015-11-21 21:26:23.132209||measurement||ad||2015-11-21 21:26:22.529205@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:26:23.277086||measurement||ad||2015-11-21 21:26:22.529205@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:26:23.402387||measurement||ad||2015-11-21 21:26:22.529205@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||0
+2015-11-21 21:26:23.402748||measurement||loadtime||0:00:01.842862||2||0
+2015-11-21 21:26:23.402881||event||progress-marker||measurement-end||2||0
+2015-11-21 21:26:25.232919||measurement||ad||2015-11-21 21:26:23.756893@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||0
+2015-11-21 21:26:25.440109||measurement||ad||2015-11-21 21:26:23.756893@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. Competitive Rates. Apply Online Now||1||0
+2015-11-21 21:26:25.642900||measurement||ad||2015-11-21 21:26:23.756893@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||1||0
+2015-11-21 21:26:25.643188||measurement||loadtime||0:00:20.204838||1||0
+2015-11-21 21:26:29.236384||measurement||ad||2015-11-21 21:26:28.134601@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:26:29.511984||measurement||ad||2015-11-21 21:26:28.134601@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:26:29.601890||measurement||ad||2015-11-21 21:26:28.134601@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-21 21:26:29.602201||measurement||loadtime||0:00:10.797233||3||1
+2015-11-21 21:26:32.036772||measurement||ad||2015-11-21 21:26:31.286476@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:26:32.187595||measurement||ad||2015-11-21 21:26:31.286476@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:26:32.385562||measurement||ad||2015-11-21 21:26:31.286476@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||0
+2015-11-21 21:26:32.385823||measurement||loadtime||0:00:01.742066||1||0
+2015-11-21 21:26:38.902510||measurement||ad||2015-11-21 21:26:38.042774@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||0
+2015-11-21 21:26:39.011655||measurement||ad||2015-11-21 21:26:38.042774@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. Competitive Rates. Apply Online Now||1||0
+2015-11-21 21:26:39.196334||measurement||ad||2015-11-21 21:26:38.042774@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 21:26:39.196764||measurement||loadtime||0:00:01.809365||1||0
+2015-11-21 21:26:41.963711||measurement||ad||2015-11-21 21:26:41.565570@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:26:42.142190||measurement||ad||2015-11-21 21:26:41.565570@|General Insurance $18/Mo@|www.general-insurance.com@|Get the Cheapest Rate on General Car Insurance  Save Up to 72% Now!||3||1
+2015-11-21 21:26:42.267913||measurement||ad||2015-11-21 21:26:41.565570@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:26:42.268170||measurement||loadtime||0:00:07.665367||3||1
+2015-11-21 21:26:45.659253||measurement||ad||2015-11-21 21:26:44.512591@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:26:45.785295||measurement||ad||2015-11-21 21:26:44.512591@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Apply Online Now.||1||0
+2015-11-21 21:26:45.985149||measurement||ad||2015-11-21 21:26:44.512591@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||0
+2015-11-21 21:26:45.985367||measurement||loadtime||0:00:01.787209||1||0
+2015-11-21 21:26:52.296290||measurement||ad||2015-11-21 21:26:51.236202@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||0
+2015-11-21 21:26:52.296667||measurement||loadtime||0:00:01.309256||1||0
+2015-11-21 21:26:53.138269||measurement||ad||2015-11-21 21:26:52.979428@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||1
+2015-11-21 21:26:53.256715||measurement||ad||2015-11-21 21:26:52.979428@|General Insurance $18/Mo@|www.general-insurance.com@|Get the Cheapest Rate on General Car Insurance  Save Up to 72% Now!||3||1
+2015-11-21 21:26:53.318095||measurement||ad||2015-11-21 21:26:52.979428@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:26:53.318395||measurement||loadtime||0:00:06.048749||3||1
+2015-11-21 21:26:57.746235||error||collecting ads||Error||1||0
+2015-11-21 21:27:03.181708||measurement||ad||2015-11-21 21:27:03.056743@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:27:03.256653||measurement||ad||2015-11-21 21:27:03.056743@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:27:03.320754||measurement||ad||2015-11-21 21:27:03.056743@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||1
+2015-11-21 21:27:03.321008||measurement||loadtime||0:00:05.001943||3||1
+2015-11-21 21:27:04.147695||measurement||ad||2015-11-21 21:27:03.408440@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||0
+2015-11-21 21:27:04.148038||measurement||loadtime||0:00:01.400137||1||0
+2015-11-21 21:27:10.550211||measurement||ad||2015-11-21 21:27:09.806338@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||0
+2015-11-21 21:27:10.550470||measurement||loadtime||0:00:01.401273||1||0
+2015-11-21 21:27:10.550584||event||progress-marker||measurement-end||1||0
+2015-11-21 21:27:14.642331||measurement||ad||2015-11-21 21:27:14.331223@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:27:14.890883||measurement||ad||2015-11-21 21:27:14.331223@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:27:15.018223||measurement||ad||2015-11-21 21:27:14.331223@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||1
+2015-11-21 21:27:15.018495||measurement||loadtime||0:00:06.696929||3||1
+2015-11-21 21:27:15.018592||event||progress-marker||measurement-end||3||1
+2015-11-21 21:28:09.893408||measurement||ad||2015-11-21 21:25:54.266800@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:28:20.454660||measurement||ad||2015-11-21 21:25:54.266800@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:28:20.496897||measurement||ad||2015-11-21 21:25:54.266800@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:28:20.497170||measurement||loadtime||0:02:33.406845||0||1
+2015-11-21 21:28:50.777565||measurement||ad||2015-11-21 21:28:50.523315@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:28:50.818160||measurement||ad||2015-11-21 21:28:50.523315@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:28:50.856887||measurement||ad||2015-11-21 21:28:50.523315@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As much as $25,000 from 6.04% APR Easy Process, Free Quotes. Act Now!||0||1
+2015-11-21 21:28:50.857112||measurement||loadtime||0:00:25.358516||0||1
+2015-11-21 21:29:00.179162||measurement||ad||2015-11-21 21:28:59.819843@|Study Sustainability@|onlineprograms.usf.edu/@|MA Degree In Sustainability Get Started At USF Online Today||0||1
+2015-11-21 21:29:00.248439||measurement||ad||2015-11-21 21:28:59.819843@|Top 7 Adult Diapers@|comparestores.net/Adult-Diapers@|Compare Latest Offers  Save on Bestselling Adult Diapers!||0||1
+2015-11-21 21:29:00.286549||measurement||ad||2015-11-21 21:28:59.819843@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||0||1
+2015-11-21 21:29:00.286812||measurement||loadtime||0:00:04.429250||0||1
+2015-11-21 21:29:09.730013||measurement||ad||2015-11-21 21:29:09.663431@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:29:09.769836||measurement||ad||2015-11-21 21:29:09.663431@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:29:09.812481||measurement||ad||2015-11-21 21:29:09.663431@|Game Changing Nanobubbles@|www.nanobubbles.com@|Experience our Nanobubbles Please register on our site||0||1
+2015-11-21 21:29:09.812750||measurement||loadtime||0:00:04.524488||0||1
+2015-11-21 21:29:19.376904||measurement||ad||2015-11-21 21:29:19.192223@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:29:19.427267||measurement||ad||2015-11-21 21:29:19.192223@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:29:19.464029||measurement||ad||2015-11-21 21:29:19.192223@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As much as $25,000 from 6.04% APR Easy Process, Free Quotes. Act Now!||0||1
+2015-11-21 21:29:19.464262||measurement||loadtime||0:00:04.650026||0||1
+2015-11-21 21:29:30.589296||measurement||ad||2015-11-21 21:29:30.473943@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:29:30.682800||measurement||ad||2015-11-21 21:29:30.473943@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:29:30.756436||measurement||ad||2015-11-21 21:29:30.473943@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:29:30.756741||measurement||loadtime||0:00:06.291081||0||1
+2015-11-21 21:29:39.631200||measurement||ad||2015-11-21 21:29:39.504664@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:29:39.725196||measurement||ad||2015-11-21 21:29:39.504664@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:29:39.825502||measurement||ad||2015-11-21 21:29:39.504664@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:29:39.825748||measurement||loadtime||0:00:04.067309||0||1
+2015-11-21 21:29:48.634924||measurement||ad||2015-11-21 21:29:48.573609@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:29:48.682185||measurement||ad||2015-11-21 21:29:48.573609@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:29:48.722113||measurement||ad||2015-11-21 21:29:48.573609@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:29:48.722359||measurement||loadtime||0:00:03.895100||0||1
+2015-11-21 21:29:48.722452||event||progress-marker||measurement-end||0||1
+2015-11-21 21:29:49.001223||meta||block_id end||14
+2015-11-21 21:29:49.002446||meta||block_id start||15
+2015-11-21 21:29:49.002474||meta||assignment||1@|3@|2@|0
+2015-11-21 21:29:51.257590||event||progress-marker||training-start||1||0
+2015-11-21 21:29:51.257906||event||progress-marker||training-end||1||0
+2015-11-21 21:29:51.463341||event||progress-marker||training-start||3||0
+2015-11-21 21:29:51.463651||event||progress-marker||training-end||3||0
+2015-11-21 21:29:54.185889||event||progress-marker||training-start||0||1
+2015-11-21 21:29:54.186209||event||progress-marker||training-end||0||1
+2015-11-21 21:29:54.191382||event||progress-marker||training-start||2||1
+2015-11-21 21:29:54.191731||event||progress-marker||training-end||2||1
+2015-11-21 21:29:56.291598||event||progress-marker||measurement-start||1||0
+2015-11-21 21:29:56.498637||event||progress-marker||measurement-start||3||0
+2015-11-21 21:29:59.212162||event||progress-marker||measurement-start||0||1
+2015-11-21 21:29:59.217471||event||progress-marker||measurement-start||2||1
+2015-11-21 21:30:03.833033||measurement||ad||2015-11-21 21:30:03.144116@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:30:04.959628||measurement||ad||2015-11-21 21:30:03.144116@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||3||0
+2015-11-21 21:30:05.284793||measurement||ad||2015-11-21 21:30:03.144116@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||3||0
+2015-11-21 21:30:05.285179||measurement||loadtime||0:00:03.785034||3||0
+2015-11-21 21:30:07.261271||measurement||ad||2015-11-21 21:30:04.529221@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:30:09.954559||measurement||ad||2015-11-21 21:30:04.529221@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:30:14.290426||measurement||ad||2015-11-21 21:30:04.529221@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:30:14.290694||measurement||loadtime||0:00:12.997561||1||0
+2015-11-21 21:30:16.451368||measurement||ad||2015-11-21 21:30:11.925060@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:30:17.442008||measurement||ad||2015-11-21 21:30:11.925060@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:30:18.977238||measurement||ad||2015-11-21 21:30:17.501022@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:30:19.029388||measurement||ad||2015-11-21 21:30:11.925060@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||0
+2015-11-21 21:30:19.029683||measurement||loadtime||0:00:08.743551||3||0
+2015-11-21 21:30:19.095185||measurement||ad||2015-11-21 21:30:17.501022@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||2||1
+2015-11-21 21:30:19.204512||measurement||ad||2015-11-21 21:30:17.501022@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-21 21:30:19.204886||measurement||loadtime||0:00:14.985959||2||1
+2015-11-21 21:30:20.912285||measurement||ad||2015-11-21 21:30:18.715253@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:30:21.113487||measurement||ad||2015-11-21 21:30:18.715253@|Fora Financial® Loans@|forafinancial.com/@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||0||1
+2015-11-21 21:30:21.801529||measurement||ad||2015-11-21 21:30:18.715253@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:30:21.801852||measurement||loadtime||0:00:17.588186||0||1
+2015-11-21 21:30:23.672098||measurement||ad||2015-11-21 21:30:21.687521@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:30:24.097225||measurement||ad||2015-11-21 21:30:21.687521@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:30:25.948618||measurement||ad||2015-11-21 21:30:21.687521@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:30:25.948917||measurement||loadtime||0:00:06.657392||1||0
+2015-11-21 21:30:28.416491||measurement||ad||2015-11-21 21:30:25.653872@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:30:29.330931||measurement||ad||2015-11-21 21:30:25.653872@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||3||0
+2015-11-21 21:30:32.412142||measurement||ad||2015-11-21 21:30:25.653872@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 21:30:32.412442||measurement||loadtime||0:00:08.382172||3||0
+2015-11-21 21:30:35.686745||measurement||ad||2015-11-21 21:30:33.029598@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:30:37.656943||measurement||ad||2015-11-21 21:30:33.029598@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:30:39.288478||measurement||ad||2015-11-21 21:30:33.029598@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||1||0
+2015-11-21 21:30:39.288817||measurement||loadtime||0:00:08.339454||1||0
+2015-11-21 21:30:40.424711||measurement||ad||2015-11-21 21:30:39.924474@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:30:40.623046||measurement||ad||2015-11-21 21:30:39.924474@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||2||1
+2015-11-21 21:30:40.712942||measurement||ad||2015-11-21 21:30:39.924474@|Top 7 Motor Oil Brands@|comparestores.net@|Finest Motor Oil For Your Vehicle Compare Cyber Monday Deals  Save!||2||1
+2015-11-21 21:30:40.713231||measurement||loadtime||0:00:16.507523||2||1
+2015-11-21 21:30:40.771778||measurement||ad||2015-11-21 21:30:38.762638@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:30:41.249093||measurement||ad||2015-11-21 21:30:38.762638@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:30:41.440743||measurement||ad||2015-11-21 21:30:38.762638@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||3||0
+2015-11-21 21:30:41.441350||measurement||loadtime||0:00:04.026855||3||0
+2015-11-21 21:30:45.996410||measurement||ad||2015-11-21 21:30:45.133958@|Environmental Grad Degree@|onlineprograms.usf.edu/@|Masters in Global Sustainability. 3 Unique Online Concentrations||1||0
+2015-11-21 21:30:46.122684||measurement||ad||2015-11-21 21:30:45.133958@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:30:46.308792||measurement||ad||2015-11-21 21:30:45.133958@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||1||0
+2015-11-21 21:30:46.309069||measurement||loadtime||0:00:02.019072||1||0
+2015-11-21 21:30:49.235134||measurement||ad||2015-11-21 21:30:47.635328@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:30:49.477583||measurement||ad||2015-11-21 21:30:47.635328@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||3||0
+2015-11-21 21:30:49.683010||measurement||ad||2015-11-21 21:30:47.635328@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||3||0
+2015-11-21 21:30:49.683284||measurement||loadtime||0:00:03.239792||3||0
+2015-11-21 21:30:54.460092||measurement||ad||2015-11-21 21:30:52.558717@|Environmental Grad Degree@|onlineprograms.usf.edu/@|Masters in Global Sustainability. 3 Unique Online Concentrations||1||0
+2015-11-21 21:30:55.494343||measurement||ad||2015-11-21 21:30:52.558717@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:30:56.337444||measurement||ad||2015-11-21 21:30:52.558717@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||1||0
+2015-11-21 21:30:56.337773||measurement||loadtime||0:00:05.027214||1||0
+2015-11-21 21:30:57.270285||measurement||ad||2015-11-21 21:30:55.786159@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:30:57.413281||measurement||ad||2015-11-21 21:30:55.786159@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:30:57.963812||measurement||ad||2015-11-21 21:30:55.786159@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||0
+2015-11-21 21:30:57.964151||measurement||loadtime||0:00:03.279019||3||0
+2015-11-21 21:30:58.762322||measurement||ad||2015-11-21 21:30:57.031271@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:30:59.416121||measurement||ad||2015-11-21 21:30:57.031271@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:30:59.556272||measurement||ad||2015-11-21 21:30:57.031271@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:30:59.556746||measurement||loadtime||0:00:13.842107||2||1
+2015-11-21 21:31:03.784080||measurement||ad||2015-11-21 21:31:02.284395@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:31:03.945137||measurement||ad||2015-11-21 21:31:02.284395@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:31:04.067399||measurement||ad||2015-11-21 21:31:02.284395@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:31:04.067608||measurement||loadtime||0:00:02.728919||1||0
+2015-11-21 21:31:05.168684||measurement||ad||2015-11-21 21:31:03.673690@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:31:05.386582||measurement||ad||2015-11-21 21:31:03.673690@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||0
+2015-11-21 21:31:06.827438||measurement||ad||2015-11-21 21:31:03.673690@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:31:06.828420||measurement||loadtime||0:00:03.863860||3||0
+2015-11-21 21:31:09.484432||measurement||ad||2015-11-21 21:31:08.625826@|The Rich Moving Money?@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires.||0||1
+2015-11-21 21:31:09.591701||measurement||ad||2015-11-21 21:31:08.625826@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:31:09.709156||measurement||ad||2015-11-21 21:31:08.625826@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-21 21:31:09.709467||measurement||loadtime||0:00:42.907133||0||1
+2015-11-21 21:31:11.372724||measurement||ad||2015-11-21 21:31:10.408160@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:31:11.619430||measurement||ad||2015-11-21 21:31:10.408160@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||0
+2015-11-21 21:31:11.742493||measurement||ad||2015-11-21 21:31:10.408160@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:31:11.742792||measurement||loadtime||0:00:02.673675||1||0
+2015-11-21 21:31:12.506275||measurement||ad||2015-11-21 21:31:12.179102@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:31:12.660271||measurement||ad||2015-11-21 21:31:12.179102@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||3||0
+2015-11-21 21:31:12.766477||measurement||ad||2015-11-21 21:31:12.179102@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:31:12.766748||measurement||loadtime||0:00:00.937157||3||0
+2015-11-21 21:31:14.049484||measurement||ad||2015-11-21 21:31:13.264814@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:31:14.261657||measurement||ad||2015-11-21 21:31:13.264814@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:31:14.398050||measurement||ad||2015-11-21 21:31:13.264814@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||2||1
+2015-11-21 21:31:14.398375||measurement||loadtime||0:00:09.841025||2||1
+2015-11-21 21:31:19.281861||error||collecting ads||Error||3||0
+2015-11-21 21:31:20.103129||measurement||ad||2015-11-21 21:31:18.383891@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:31:20.403200||measurement||ad||2015-11-21 21:31:18.383891@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:31:20.746329||measurement||ad||2015-11-21 21:31:18.383891@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||1||0
+2015-11-21 21:31:20.746667||measurement||loadtime||0:00:04.003258||1||0
+2015-11-21 21:31:25.168971||error||collecting ads||Error||3||0
+2015-11-21 21:31:25.169654||event||progress-marker||measurement-end||3||0
+2015-11-21 21:31:26.564075||error||collecting ads||Error||1||0
+2015-11-21 21:31:27.950200||measurement||ad||2015-11-21 21:31:27.697024@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:31:28.101549||measurement||ad||2015-11-21 21:31:27.697024@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||2||1
+2015-11-21 21:31:28.190398||measurement||ad||2015-11-21 21:31:27.697024@|Top 7 Motor Oil Brands@|comparestores.net@|Finest Motor Oil For Your Vehicle Compare Cyber Monday Deals  Save!||2||1
+2015-11-21 21:31:28.190791||measurement||loadtime||0:00:08.791557||2||1
+2015-11-21 21:31:33.172740||measurement||ad||2015-11-21 21:31:32.249854@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:31:33.414367||measurement||ad||2015-11-21 21:31:32.249854@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:31:33.606906||measurement||ad||2015-11-21 21:31:32.249854@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||1||0
+2015-11-21 21:31:33.607176||measurement||loadtime||0:00:02.041641||1||0
+2015-11-21 21:31:33.607363||event||progress-marker||measurement-end||1||0
+2015-11-21 21:31:38.207599||measurement||ad||2015-11-21 21:31:37.989977@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:31:38.281710||measurement||ad||2015-11-21 21:31:37.989977@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:31:38.344035||measurement||ad||2015-11-21 21:31:37.989977@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||2||1
+2015-11-21 21:31:38.344299||measurement||loadtime||0:00:05.153124||2||1
+2015-11-21 21:31:48.224800||measurement||ad||2015-11-21 21:31:48.118040@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:31:48.345066||measurement||ad||2015-11-21 21:31:48.118040@|Next Financial Moves@|www.caseyresearch.com@|Discover the Next Financial Moves of these 3 Billionaires||2||1
+2015-11-21 21:31:48.359116||measurement||ad||2015-11-21 21:31:47.715340@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:31:48.413832||measurement||ad||2015-11-21 21:31:48.118040@|Top 7 Motor Oil Brands@|comparestores.net@|Finest Motor Oil For Your Vehicle Compare Cyber Monday Deals  Save!||2||1
+2015-11-21 21:31:48.414103||measurement||loadtime||0:00:05.069073||2||1
+2015-11-21 21:31:48.419631||measurement||ad||2015-11-21 21:31:47.715340@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:31:48.474119||measurement||ad||2015-11-21 21:31:47.715340@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||0||1
+2015-11-21 21:31:48.474413||measurement||loadtime||0:00:33.764081||0||1
+2015-11-21 21:31:57.778575||measurement||ad||2015-11-21 21:31:57.683053@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:31:57.849384||measurement||ad||2015-11-21 21:31:57.683053@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:31:57.909121||measurement||ad||2015-11-21 21:31:57.683053@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:31:57.909517||measurement||loadtime||0:00:04.434260||0||1
+2015-11-21 21:31:58.121936||measurement||ad||2015-11-21 21:31:58.033783@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:31:58.238934||measurement||ad||2015-11-21 21:31:58.033783@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:31:58.291725||measurement||ad||2015-11-21 21:31:58.033783@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:31:58.292018||measurement||loadtime||0:00:04.876216||2||1
+2015-11-21 21:32:08.394955||measurement||ad||2015-11-21 21:32:08.232786@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:32:08.492786||measurement||ad||2015-11-21 21:32:08.232786@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:32:08.582152||measurement||ad||2015-11-21 21:32:08.232786@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:32:08.582454||measurement||loadtime||0:00:05.671866||0||1
+2015-11-21 21:32:09.093649||measurement||ad||2015-11-21 21:32:08.985791@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:32:09.167877||measurement||ad||2015-11-21 21:32:08.985791@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:32:09.224549||measurement||ad||2015-11-21 21:32:08.985791@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:32:09.224886||measurement||loadtime||0:00:05.932099||2||1
+2015-11-21 21:32:17.032946||measurement||ad||2015-11-21 21:32:14.317983@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. Competitive Rates. Apply Online Now||2||1
+2015-11-21 21:32:17.382037||measurement||ad||2015-11-21 21:32:14.317983@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:32:17.645470||measurement||ad||2015-11-21 21:32:14.317983@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:32:17.645759||measurement||loadtime||0:00:03.420404||2||1
+2015-11-21 21:32:17.645951||event||progress-marker||measurement-end||2||1
+2015-11-21 21:32:18.255175||measurement||ad||2015-11-21 21:32:18.018931@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:32:18.401435||measurement||ad||2015-11-21 21:32:18.018931@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:32:18.515193||measurement||ad||2015-11-21 21:32:18.018931@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:32:18.515428||measurement||loadtime||0:00:04.930995||0||1
+2015-11-21 21:32:28.435430||measurement||ad||2015-11-21 21:32:28.366476@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||0||1
+2015-11-21 21:32:28.510022||measurement||ad||2015-11-21 21:32:28.366476@|75% off Cruise deals@|www.bookingbuddy.com/Cruises@|Find the Cheapest Cruise Deals. Free Search Tool. Compare  Save!||0||1
+2015-11-21 21:32:28.563839||measurement||ad||2015-11-21 21:32:28.366476@|Smoothie Blenders Sale@|blackfridaydiscount.net/Sale@|Smoothie Blenders Markdowns Top 5 Stunning Black Friday Deals !||0||1
+2015-11-21 21:32:28.564177||measurement||loadtime||0:00:05.047403||0||1
+2015-11-21 21:32:37.116060||measurement||ad||2015-11-21 21:32:37.040540@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:32:37.161014||measurement||ad||2015-11-21 21:32:37.040540@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:32:37.209453||measurement||ad||2015-11-21 21:32:37.040540@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:32:37.209728||measurement||loadtime||0:00:03.644441||0||1
+2015-11-21 21:32:45.946723||measurement||ad||2015-11-21 21:32:45.863117@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:32:46.003274||measurement||ad||2015-11-21 21:32:45.863117@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:32:46.048114||measurement||ad||2015-11-21 21:32:45.863117@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 21:32:46.048944||measurement||loadtime||0:00:03.837497||0||1
+2015-11-21 21:32:53.283060||measurement||ad||2015-11-21 21:32:51.151142@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:32:54.242098||measurement||ad||2015-11-21 21:32:51.151142@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||0||1
+2015-11-21 21:32:54.299160||measurement||ad||2015-11-21 21:32:51.151142@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||1
+2015-11-21 21:32:54.299521||measurement||loadtime||0:00:03.248333||0||1
+2015-11-21 21:32:54.299650||event||progress-marker||measurement-end||0||1
+2015-11-21 21:32:54.508837||meta||block_id end||15
+2015-11-21 21:32:54.511252||meta||block_id start||16
+2015-11-21 21:32:54.511297||meta||assignment||2@|1@|0@|3
+2015-11-21 21:32:57.177512||event||progress-marker||training-start||2||0
+2015-11-21 21:32:57.177888||event||progress-marker||training-end||2||0
+2015-11-21 21:32:57.285365||event||progress-marker||training-start||1||0
+2015-11-21 21:32:57.285712||event||progress-marker||training-end||1||0
+2015-11-21 21:33:00.706270||event||progress-marker||training-start||0||1
+2015-11-21 21:33:00.706578||event||progress-marker||training-end||0||1
+2015-11-21 21:33:00.708540||event||progress-marker||training-start||3||1
+2015-11-21 21:33:00.708836||event||progress-marker||training-end||3||1
+2015-11-21 21:33:02.210116||event||progress-marker||measurement-start||2||0
+2015-11-21 21:33:02.385435||event||progress-marker||measurement-start||1||0
+2015-11-21 21:33:05.731861||event||progress-marker||measurement-start||0||1
+2015-11-21 21:33:05.733948||event||progress-marker||measurement-start||3||1
+2015-11-21 21:33:09.773999||measurement||ad||2015-11-21 21:33:09.035342@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:33:10.479280||measurement||ad||2015-11-21 21:33:09.035342@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||2||0
+2015-11-21 21:33:10.560787||measurement||ad||2015-11-21 21:33:09.035342@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||2||0
+2015-11-21 21:33:10.561071||measurement||loadtime||0:00:03.349454||2||0
+2015-11-21 21:33:10.786843||measurement||ad||2015-11-21 21:33:09.452839@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:33:11.041044||measurement||ad||2015-11-21 21:33:09.452839@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||0
+2015-11-21 21:33:11.299430||measurement||ad||2015-11-21 21:33:09.452839@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||0
+2015-11-21 21:33:11.299825||measurement||loadtime||0:00:03.913670||1||0
+2015-11-21 21:33:21.243856||measurement||ad||2015-11-21 21:33:17.181593@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:33:21.395818||measurement||ad||2015-11-21 21:33:17.181593@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:33:22.233168||measurement||ad||2015-11-21 21:33:17.970614@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:33:22.466647||measurement||ad||2015-11-21 21:33:21.817379@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 21:33:22.597698||measurement||ad||2015-11-21 21:33:21.817379@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||1
+2015-11-21 21:33:22.680832||measurement||ad||2015-11-21 21:33:17.181593@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||2||0
+2015-11-21 21:33:22.681159||measurement||loadtime||0:00:07.119242||2||0
+2015-11-21 21:33:22.785471||measurement||ad||2015-11-21 21:33:21.817379@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||1
+2015-11-21 21:33:22.785859||measurement||loadtime||0:00:12.051332||3||1
+2015-11-21 21:33:23.289120||measurement||ad||2015-11-21 21:33:17.970614@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:33:24.910065||measurement||ad||2015-11-21 21:33:17.970614@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:33:24.910435||measurement||loadtime||0:00:08.610033||1||0
+2015-11-21 21:33:26.984305||measurement||ad||2015-11-21 21:33:23.131031@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:33:28.565601||measurement||ad||2015-11-21 21:33:23.131031@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:33:29.243721||measurement||ad||2015-11-21 21:33:23.131031@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:33:29.244146||measurement||loadtime||0:00:18.511040||0||1
+2015-11-21 21:33:32.864455||measurement||ad||2015-11-21 21:33:29.930759@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:33:33.425986||measurement||ad||2015-11-21 21:33:29.930759@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:33:33.908170||measurement||ad||2015-11-21 21:33:31.858721@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:33:34.157193||measurement||ad||2015-11-21 21:33:31.858721@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:33:34.562372||measurement||ad||2015-11-21 21:33:29.930759@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||2||0
+2015-11-21 21:33:34.562944||measurement||loadtime||0:00:06.880419||2||0
+2015-11-21 21:33:35.906280||measurement||ad||2015-11-21 21:33:31.858721@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:33:35.906604||measurement||loadtime||0:00:05.995335||1||0
+2015-11-21 21:33:44.571774||measurement||ad||2015-11-21 21:33:41.023468@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-21 21:33:45.037973||measurement||ad||2015-11-21 21:33:42.943797@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 21:33:45.259305||measurement||ad||2015-11-21 21:33:41.023468@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||0
+2015-11-21 21:33:45.484871||measurement||ad||2015-11-21 21:33:41.023468@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||2||0
+2015-11-21 21:33:45.485194||measurement||loadtime||0:00:05.920930||2||0
+2015-11-21 21:33:45.616922||measurement||ad||2015-11-21 21:33:42.629251@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:33:45.648338||measurement||ad||2015-11-21 21:33:42.943797@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:33:46.321351||measurement||ad||2015-11-21 21:33:42.943797@|International Calls@|www.keepcalling.com@|Cheapest Rates with KeepCalling. Find Out More!||3||1
+2015-11-21 21:33:46.321709||measurement||loadtime||0:00:18.535414||3||1
+2015-11-21 21:33:46.543121||measurement||ad||2015-11-21 21:33:42.629251@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:33:47.939578||measurement||ad||2015-11-21 21:33:42.629251@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:33:47.940082||measurement||loadtime||0:00:07.032415||1||0
+2015-11-21 21:33:52.849904||measurement||ad||2015-11-21 21:33:51.237853@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 21:33:53.010171||measurement||ad||2015-11-21 21:33:51.237853@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:33:53.245077||measurement||ad||2015-11-21 21:33:51.237853@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:33:53.245349||measurement||loadtime||0:00:02.758903||2||0
+2015-11-21 21:33:57.387235||measurement||ad||2015-11-21 21:33:53.718368@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:33:57.536979||measurement||ad||2015-11-21 21:33:53.718368@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:33:59.330027||measurement||ad||2015-11-21 21:33:53.718368@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:33:59.330349||measurement||loadtime||0:00:06.388818||1||0
+2015-11-21 21:34:02.140813||measurement||ad||2015-11-21 21:33:59.484515@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:34:02.751900||measurement||ad||2015-11-21 21:33:59.484515@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||0
+2015-11-21 21:34:03.173292||measurement||ad||2015-11-21 21:34:02.758549@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||1
+2015-11-21 21:34:03.279237||measurement||ad||2015-11-21 21:34:02.758549@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:34:03.558681||measurement||ad||2015-11-21 21:34:02.758549@|Forensic Science Training@|forensics.comparetopschools.com@|Find Colleges  Universities With Forensic Science Degree Programs.||3||1
+2015-11-21 21:34:03.558998||measurement||loadtime||0:00:12.235201||3||1
+2015-11-21 21:34:04.390437||measurement||ad||2015-11-21 21:33:59.484515@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||0
+2015-11-21 21:34:04.390768||measurement||loadtime||0:00:06.143968||2||0
+2015-11-21 21:34:07.952348||measurement||ad||2015-11-21 21:34:05.536634@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:34:08.239097||measurement||ad||2015-11-21 21:34:05.536634@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:34:10.225781||measurement||ad||2015-11-21 21:34:05.536634@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:34:10.226087||measurement||loadtime||0:00:05.895288||1||0
+2015-11-21 21:34:13.438125||measurement||ad||2015-11-21 21:34:11.003479@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:34:14.513053||measurement||ad||2015-11-21 21:34:11.003479@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||0
+2015-11-21 21:34:14.715246||measurement||ad||2015-11-21 21:34:11.003479@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||0
+2015-11-21 21:34:14.715573||measurement||loadtime||0:00:05.324192||2||0
+2015-11-21 21:34:20.457408||error||collecting ads||Error||2||0
+2015-11-21 21:34:20.895429||measurement||ad||2015-11-21 21:34:16.882806@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:34:22.302575||measurement||ad||2015-11-21 21:34:16.882806@|3 Herbs that Beat Anxiety@|www.a2xanxiety.com@|Doctors Reveal 1 Weird Compound to Calm Anxiety that May Surprise You||1||0
+2015-11-21 21:34:24.687832||measurement||ad||2015-11-21 21:34:24.314010@|Earth Day@|cafepress.com@|Shop Over 150 Million Unique Gifts  Print-On-Demand Products.||3||1
+2015-11-21 21:34:24.785063||measurement||ad||2015-11-21 21:34:24.314010@|Forensic Science Training@|forensics.comparetopschools.com@|Find Colleges  Universities With Forensic Science Degree Programs.||3||1
+2015-11-21 21:34:24.862671||measurement||ad||2015-11-21 21:34:24.314010@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-21 21:34:24.862965||measurement||loadtime||0:00:16.303533||3||1
+2015-11-21 21:34:26.629854||measurement||ad||2015-11-21 21:34:16.882806@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||1||0
+2015-11-21 21:34:26.630541||measurement||loadtime||0:00:11.402460||1||0
+2015-11-21 21:34:27.881752||measurement||ad||2015-11-21 21:34:26.041551@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-21 21:34:28.037894||measurement||ad||2015-11-21 21:34:26.041551@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-21 21:34:28.270309||measurement||ad||2015-11-21 21:34:26.041551@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||0
+2015-11-21 21:34:28.270640||measurement||loadtime||0:00:02.811764||2||0
+2015-11-21 21:34:35.263278||measurement||ad||2015-11-21 21:34:32.611096@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||0
+2015-11-21 21:34:35.263938||measurement||loadtime||0:00:03.632893||1||0
+2015-11-21 21:34:37.127986||measurement||ad||2015-11-21 21:34:33.836757@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||0
+2015-11-21 21:34:37.259970||measurement||ad||2015-11-21 21:34:33.836757@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||0
+2015-11-21 21:34:37.408524||measurement||ad||2015-11-21 21:34:33.836757@|Fora Financial® Loans@|forafinancial.com/@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||2||0
+2015-11-21 21:34:37.408986||measurement||loadtime||0:00:04.136908||2||0
+2015-11-21 21:34:37.409291||event||progress-marker||measurement-end||2||0
+2015-11-21 21:34:39.287180||measurement||ad||2015-11-21 21:34:38.870137@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 21:34:39.488860||measurement||ad||2015-11-21 21:34:38.870137@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:34:39.595858||measurement||ad||2015-11-21 21:34:38.870137@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:34:39.596211||measurement||loadtime||0:00:09.730092||3||1
+2015-11-21 21:34:42.147352||measurement||ad||2015-11-21 21:34:41.005721@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:34:42.218656||measurement||ad||2015-11-21 21:34:41.005721@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||0
+2015-11-21 21:34:42.403448||measurement||ad||2015-11-21 21:34:41.005721@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||0
+2015-11-21 21:34:42.403770||measurement||loadtime||0:00:02.138612||1||0
+2015-11-21 21:34:49.633897||measurement||ad||2015-11-21 21:34:48.390646@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:34:49.771626||measurement||ad||2015-11-21 21:34:48.390646@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||0
+2015-11-21 21:34:49.871737||measurement||ad||2015-11-21 21:34:48.390646@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||0
+2015-11-21 21:34:49.871995||measurement||loadtime||0:00:02.467931||1||0
+2015-11-21 21:34:49.872150||event||progress-marker||measurement-end||1||0
+2015-11-21 21:34:50.949998||measurement||ad||2015-11-21 21:34:50.821440@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:34:51.011230||measurement||ad||2015-11-21 21:34:50.821440@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:34:51.056672||measurement||ad||2015-11-21 21:34:50.821440@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:34:51.056963||measurement||loadtime||0:00:06.459643||3||1
+2015-11-21 21:35:01.341386||measurement||ad||2015-11-21 21:35:01.112981@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:35:01.396682||measurement||ad||2015-11-21 21:35:01.112981@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:35:01.454344||measurement||ad||2015-11-21 21:35:01.112981@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:35:01.454604||measurement||loadtime||0:00:05.396493||3||1
+2015-11-21 21:35:10.405976||measurement||ad||2015-11-21 21:35:10.318239@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:35:10.460899||measurement||ad||2015-11-21 21:35:10.318239@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:35:10.514396||measurement||ad||2015-11-21 21:35:10.318239@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:35:10.514622||measurement||loadtime||0:00:04.059037||3||1
+2015-11-21 21:35:17.297139||measurement||ad||2015-11-21 21:35:15.604546@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||3||1
+2015-11-21 21:35:17.870038||measurement||ad||2015-11-21 21:35:15.604546@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||1
+2015-11-21 21:35:19.967500||measurement||ad||2015-11-21 21:35:15.604546@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-21 21:35:19.967910||measurement||loadtime||0:00:04.451953||3||1
+2015-11-21 21:35:29.975605||measurement||ad||2015-11-21 21:35:29.743403@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||1
+2015-11-21 21:35:30.058205||measurement||ad||2015-11-21 21:35:29.743403@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-21 21:35:30.140852||measurement||ad||2015-11-21 21:35:29.743403@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||3||1
+2015-11-21 21:35:30.141093||measurement||loadtime||0:00:05.172719||3||1
+2015-11-21 21:35:30.141239||event||progress-marker||measurement-end||3||1
+2015-11-21 21:35:30.858067||measurement||ad||2015-11-21 21:33:49.215459@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:35:30.903666||measurement||ad||2015-11-21 21:33:49.215459@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:35:30.936444||measurement||ad||2015-11-21 21:33:49.215459@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||0||1
+2015-11-21 21:35:30.936744||measurement||loadtime||0:01:56.691444||0||1
+2015-11-21 21:35:55.886880||measurement||ad||2015-11-21 21:35:55.393045@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:35:55.939368||measurement||ad||2015-11-21 21:35:55.393045@|Earth Day@|cafepress.com@|1000s of Earth Day Gifts to Choose From. Shop Online Now!||0||1
+2015-11-21 21:35:55.976139||measurement||ad||2015-11-21 21:35:55.393045@|Moving the Giants@|www.movingthegiants.com@|Plant a Tree. Save the Planet Inspiring video on saving redwoods||0||1
+2015-11-21 21:35:55.976380||measurement||loadtime||0:00:20.038193||0||1
+2015-11-21 21:36:05.177310||measurement||ad||2015-11-21 21:36:05.020569@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:36:05.289360||measurement||ad||2015-11-21 21:36:05.020569@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 21:36:05.474776||measurement||ad||2015-11-21 21:36:05.020569@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:36:05.475074||measurement||loadtime||0:00:04.497393||0||1
+2015-11-21 21:36:18.062839||measurement||ad||2015-11-21 21:36:17.765263@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:36:18.268503||measurement||ad||2015-11-21 21:36:17.765263@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 21:36:18.393000||measurement||ad||2015-11-21 21:36:17.765263@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:36:18.393513||measurement||loadtime||0:00:07.917785||0||1
+2015-11-21 21:36:26.981715||measurement||ad||2015-11-21 21:36:26.807575@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:36:27.147770||measurement||ad||2015-11-21 21:36:26.807575@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||0||1
+2015-11-21 21:36:27.201937||measurement||ad||2015-11-21 21:36:26.807575@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:36:27.202286||measurement||loadtime||0:00:03.808064||0||1
+2015-11-21 21:36:35.447603||measurement||ad||2015-11-21 21:36:35.273222@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||0||1
+2015-11-21 21:36:35.667929||measurement||ad||2015-11-21 21:36:35.273222@|Earth Day@|cafepress.com@|1000s of Earth Day Gifts to Choose From. Shop Online Now!||0||1
+2015-11-21 21:36:35.759523||measurement||ad||2015-11-21 21:36:35.273222@|Moving the Giants@|www.movingthegiants.com@|Plant a Tree. Save the Planet Inspiring video on saving redwoods||0||1
+2015-11-21 21:36:35.759783||measurement||loadtime||0:00:03.556776||0||1
+2015-11-21 21:36:42.232946||measurement||ad||2015-11-21 21:36:40.822112@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:36:42.339011||measurement||ad||2015-11-21 21:36:40.822112@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 21:36:42.454348||measurement||ad||2015-11-21 21:36:40.822112@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:36:42.454620||measurement||loadtime||0:00:01.693743||0||1
+2015-11-21 21:36:51.321512||measurement||ad||2015-11-21 21:36:51.226656@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:36:51.372490||measurement||ad||2015-11-21 21:36:51.226656@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 21:36:51.418372||measurement||ad||2015-11-21 21:36:51.226656@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||1
+2015-11-21 21:36:51.418996||measurement||loadtime||0:00:03.962844||0||1
+2015-11-21 21:37:01.781787||measurement||ad||2015-11-21 21:37:01.706739@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||0||1
+2015-11-21 21:37:01.834363||measurement||ad||2015-11-21 21:37:01.706739@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||0||1
+2015-11-21 21:37:01.890510||measurement||ad||2015-11-21 21:37:01.706739@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:37:01.890804||measurement||loadtime||0:00:05.471309||0||1
+2015-11-21 21:37:01.891050||event||progress-marker||measurement-end||0||1
+2015-11-21 21:37:02.154686||meta||block_id end||16
+2015-11-21 21:37:02.156526||meta||block_id start||17
+2015-11-21 21:37:02.156559||meta||assignment||3@|0@|2@|1
+2015-11-21 21:37:04.530042||event||progress-marker||training-start||3||0
+2015-11-21 21:37:04.530334||event||progress-marker||training-end||3||0
+2015-11-21 21:37:04.643187||event||progress-marker||training-start||0||0
+2015-11-21 21:37:04.643498||event||progress-marker||training-end||0||0
+2015-11-21 21:37:07.355685||event||progress-marker||training-start||2||1
+2015-11-21 21:37:07.356029||event||progress-marker||training-end||2||1
+2015-11-21 21:37:07.366669||event||progress-marker||training-start||1||1
+2015-11-21 21:37:07.366927||event||progress-marker||training-end||1||1
+2015-11-21 21:37:09.571745||event||progress-marker||measurement-start||3||0
+2015-11-21 21:37:09.675771||event||progress-marker||measurement-start||0||0
+2015-11-21 21:37:12.382911||event||progress-marker||measurement-start||2||1
+2015-11-21 21:37:12.387858||event||progress-marker||measurement-start||1||1
+2015-11-21 21:37:17.198321||measurement||ad||2015-11-21 21:37:16.494591@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:37:17.814802||measurement||ad||2015-11-21 21:37:16.542686@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:37:18.205968||measurement||ad||2015-11-21 21:37:16.494591@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||0||0
+2015-11-21 21:37:18.226320||measurement||ad||2015-11-21 21:37:16.542686@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||3||0
+2015-11-21 21:37:18.508151||measurement||ad||2015-11-21 21:37:16.542686@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||3||0
+2015-11-21 21:37:18.508479||measurement||loadtime||0:00:03.935216||3||0
+2015-11-21 21:37:18.539801||measurement||ad||2015-11-21 21:37:16.494591@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||0||0
+2015-11-21 21:37:18.540125||measurement||loadtime||0:00:03.863276||0||0
+2015-11-21 21:37:25.156811||error||collecting ads||Error||0||0
+2015-11-21 21:37:27.710420||measurement||ad||2015-11-21 21:37:24.019571@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:37:27.900493||measurement||ad||2015-11-21 21:37:24.019571@|Guaranteed Business Loans@|biz2credit.com/Business-Loan@|$5000-$5MM Business Loan Available! No Startups, Get Approved Today.||3||0
+2015-11-21 21:37:28.994129||measurement||ad||2015-11-21 21:37:24.019571@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:37:28.994514||measurement||loadtime||0:00:05.485531||3||0
+2015-11-21 21:37:31.239165||measurement||ad||2015-11-21 21:37:29.620428@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:37:31.445442||measurement||ad||2015-11-21 21:37:29.620428@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||1||1
+2015-11-21 21:37:31.870041||measurement||ad||2015-11-21 21:37:29.620428@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||1||1
+2015-11-21 21:37:31.870448||measurement||loadtime||0:00:14.481541||1||1
+2015-11-21 21:37:35.833795||measurement||ad||2015-11-21 21:37:32.700243@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:37:36.246832||measurement||ad||2015-11-21 21:37:32.700243@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||1
+2015-11-21 21:37:36.373800||measurement||ad||2015-11-21 21:37:31.956002@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||0||0
+2015-11-21 21:37:36.374095||measurement||loadtime||0:00:06.216641||0||0
+2015-11-21 21:37:36.637494||measurement||ad||2015-11-21 21:37:32.700243@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||1
+2015-11-21 21:37:36.637830||measurement||loadtime||0:00:19.253460||2||1
+2015-11-21 21:37:38.257388||measurement||ad||2015-11-21 21:37:35.785915@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:37:40.805278||measurement||ad||2015-11-21 21:37:35.785915@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||0
+2015-11-21 21:37:42.137963||measurement||ad||2015-11-21 21:37:35.785915@|Forensic Science Training@|forensics.comparetopschools.com@|Request Free Info From Schools With Forensic Science Degree Programs.||3||0
+2015-11-21 21:37:42.138439||measurement||loadtime||0:00:08.143415||3||0
+2015-11-21 21:37:42.318879||error||collecting ads||Error||0||0
+2015-11-21 21:37:48.097022||error||collecting ads||Error||0||0
+2015-11-21 21:37:49.413195||measurement||ad||2015-11-21 21:37:49.135876@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:37:49.557350||measurement||ad||2015-11-21 21:37:49.135876@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:37:49.640626||measurement||ad||2015-11-21 21:37:49.135876@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||1
+2015-11-21 21:37:49.640967||measurement||loadtime||0:00:12.769585||1||1
+2015-11-21 21:37:50.039852||measurement||ad||2015-11-21 21:37:48.573990@|Guaranteed Business Loans@|biz2credit.com/Business-Loan@|$5000-$5MM Business Loan Available! No Startups, Get Approved Today.||3||0
+2015-11-21 21:37:50.193682||measurement||ad||2015-11-21 21:37:48.573990@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:37:50.325240||measurement||ad||2015-11-21 21:37:48.573990@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:37:50.325543||measurement||loadtime||0:00:03.186711||3||0
+2015-11-21 21:37:54.475980||error||collecting ads||Error||0||0
+2015-11-21 21:37:55.542090||measurement||ad||2015-11-21 21:37:54.241733@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:37:56.216068||measurement||ad||2015-11-21 21:37:54.241733@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:37:56.525705||measurement||ad||2015-11-21 21:37:54.241733@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:37:56.526548||measurement||loadtime||0:00:14.887094||2||1
+2015-11-21 21:37:56.909181||error||collecting ads||Error||3||0
+2015-11-21 21:38:01.550373||error||collecting ads||Error||0||0
+2015-11-21 21:38:06.775052||measurement||ad||2015-11-21 21:38:03.257560@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:38:07.944086||measurement||ad||2015-11-21 21:38:03.257560@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||0
+2015-11-21 21:38:09.479464||measurement||ad||2015-11-21 21:38:07.136292@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:38:10.087843||measurement||ad||2015-11-21 21:38:07.136292@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:38:10.418014||measurement||ad||2015-11-21 21:38:03.257560@|Forensic Science Training@|forensics.comparetopschools.com@|Request Free Info From Schools With Forensic Science Degree Programs.||3||0
+2015-11-21 21:38:10.418338||measurement||loadtime||0:00:08.508072||3||0
+2015-11-21 21:38:10.746979||measurement||ad||2015-11-21 21:38:07.136292@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||1
+2015-11-21 21:38:10.747347||measurement||loadtime||0:00:16.105621||1||1
+2015-11-21 21:38:11.835216||measurement||ad||2015-11-21 21:38:08.352366@|Sharefile®@|99% of Fortune 500 companies use it@|Secure file sharing and storage. ||0||0
+2015-11-21 21:38:11.836372||measurement||loadtime||0:00:05.285095||0||0
+2015-11-21 21:38:13.189975||measurement||ad||2015-11-21 21:38:12.624646@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:38:13.371543||measurement||ad||2015-11-21 21:38:12.624646@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:38:13.474170||measurement||ad||2015-11-21 21:38:12.624646@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:38:13.474451||measurement||loadtime||0:00:11.946481||2||1
+2015-11-21 21:38:18.527535||measurement||ad||2015-11-21 21:38:17.029258@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:38:18.696119||measurement||ad||2015-11-21 21:38:17.029258@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||0
+2015-11-21 21:38:19.078471||measurement||ad||2015-11-21 21:38:17.029258@|Forensic Science Training@|forensics.comparetopschools.com@|Request Free Info From Schools With Forensic Science Degree Programs.||3||0
+2015-11-21 21:38:19.078782||measurement||loadtime||0:00:03.659392||3||0
+2015-11-21 21:38:20.295004||measurement||ad||2015-11-21 21:38:17.368845@|Sharefile®@|99% of Fortune 500 companies use it@|Secure file sharing and storage. ||0||0
+2015-11-21 21:38:20.295397||measurement||loadtime||0:00:03.458152||0||0
+2015-11-21 21:38:26.268645||error||collecting ads||Error||0||0
+2015-11-21 21:38:26.270268||event||progress-marker||measurement-end||0||0
+2015-11-21 21:38:27.808309||measurement||ad||2015-11-21 21:38:25.479222@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:38:28.053941||measurement||ad||2015-11-21 21:38:25.479222@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:38:28.445703||measurement||ad||2015-11-21 21:38:27.914234@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||1||1
+2015-11-21 21:38:28.605243||measurement||ad||2015-11-21 21:38:27.914234@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-21 21:38:28.703324||measurement||ad||2015-11-21 21:38:27.914234@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:38:28.704758||measurement||loadtime||0:00:12.955340||1||1
+2015-11-21 21:38:29.583032||measurement||ad||2015-11-21 21:38:28.992130@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:38:29.663509||measurement||ad||2015-11-21 21:38:25.479222@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||3||0
+2015-11-21 21:38:29.664634||measurement||loadtime||0:00:05.585203||3||0
+2015-11-21 21:38:29.899669||measurement||ad||2015-11-21 21:38:28.992130@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:38:30.124456||measurement||ad||2015-11-21 21:38:28.992130@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:38:30.124780||measurement||loadtime||0:00:11.649106||2||1
+2015-11-21 21:38:36.756105||measurement||ad||2015-11-21 21:38:35.703712@|Guaranteed Business Loans@|biz2credit.com/Business-Loan@|$5000-$5MM Business Loan Available! No Startups, Get Approved Today.||3||0
+2015-11-21 21:38:36.970687||measurement||ad||2015-11-21 21:38:35.703712@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:38:37.101057||measurement||ad||2015-11-21 21:38:35.703712@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||3||0
+2015-11-21 21:38:37.101393||measurement||loadtime||0:00:02.435906||3||0
+2015-11-21 21:38:40.322004||measurement||ad||2015-11-21 21:38:40.148765@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||1||1
+2015-11-21 21:38:40.421693||measurement||ad||2015-11-21 21:38:40.148765@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||1||1
+2015-11-21 21:38:40.526460||measurement||ad||2015-11-21 21:38:40.148765@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:38:40.527247||measurement||loadtime||0:00:06.821324||1||1
+2015-11-21 21:38:43.216332||measurement||ad||2015-11-21 21:38:42.769143@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:38:43.299731||measurement||ad||2015-11-21 21:38:42.769143@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:38:43.371324||measurement||ad||2015-11-21 21:38:42.769143@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:38:43.371685||measurement||loadtime||0:00:08.245815||2||1
+2015-11-21 21:38:43.738578||measurement||ad||2015-11-21 21:38:42.689416@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:38:43.816706||measurement||ad||2015-11-21 21:38:42.689416@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:38:43.914487||measurement||ad||2015-11-21 21:38:42.689416@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||3||0
+2015-11-21 21:38:43.914735||measurement||loadtime||0:00:01.812866||3||0
+2015-11-21 21:38:43.915084||event||progress-marker||measurement-end||3||0
+2015-11-21 21:38:49.897565||measurement||ad||2015-11-21 21:38:49.668283@|Sharefile®@|99% of Fortune 500 companies use it@|Secure file sharing and storage. ||1||1
+2015-11-21 21:38:49.897804||measurement||loadtime||0:00:04.369150||1||1
+2015-11-21 21:38:53.139695||measurement||ad||2015-11-21 21:38:52.883784@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:38:53.221985||measurement||ad||2015-11-21 21:38:52.883784@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:38:53.280983||measurement||ad||2015-11-21 21:38:52.883784@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:38:53.281300||measurement||loadtime||0:00:04.909178||2||1
+2015-11-21 21:38:59.869329||measurement||ad||2015-11-21 21:38:59.637623@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:38:59.954934||measurement||ad||2015-11-21 21:38:59.637623@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:39:00.018857||measurement||ad||2015-11-21 21:38:59.637623@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||1
+2015-11-21 21:39:00.019189||measurement||loadtime||0:00:05.120390||1||1
+2015-11-21 21:39:04.377510||measurement||ad||2015-11-21 21:39:03.675759@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:39:04.442805||measurement||ad||2015-11-21 21:39:03.675759@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:39:04.498356||measurement||ad||2015-11-21 21:39:03.675759@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-21 21:39:04.498607||measurement||loadtime||0:00:06.215985||2||1
+2015-11-21 21:39:07.135143||measurement||ad||2015-11-21 21:39:05.278698@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:39:07.218665||measurement||ad||2015-11-21 21:39:05.278698@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:39:07.336529||measurement||ad||2015-11-21 21:39:05.278698@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||1
+2015-11-21 21:39:07.336817||measurement||loadtime||0:00:02.316498||1||1
+2015-11-21 21:39:14.047950||measurement||ad||2015-11-21 21:39:13.945101@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:39:14.121189||measurement||ad||2015-11-21 21:39:13.945101@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:39:14.188970||measurement||ad||2015-11-21 21:39:13.945101@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:39:14.189413||measurement||loadtime||0:00:04.690182||2||1
+2015-11-21 21:39:16.421468||measurement||ad||2015-11-21 21:39:16.191644@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:39:16.522599||measurement||ad||2015-11-21 21:39:16.191644@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:39:16.609645||measurement||ad||2015-11-21 21:39:16.191644@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||1||1
+2015-11-21 21:39:16.609935||measurement||loadtime||0:00:04.272719||1||1
+2015-11-21 21:39:24.749731||measurement||ad||2015-11-21 21:39:24.641210@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:39:24.843059||measurement||ad||2015-11-21 21:39:24.641210@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:39:24.920255||measurement||ad||2015-11-21 21:39:24.641210@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:39:24.920498||measurement||loadtime||0:00:05.730470||2||1
+2015-11-21 21:39:27.870778||measurement||ad||2015-11-21 21:39:27.756845@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:39:27.938911||measurement||ad||2015-11-21 21:39:27.756845@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:39:27.993636||measurement||ad||2015-11-21 21:39:27.756845@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||1||1
+2015-11-21 21:39:27.994041||measurement||loadtime||0:00:06.383130||1||1
+2015-11-21 21:39:27.994303||event||progress-marker||measurement-end||1||1
+2015-11-21 21:39:34.088253||measurement||ad||2015-11-21 21:39:34.006751@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||2||1
+2015-11-21 21:39:34.149764||measurement||ad||2015-11-21 21:39:34.006751@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:39:34.199929||measurement||ad||2015-11-21 21:39:34.006751@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:39:34.200171||measurement||loadtime||0:00:04.278560||2||1
+2015-11-21 21:39:34.200333||event||progress-marker||measurement-end||2||1
+2015-11-21 21:39:34.470391||meta||block_id end||17
+2015-11-21 21:39:34.472420||meta||block_id start||18
+2015-11-21 21:39:34.472460||meta||assignment||3@|1@|0@|2
+2015-11-21 21:39:36.837061||event||progress-marker||training-start||3||0
+2015-11-21 21:39:36.837402||event||progress-marker||training-end||3||0
+2015-11-21 21:39:36.922661||event||progress-marker||training-start||1||0
+2015-11-21 21:39:36.923024||event||progress-marker||training-end||1||0
+2015-11-21 21:39:39.676516||event||progress-marker||training-start||0||1
+2015-11-21 21:39:39.676817||event||progress-marker||training-end||0||1
+2015-11-21 21:39:39.680568||event||progress-marker||training-start||2||1
+2015-11-21 21:39:39.680895||event||progress-marker||training-end||2||1
+2015-11-21 21:39:41.888100||event||progress-marker||measurement-start||3||0
+2015-11-21 21:39:41.952922||event||progress-marker||measurement-start||1||0
+2015-11-21 21:39:44.702654||event||progress-marker||measurement-start||0||1
+2015-11-21 21:39:44.704762||event||progress-marker||measurement-start||2||1
+2015-11-21 21:39:50.054493||measurement||ad||2015-11-21 21:39:49.066745@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:39:50.417373||measurement||ad||2015-11-21 21:39:49.066745@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||1||0
+2015-11-21 21:39:50.431157||measurement||ad||2015-11-21 21:39:48.813736@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:39:50.581175||measurement||ad||2015-11-21 21:39:48.813736@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||3||0
+2015-11-21 21:39:50.752028||measurement||ad||2015-11-21 21:39:49.066745@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||1||0
+2015-11-21 21:39:50.752326||measurement||loadtime||0:00:03.798784||1||0
+2015-11-21 21:39:50.828259||measurement||ad||2015-11-21 21:39:48.813736@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||3||0
+2015-11-21 21:39:50.828562||measurement||loadtime||0:00:03.938776||3||0
+2015-11-21 21:39:57.081455||error||collecting ads||Error||3||0
+2015-11-21 21:39:58.357093||error||collecting ads||Error||1||0
+2015-11-21 21:40:01.260622||measurement||ad||2015-11-21 21:40:00.746964@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:40:01.976036||measurement||ad||2015-11-21 21:40:00.746964@|Pictures Of Breast Cancer@|www.healthline.com/breastcancer/pic@|Look Through Images Of Inflammatory Breast Cancer Symptoms.||0||1
+2015-11-21 21:40:02.245490||measurement||ad||2015-11-21 21:40:00.746964@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||0||1
+2015-11-21 21:40:02.245790||measurement||loadtime||0:00:12.541945||0||1
+2015-11-21 21:40:02.423765||measurement||ad||2015-11-21 21:40:00.949201@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:40:03.205137||measurement||ad||2015-11-21 21:40:00.949201@|Make Your Home Smarter@|singlecue.com@|Meet singlecue™ - One Device Connecting Your Home. Touch-Free!||2||1
+2015-11-21 21:40:03.611650||measurement||ad||2015-11-21 21:40:00.949201@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||2||1
+2015-11-21 21:40:03.611940||measurement||loadtime||0:00:13.906647||2||1
+2015-11-21 21:40:05.718109||error||collecting ads||Error||1||0
+2015-11-21 21:40:07.301665||measurement||ad||2015-11-21 21:40:04.099403@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:40:08.700464||measurement||ad||2015-11-21 21:40:04.099403@|Power Plant@|livelocal.net/Power-Plant@|All the Information in One Place. Updated one minute ago!||3||0
+2015-11-21 21:40:09.553206||measurement||ad||2015-11-21 21:40:04.099403@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||3||0
+2015-11-21 21:40:09.553563||measurement||loadtime||0:00:07.471185||3||0
+2015-11-21 21:40:11.542017||error||collecting ads||Error||1||0
+2015-11-21 21:40:18.572534||measurement||ad||2015-11-21 21:40:16.336311@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:40:18.678577||measurement||ad||2015-11-21 21:40:17.979864@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:40:18.831499||measurement||ad||2015-11-21 21:40:17.979864@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:40:19.018284||measurement||ad||2015-11-21 21:40:16.336311@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:40:19.152169||measurement||ad||2015-11-21 21:40:17.979864@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:40:19.152682||measurement||loadtime||0:00:11.905917||0||1
+2015-11-21 21:40:20.168713||measurement||ad||2015-11-21 21:40:16.336311@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||3||0
+2015-11-21 21:40:20.169014||measurement||loadtime||0:00:05.614268||3||0
+2015-11-21 21:40:21.008666||measurement||ad||2015-11-21 21:40:17.948176@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||0
+2015-11-21 21:40:21.187673||measurement||ad||2015-11-21 21:40:17.948176@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:40:21.616981||measurement||ad||2015-11-21 21:40:17.948176@|Direct Capital@|www.directcapital.com/Financing@|Equipment finance  working capital at great rates. A+BBB. Apply today||1||0
+2015-11-21 21:40:21.617274||measurement||loadtime||0:00:05.074499||1||0
+2015-11-21 21:40:28.572778||measurement||ad||2015-11-21 21:40:26.185437@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:40:28.686178||measurement||ad||2015-11-21 21:40:26.185437@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:40:28.823912||measurement||ad||2015-11-21 21:40:26.185437@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 21:40:28.824219||measurement||loadtime||0:00:03.654790||3||0
+2015-11-21 21:40:29.627384||measurement||ad||2015-11-21 21:40:28.113177@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 21:40:30.095328||measurement||ad||2015-11-21 21:40:28.113177@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:40:30.900501||measurement||ad||2015-11-21 21:40:28.113177@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 21:40:30.900911||measurement||loadtime||0:00:04.282839||1||0
+2015-11-21 21:40:35.790071||measurement||ad||2015-11-21 21:40:34.217621@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:40:35.968744||measurement||ad||2015-11-21 21:40:34.217621@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:40:36.115717||measurement||ad||2015-11-21 21:40:34.217621@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||3||0
+2015-11-21 21:40:36.116020||measurement||loadtime||0:00:02.291313||3||0
+2015-11-21 21:40:38.486157||measurement||ad||2015-11-21 21:40:36.709865@|Fortune Brainstorm E@|www.fortuneconferences.com@|New Ideas, Actionable Solutions Sept. 28-29, Austin Texas||1||0
+2015-11-21 21:40:38.606817||measurement||ad||2015-11-21 21:40:36.709865@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||0
+2015-11-21 21:40:38.792764||measurement||ad||2015-11-21 21:40:36.709865@|Contaminated Soil  Water@|rawlingsforestry.com@|Clean it up fast , effective and natural with phytormediation.||1||0
+2015-11-21 21:40:38.793091||measurement||loadtime||0:00:02.891548||1||0
+2015-11-21 21:40:41.707963||error||collecting ads||Error||3||0
+2015-11-21 21:40:45.856915||measurement||ad||2015-11-21 21:40:44.848485@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:40:46.112542||measurement||ad||2015-11-21 21:40:44.848485@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:40:46.738889||measurement||ad||2015-11-21 21:40:44.848485@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||1||0
+2015-11-21 21:40:46.739399||measurement||loadtime||0:00:02.945285||1||0
+2015-11-21 21:40:49.052122||measurement||ad||2015-11-21 21:40:48.016520@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||0
+2015-11-21 21:40:49.052450||measurement||loadtime||0:00:02.343848||3||0
+2015-11-21 21:40:53.217853||measurement||ad||2015-11-21 21:40:52.539950@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:40:53.352287||measurement||ad||2015-11-21 21:40:52.539950@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||0
+2015-11-21 21:40:53.555544||measurement||ad||2015-11-21 21:40:52.539950@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:40:53.555788||measurement||loadtime||0:00:01.814963||1||0
+2015-11-21 21:40:56.441649||measurement||ad||2015-11-21 21:40:55.621786@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||0
+2015-11-21 21:40:56.441971||measurement||loadtime||0:00:02.388005||3||0
+2015-11-21 21:41:00.493095||measurement||ad||2015-11-21 21:40:59.647660@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-21 21:41:00.710045||measurement||ad||2015-11-21 21:40:59.647660@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||0
+2015-11-21 21:41:00.866562||measurement||ad||2015-11-21 21:40:59.647660@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||1||0
+2015-11-21 21:41:00.866819||measurement||loadtime||0:00:02.309418||1||0
+2015-11-21 21:41:00.867446||event||progress-marker||measurement-end||1||0
+2015-11-21 21:41:03.902182||measurement||ad||2015-11-21 21:41:02.911889@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||0
+2015-11-21 21:41:03.902485||measurement||loadtime||0:00:02.446501||3||0
+2015-11-21 21:41:03.903065||event||progress-marker||measurement-end||3||0
+2015-11-21 21:42:20.842059||measurement||ad||2015-11-21 21:40:35.178953@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:42:30.942733||measurement||ad||2015-11-21 21:40:35.178953@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:42:32.059939||measurement||ad||2015-11-21 21:40:19.740817@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Black Friday Top Offers||2||1
+2015-11-21 21:42:32.068498||measurement||ad||2015-11-21 21:40:35.178953@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||0||1
+2015-11-21 21:42:32.068809||measurement||loadtime||0:02:07.914498||0||1
+2015-11-21 21:42:32.096042||measurement||ad||2015-11-21 21:40:19.740817@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:42:32.127155||measurement||ad||2015-11-21 21:40:19.740817@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:42:32.127592||measurement||loadtime||0:02:23.514609||2||1
+2015-11-21 21:42:52.381238||measurement||ad||2015-11-21 21:42:51.063020@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||2||1
+2015-11-21 21:42:53.405088||measurement||ad||2015-11-21 21:42:51.063020@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||2||1
+2015-11-21 21:42:54.386118||measurement||ad||2015-11-21 21:42:51.063020@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:42:54.386403||measurement||loadtime||0:00:17.257433||2||1
+2015-11-21 21:42:59.051758||measurement||ad||2015-11-21 21:42:58.371768@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:42:59.179896||measurement||ad||2015-11-21 21:42:58.371768@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:42:59.291879||measurement||ad||2015-11-21 21:42:58.371768@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:42:59.292183||measurement||loadtime||0:00:22.221632||0||1
+2015-11-21 21:43:07.502338||measurement||ad||2015-11-21 21:43:07.151865@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Black Friday Top Offers||2||1
+2015-11-21 21:43:10.292935||measurement||ad||2015-11-21 21:43:07.151865@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:43:14.696756||measurement||ad||2015-11-21 21:43:12.791754@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:43:15.385667||measurement||ad||2015-11-21 21:43:07.151865@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:43:15.386012||measurement||loadtime||0:00:15.998290||2||1
+2015-11-21 21:43:22.881891||measurement||ad||2015-11-21 21:43:12.791754@|Power Plant@|livelocal.net/Power-Plant@|All the Information in One Place. Updated one minute ago!||0||1
+2015-11-21 21:43:23.848307||measurement||ad||2015-11-21 21:43:20.997001@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:43:24.209856||measurement||ad||2015-11-21 21:43:20.997001@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:43:24.393103||measurement||ad||2015-11-21 21:43:20.997001@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:43:24.393453||measurement||loadtime||0:00:04.005964||2||1
+2015-11-21 21:43:28.502293||measurement||ad||2015-11-21 21:43:12.791754@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:43:28.502753||measurement||loadtime||0:00:24.210022||0||1
+2015-11-21 21:43:37.741056||measurement||ad||2015-11-21 21:43:36.051561@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||2||1
+2015-11-21 21:43:39.611647||measurement||ad||2015-11-21 21:43:36.051561@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||2||1
+2015-11-21 21:43:39.932561||measurement||ad||2015-11-21 21:43:36.051561@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:43:39.932835||measurement||loadtime||0:00:10.537905||2||1
+2015-11-21 21:43:46.589864||measurement||ad||2015-11-21 21:43:43.656827@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:43:55.162668||measurement||ad||2015-11-21 21:43:52.316481@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Cyber Monday Top Offers||2||1
+2015-11-21 21:43:57.501020||measurement||ad||2015-11-21 21:43:43.656827@|Power Plant@|livelocal.net/Power-Plant@|All the Information in One Place. Updated one minute ago!||0||1
+2015-11-21 21:44:00.695651||measurement||ad||2015-11-21 21:43:43.656827@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:44:00.695937||measurement||loadtime||0:00:27.192142||0||1
+2015-11-21 21:44:02.280434||measurement||ad||2015-11-21 21:43:52.316481@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|The Online Franchise Marketplace. New Franchises Start Under $30,000.||2||1
+2015-11-21 21:44:09.406102||measurement||ad||2015-11-21 21:43:52.316481@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:44:09.406429||measurement||loadtime||0:00:24.471998||2||1
+2015-11-21 21:44:18.550459||measurement||ad||2015-11-21 21:44:16.492037@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:44:24.431001||measurement||ad||2015-11-21 21:44:16.492037@|Power Plant@|livelocal.net/Power-Plant@|All the Information in One Place. Updated one minute ago!||0||1
+2015-11-21 21:44:24.503299||measurement||ad||2015-11-21 21:44:22.802820@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:44:25.924114||measurement||ad||2015-11-21 21:44:22.802820@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:44:26.864652||measurement||ad||2015-11-21 21:44:22.802820@|"Alternative Currency"?@|www.palmbeachgroup.com@|New book reveals how to protect yourself from a financial crisis||2||1
+2015-11-21 21:44:26.864856||measurement||loadtime||0:00:12.458023||2||1
+2015-11-21 21:44:37.591872||measurement||ad||2015-11-21 21:44:16.492037@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||0||1
+2015-11-21 21:44:37.592177||measurement||loadtime||0:00:31.894949||0||1
+2015-11-21 21:44:41.494971||measurement||ad||2015-11-21 21:44:39.347394@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Black Friday Top Offers||2||1
+2015-11-21 21:44:42.580384||measurement||ad||2015-11-21 21:44:39.347394@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:44:48.575439||measurement||ad||2015-11-21 21:44:39.347394@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:44:48.575793||measurement||loadtime||0:00:16.710188||2||1
+2015-11-21 21:44:52.172151||measurement||ad||2015-11-21 21:44:48.870696@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-21 21:44:52.441737||measurement||ad||2015-11-21 21:44:48.870696@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:44:52.603447||measurement||ad||2015-11-21 21:44:48.870696@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||0||1
+2015-11-21 21:44:52.603675||measurement||loadtime||0:00:10.010097||0||1
+2015-11-21 21:45:05.193106||measurement||ad||2015-11-21 21:45:04.560575@|Prostate Cancer Treatment@|shopsteal.us/Prostate-Cancer@|Find Prostate Cancer Treatments Compare All Black Friday Top Offers||2||1
+2015-11-21 21:45:05.727366||measurement||ad||2015-11-21 21:45:05.221267@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:45:06.045404||measurement||ad||2015-11-21 21:45:05.221267@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:45:06.400489||measurement||ad||2015-11-21 21:45:05.221267@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||0||1
+2015-11-21 21:45:06.401060||measurement||loadtime||0:00:08.795873||0||1
+2015-11-21 21:45:08.578840||measurement||ad||2015-11-21 21:45:04.560575@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||1
+2015-11-21 21:45:16.730722||measurement||ad||2015-11-21 21:45:04.560575@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:45:16.731126||measurement||loadtime||0:00:23.154862||2||1
+2015-11-21 21:45:16.731266||event||progress-marker||measurement-end||2||1
+2015-11-21 21:45:17.493522||measurement||ad||2015-11-21 21:45:17.206886@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-21 21:45:17.543006||measurement||ad||2015-11-21 21:45:17.206886@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||1
+2015-11-21 21:45:17.586481||measurement||ad||2015-11-21 21:45:17.206886@|Trade with OptionsHouse®@|www.optionshouse.com@|Trade Commission Free for 60 Days. Open an Account w/OptionsHouse.||0||1
+2015-11-21 21:45:17.586738||measurement||loadtime||0:00:06.184436||0||1
+2015-11-21 21:45:17.586818||event||progress-marker||measurement-end||0||1
+2015-11-21 21:45:17.820582||meta||block_id end||18
+2015-11-21 21:45:17.821431||meta||block_id start||19
+2015-11-21 21:45:17.821556||meta||assignment||3@|0@|2@|1
+2015-11-21 21:45:20.240825||event||progress-marker||training-start||0||0
+2015-11-21 21:45:20.241194||event||progress-marker||training-end||0||0
+2015-11-21 21:45:20.242671||event||progress-marker||training-start||3||0
+2015-11-21 21:45:20.242939||event||progress-marker||training-end||3||0
+2015-11-21 21:45:23.017829||event||progress-marker||training-start||1||1
+2015-11-21 21:45:23.018211||event||progress-marker||training-end||1||1
+2015-11-21 21:45:23.069599||event||progress-marker||training-start||2||1
+2015-11-21 21:45:23.069870||event||progress-marker||training-end||2||1
+2015-11-21 21:45:25.277142||event||progress-marker||measurement-start||0||0
+2015-11-21 21:45:25.277635||event||progress-marker||measurement-start||3||0
+2015-11-21 21:45:28.045720||event||progress-marker||measurement-start||1||1
+2015-11-21 21:45:28.096189||event||progress-marker||measurement-start||2||1
+2015-11-21 21:45:32.885857||measurement||ad||2015-11-21 21:45:32.315586@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-21 21:45:33.737581||measurement||ad||2015-11-21 21:45:32.204164@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:45:33.826922||measurement||ad||2015-11-21 21:45:32.204164@|Enjoy Your TV, Touch-Free@|singlecue.com@|Control Your TV with Gestures. Touch-Free. Only $199. Buy Now!||0||0
+2015-11-21 21:45:34.215620||measurement||ad||2015-11-21 21:45:32.315586@|Osteoporosis  Fracture@|everydayhealth.com/Osteoporosis@|Calculate your Bone Fracture Risk With Xray Scan Test. Member Support||3||0
+2015-11-21 21:45:34.251792||measurement||ad||2015-11-21 21:45:32.204164@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||0||0
+2015-11-21 21:45:34.252117||measurement||loadtime||0:00:03.973419||0||0
+2015-11-21 21:45:34.876163||measurement||ad||2015-11-21 21:45:32.315586@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||3||0
+2015-11-21 21:45:34.876446||measurement||loadtime||0:00:04.597745||3||0
+2015-11-21 21:45:40.839070||error||collecting ads||Error||0||0
+2015-11-21 21:45:41.340750||error||collecting ads||Error||3||0
+2015-11-21 21:45:44.209354||measurement||ad||2015-11-21 21:45:43.425035@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||2||1
+2015-11-21 21:45:44.534995||measurement||ad||2015-11-21 21:45:43.425035@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||2||1
+2015-11-21 21:45:44.788010||measurement||ad||2015-11-21 21:45:43.425035@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||2||1
+2015-11-21 21:45:44.788326||measurement||loadtime||0:00:11.691022||2||1
+2015-11-21 21:45:44.925837||measurement||ad||2015-11-21 21:45:43.907332@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||1||1
+2015-11-21 21:45:45.731271||measurement||ad||2015-11-21 21:45:43.907332@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|Minimum of $15k Monthly Sales. BBB A Rating, No Start Ups.||1||1
+2015-11-21 21:45:46.050888||measurement||ad||2015-11-21 21:45:43.907332@|LendingTree Personal Loan@|www.lendingtree.com/Personal-Loans@|As Much as $35,000, No Collateral. Loan Quotes in Minutes. Act Now!||1||1
+2015-11-21 21:45:46.051208||measurement||loadtime||0:00:13.004097||1||1
+2015-11-21 21:45:53.655096||measurement||ad||2015-11-21 21:45:48.123990@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:45:53.799230||measurement||ad||2015-11-21 21:45:47.448602@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:45:53.950751||measurement||ad||2015-11-21 21:45:48.123990@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:45:54.399250||measurement||ad||2015-11-21 21:45:48.123990@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 21:45:54.399555||measurement||loadtime||0:00:08.057368||3||0
+2015-11-21 21:45:55.863665||measurement||ad||2015-11-21 21:45:47.448602@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:46:01.398227||measurement||ad||2015-11-21 21:45:47.448602@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||0||0
+2015-11-21 21:46:01.398871||measurement||loadtime||0:00:15.558020||0||0
+2015-11-21 21:46:02.075787||error||collecting ads||Error||3||0
+2015-11-21 21:46:04.396421||measurement||ad||2015-11-21 21:46:03.950862@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||2||1
+2015-11-21 21:46:04.493875||measurement||ad||2015-11-21 21:46:03.933931@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:46:04.588423||measurement||ad||2015-11-21 21:46:03.950862@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||1
+2015-11-21 21:46:04.721664||measurement||ad||2015-11-21 21:46:03.950862@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||1
+2015-11-21 21:46:04.722232||measurement||loadtime||0:00:14.932401||2||1
+2015-11-21 21:46:05.035395||measurement||ad||2015-11-21 21:46:03.933931@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:46:05.444075||measurement||ad||2015-11-21 21:46:03.933931@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:46:05.444437||measurement||loadtime||0:00:14.391848||1||1
+2015-11-21 21:46:08.755397||measurement||ad||2015-11-21 21:46:07.525560@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-21 21:46:08.944187||measurement||ad||2015-11-21 21:46:07.525560@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||0||0
+2015-11-21 21:46:09.088886||measurement||ad||2015-11-21 21:46:07.525560@|Warning About Low Free T@|www.nugenix.com@|10 second free testosterone trick for Men over the age of 40||0||0
+2015-11-21 21:46:09.089232||measurement||loadtime||0:00:02.689680||0||0
+2015-11-21 21:46:10.085931||measurement||ad||2015-11-21 21:46:08.291353@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:46:10.467251||measurement||ad||2015-11-21 21:46:08.291353@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:46:10.911280||measurement||ad||2015-11-21 21:46:08.291353@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||0
+2015-11-21 21:46:10.911585||measurement||loadtime||0:00:03.834488||3||0
+2015-11-21 21:46:20.105987||measurement||ad||2015-11-21 21:46:17.320830@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-21 21:46:20.401400||error||collecting ads||Error||0||0
+2015-11-21 21:46:20.611501||measurement||ad||2015-11-21 21:46:17.320830@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:46:20.860329||measurement||ad||2015-11-21 21:46:17.320830@|Galaxy S6 Edge 32GB@|lowerprices.us/Galaxy-S6-Edge-32GB@|Great Offers On Galaxy S6 Edge 32GB Find Amazing Bargains and Save!||3||0
+2015-11-21 21:46:20.860751||measurement||loadtime||0:00:04.945814||3||0
+2015-11-21 21:46:22.826571||measurement||ad||2015-11-21 21:46:22.059871@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||2||1
+2015-11-21 21:46:23.333630||measurement||ad||2015-11-21 21:46:22.059871@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||1
+2015-11-21 21:46:23.491663||measurement||ad||2015-11-21 21:46:22.059871@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:46:23.491990||measurement||loadtime||0:00:13.768832||2||1
+2015-11-21 21:46:23.965757||measurement||ad||2015-11-21 21:46:22.692432@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:46:27.150022||error||collecting ads||Error||0||0
+2015-11-21 21:46:27.159243||measurement||ad||2015-11-21 21:46:22.692432@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:46:30.871103||measurement||ad||2015-11-21 21:46:26.873726@|Guaranteed SBA Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. No Startups, Get Approved Today.||3||0
+2015-11-21 21:46:31.780877||measurement||ad||2015-11-21 21:46:26.873726@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||3||0
+2015-11-21 21:46:33.550606||measurement||ad||2015-11-21 21:46:26.873726@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||3||0
+2015-11-21 21:46:33.550989||measurement||loadtime||0:00:07.689769||3||0
+2015-11-21 21:46:34.894687||measurement||ad||2015-11-21 21:46:22.692432@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:46:34.894950||measurement||loadtime||0:00:24.449159||1||1
+2015-11-21 21:46:38.301643||error||collecting ads||Error||0||0
+2015-11-21 21:46:42.187627||measurement||ad||2015-11-21 21:46:41.794877@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:46:42.302692||measurement||ad||2015-11-21 21:46:41.794877@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||2||1
+2015-11-21 21:46:42.311164||measurement||ad||2015-11-21 21:46:40.044629@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-21 21:46:42.395251||measurement||ad||2015-11-21 21:46:41.794877@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||2||1
+2015-11-21 21:46:42.395575||measurement||loadtime||0:00:13.899771||2||1
+2015-11-21 21:46:42.768396||measurement||ad||2015-11-21 21:46:40.044629@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||3||0
+2015-11-21 21:46:42.958833||measurement||ad||2015-11-21 21:46:40.044629@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||3||0
+2015-11-21 21:46:42.959132||measurement||loadtime||0:00:04.406995||3||0
+2015-11-21 21:46:45.200452||error||collecting ads||Error||0||0
+2015-11-21 21:46:51.727608||measurement||ad||2015-11-21 21:46:48.790006@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||0
+2015-11-21 21:46:51.728329||measurement||loadtime||0:00:03.768626||3||0
+2015-11-21 21:46:51.776997||measurement||ad||2015-11-21 21:46:51.666340@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:46:51.878044||measurement||ad||2015-11-21 21:46:51.666340@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:46:51.940050||measurement||ad||2015-11-21 21:46:51.666340@|Social Security Sucks@|palmbeachgroup.com@|Born before 1969? You can get an extra $4,098 monthly with this||1||1
+2015-11-21 21:46:51.940362||measurement||loadtime||0:00:12.044908||1||1
+2015-11-21 21:46:52.863069||error||collecting ads||Error||0||0
+2015-11-21 21:46:56.554496||measurement||ad||2015-11-21 21:46:55.723763@|7 Hidden Dementia Signs@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Dementia Is Coming.||2||1
+2015-11-21 21:46:56.683876||measurement||ad||2015-11-21 21:46:55.723763@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||1
+2015-11-21 21:46:56.842286||measurement||ad||2015-11-21 21:46:55.723763@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||2||1
+2015-11-21 21:46:56.842606||measurement||loadtime||0:00:09.446066||2||1
+2015-11-21 21:46:59.407469||measurement||ad||2015-11-21 21:46:57.640727@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||3||0
+2015-11-21 21:46:59.408837||measurement||loadtime||0:00:02.679659||3||0
+2015-11-21 21:46:59.409595||event||progress-marker||measurement-end||3||0
+2015-11-21 21:47:04.357084||measurement||ad||2015-11-21 21:47:04.231328@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:47:04.446654||measurement||ad||2015-11-21 21:47:04.231328@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||1||1
+2015-11-21 21:47:04.531026||measurement||ad||2015-11-21 21:47:04.231328@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||1
+2015-11-21 21:47:04.531433||measurement||loadtime||0:00:07.589472||1||1
+2015-11-21 21:47:06.665892||measurement||ad||2015-11-21 21:47:03.514929@|Fora Financial® Loans@|forafinancial.com/Business+Credit+Loans@|BBB A Rating, No Start Ups. Minimum of $15k Monthly Sales.||0||0
+2015-11-21 21:47:07.017634||measurement||ad||2015-11-21 21:47:03.514929@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. Competitive Rates. Apply Online Now||0||0
+2015-11-21 21:47:07.416099||measurement||ad||2015-11-21 21:47:03.514929@|Fast Cash $200-$1000@|loansofsuccess.com@|2 Min Approvals (recommended site) All Credit OK! Pay Back Over Time||0||0
+2015-11-21 21:47:07.416515||measurement||loadtime||0:00:09.552452||0||0
+2015-11-21 21:47:07.416733||event||progress-marker||measurement-end||0||0
+2015-11-21 21:47:09.134940||measurement||ad||2015-11-21 21:47:08.740937@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:47:09.225420||measurement||ad||2015-11-21 21:47:08.740937@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:47:09.276103||measurement||ad||2015-11-21 21:47:08.740937@|Guaranteed Business Loans@|biz2credit.com/Business_Loans@|$5000-$1MM Business Loan Available. No Startups, Get Approved Today.||2||1
+2015-11-21 21:47:09.276460||measurement||loadtime||0:00:07.432634||2||1
+2015-11-21 21:47:14.067498||measurement||ad||2015-11-21 21:47:13.682135@|SBA Express Loans@|biz2credit.com/SBA-Loans@|$5K-$1 Million SBA Business Loans. Quick  Easy. Apply Online Now.||1||1
+2015-11-21 21:47:14.123875||measurement||ad||2015-11-21 21:47:13.682135@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||1||1
+2015-11-21 21:47:14.176706||measurement||ad||2015-11-21 21:47:13.682135@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:47:14.177174||measurement||loadtime||0:00:04.644478||1||1
+2015-11-21 21:47:16.255128||measurement||ad||2015-11-21 21:47:14.392849@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:47:16.720143||measurement||ad||2015-11-21 21:47:14.392849@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||2||1
+2015-11-21 21:47:16.771472||measurement||ad||2015-11-21 21:47:14.392849@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:47:16.771768||measurement||loadtime||0:00:02.493872||2||1
+2015-11-21 21:47:23.015488||measurement||ad||2015-11-21 21:47:22.892152@|Send Money to Philippines@|Fast Delivery, Send Money Online!@|Why Drive, Line Up or Pay Fees? ||1||1
+2015-11-21 21:47:23.015823||measurement||loadtime||0:00:03.837297||1||1
+2015-11-21 21:47:31.039476||measurement||ad||2015-11-21 21:47:30.540562@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:47:31.128146||measurement||ad||2015-11-21 21:47:30.540562@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||2||1
+2015-11-21 21:47:31.190785||measurement||ad||2015-11-21 21:47:30.540562@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||2||1
+2015-11-21 21:47:31.191052||measurement||loadtime||0:00:09.417898||2||1
+2015-11-21 21:47:31.936382||measurement||ad||2015-11-21 21:47:31.785637@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:47:32.039821||measurement||ad||2015-11-21 21:47:31.785637@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:47:32.106006||measurement||ad||2015-11-21 21:47:31.785637@|Top Franchises For 2015@|franchisehelp.com/Opportunity@|Opening In Your Local Area! New Franchises Start Under $30,000.||1||1
+2015-11-21 21:47:32.106264||measurement||loadtime||0:00:04.088966||1||1
+2015-11-21 21:47:41.199539||measurement||ad||2015-11-21 21:47:41.077983@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-21 21:47:41.288532||measurement||ad||2015-11-21 21:47:41.077983@|5 Handgun Accuracy Myths:@|www.masterhandgunaccuracy.org@|Video: Don't be victim to the 5 Deadly Myths of Handgun Accuracy:||2||1
+2015-11-21 21:47:41.373326||measurement||ad||2015-11-21 21:47:41.077983@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:47:41.373639||measurement||loadtime||0:00:05.181642||2||1
+2015-11-21 21:47:43.542249||measurement||ad||2015-11-21 21:47:43.448871@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:47:43.603003||measurement||ad||2015-11-21 21:47:43.448871@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:47:43.660289||measurement||ad||2015-11-21 21:47:43.448871@|Free Ecuador Fact Sheet@|www.internationalliving.com/Ecuador@|For people considering retiring, visiting, or living in Ecuador||1||1
+2015-11-21 21:47:43.660622||measurement||loadtime||0:00:06.553112||1||1
+2015-11-21 21:47:51.345592||measurement||ad||2015-11-21 21:47:48.761429@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-21 21:47:53.396635||measurement||ad||2015-11-21 21:47:48.761429@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-21 21:47:53.483721||measurement||ad||2015-11-21 21:47:48.761429@|Free Ecuador Fact Sheet@|www.internationalliving.com/Ecuador@|For people considering retiring, visiting, or living in Ecuador||1||1
+2015-11-21 21:47:53.484084||measurement||loadtime||0:00:04.822828||1||1
+2015-11-21 21:47:53.484765||event||progress-marker||measurement-end||1||1
+2015-11-21 21:47:56.790397||measurement||ad||2015-11-21 21:47:56.709546@|Economy About To Collapse@|www.thesovereigninvestor.com@|$5 Bill Proves Stock Market Is On The Verge Of A Collapse. See Proof!||2||1
+2015-11-21 21:47:56.842980||measurement||ad||2015-11-21 21:47:56.709546@|Get a Business Loan Today@|www.smartbusinessfunder.com@|Get Approved  Funded Instantly! $10k Revenue Required - No Startups||2||1
+2015-11-21 21:47:56.886153||measurement||ad||2015-11-21 21:47:56.709546@|Can 55 year Old Look 35?@|www.beautynpurpose.com/skin@|Mom reveals anti aging tips. Doctors hate her.||2||1
+2015-11-21 21:47:56.886417||measurement||loadtime||0:00:10.511970||2||1
+2015-11-21 21:47:56.886601||event||progress-marker||measurement-end||2||1
+2015-11-21 21:47:57.149877||meta||block_id end||19

--- a/AdFisher/examples/log.group_ex1.txt
+++ b/AdFisher/examples/log.group_ex1.txt
@@ -1,0 +1,3785 @@
+2015-11-08 19:14:41.978772||meta||agents||4
+2015-11-08 19:14:41.979168||meta||treatnames||control (chrome)@|experimental (firefox)
+2015-11-08 19:14:41.979685||meta||block_id start||0
+2015-11-08 19:14:41.979699||meta||assignment||1@|0@|2@|3
+2015-11-08 19:14:44.808595||event||progress-marker||training-start||1||0
+2015-11-08 19:14:44.941464||event||progress-marker||training-start||0||0
+2015-11-08 19:14:46.650098||event||progress-marker||training-start||3||1
+2015-11-08 19:14:46.861978||event||progress-marker||training-start||2||1
+2015-11-08 19:14:53.435408||treatment||visit website||http://irs.gov||1||0
+2015-11-08 19:14:54.745816||treatment||visit website||http://irs.gov||2||1
+2015-11-08 19:14:54.813621||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:14:55.432314||treatment||visit website||http://irs.gov||0||0
+2015-11-08 19:15:02.628419||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 19:15:05.056719||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 19:15:05.992786||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:15:06.149627||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 19:15:11.587172||treatment||visit website||http://pwc.com||1||0
+2015-11-08 19:15:18.294354||treatment||visit website||http://pwc.com||0||0
+2015-11-08 19:15:18.748521||treatment||visit website||http://ey.com||1||0
+2015-11-08 19:15:20.024005||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:15:20.214853||treatment||visit website||http://pwc.com||2||1
+2015-11-08 19:15:25.193780||treatment||visit website||http://ey.com||0||0
+2015-11-08 19:15:28.654773||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:15:28.685117||treatment||visit website||http://ey.com||2||1
+2015-11-08 19:15:33.802670||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 19:15:33.803072||event||progress-marker||training-end||0||0
+2015-11-08 19:15:36.966453||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 19:15:36.967732||event||progress-marker||training-end||1||0
+2015-11-08 19:15:37.165735||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:15:37.166146||event||progress-marker||training-end||3||1
+2015-11-08 19:15:38.333929||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 19:15:38.334199||event||progress-marker||training-end||2||1
+2015-11-08 19:15:38.805134||event||progress-marker||measurement-start||0||0
+2015-11-08 19:15:41.971204||event||progress-marker||measurement-start||1||0
+2015-11-08 19:15:42.168595||event||progress-marker||measurement-start||3||1
+2015-11-08 19:15:43.336972||event||progress-marker||measurement-start||2||1
+2015-11-08 19:15:58.824975||measurement||ad||2015-11-08 19:15:58.658432@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:15:58.951099||measurement||ad||2015-11-08 19:15:58.658432@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:15:59.333147||measurement||ad||2015-11-08 19:15:58.658432@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||1||0
+2015-11-08 19:15:59.333815||measurement||loadtime||0:00:12.361522||1||0
+2015-11-08 19:16:02.190186||measurement||ad||2015-11-08 19:16:01.234983@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:16:02.342767||measurement||ad||2015-11-08 19:16:01.234983@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:16:02.462191||measurement||ad||2015-11-08 19:16:01.234983@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:16:02.462487||measurement||loadtime||0:00:15.292570||3||1
+2015-11-08 19:16:02.845989||measurement||ad||2015-11-08 19:16:01.914441@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:16:03.013550||measurement||ad||2015-11-08 19:16:01.914441@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:16:03.083303||measurement||ad||2015-11-08 19:16:01.914441@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||1
+2015-11-08 19:16:03.083588||measurement||loadtime||0:00:14.745837||2||1
+2015-11-08 19:16:04.229055||measurement||ad||2015-11-08 19:16:03.909315@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:16:04.977838||measurement||ad||2015-11-08 19:16:03.909315@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:16:05.200597||measurement||ad||2015-11-08 19:16:03.909315@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:16:05.200896||measurement||loadtime||0:00:21.394740||0||0
+2015-11-08 19:16:11.155519||measurement||ad||2015-11-08 19:16:10.988594@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:16:11.414590||measurement||ad||2015-11-08 19:16:10.988594@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:16:11.608175||measurement||ad||2015-11-08 19:16:10.988594@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:16:11.608480||measurement||loadtime||0:00:07.273238||1||0
+2015-11-08 19:16:23.582247||measurement||ad||2015-11-08 19:16:20.353525@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:16:24.353930||measurement||ad||2015-11-08 19:16:20.353525@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:16:25.123098||measurement||ad||2015-11-08 19:16:20.353525@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:16:25.123428||measurement||loadtime||0:00:17.660264||3||1
+2015-11-08 19:16:26.999729||measurement||ad||2015-11-08 19:16:26.841840@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:16:27.121431||measurement||ad||2015-11-08 19:16:26.841840@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||1||0
+2015-11-08 19:16:27.372668||measurement||ad||2015-11-08 19:16:26.841840@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||1||0
+2015-11-08 19:16:27.372946||measurement||loadtime||0:00:10.763566||1||0
+2015-11-08 19:16:28.074257||measurement||ad||2015-11-08 19:16:27.466675@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:16:28.622976||measurement||ad||2015-11-08 19:16:27.466675@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:16:29.129205||measurement||ad||2015-11-08 19:16:27.466675@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:16:29.129804||measurement||loadtime||0:00:18.927891||0||0
+2015-11-08 19:16:30.678752||measurement||ad||2015-11-08 19:16:29.673361@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:16:31.055032||measurement||ad||2015-11-08 19:16:29.673361@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:16:31.150875||measurement||ad||2015-11-08 19:16:29.673361@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:16:31.151132||measurement||loadtime||0:00:23.066458||2||1
+2015-11-08 19:16:43.739273||measurement||ad||2015-11-08 19:16:41.702579@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:16:44.088157||measurement||ad||2015-11-08 19:16:41.702579@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:16:44.706678||measurement||ad||2015-11-08 19:16:41.702579@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:16:44.707010||measurement||loadtime||0:00:14.582956||3||1
+2015-11-08 19:16:52.950510||measurement||ad||2015-11-08 19:16:51.975711@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:16:53.143570||measurement||ad||2015-11-08 19:16:51.975711@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:16:53.376816||measurement||ad||2015-11-08 19:16:51.975711@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||1
+2015-11-08 19:16:53.377141||measurement||loadtime||0:00:17.222030||2||1
+2015-11-08 19:17:00.097481||measurement||ad||2015-11-08 19:16:59.702837@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:17:00.239591||measurement||ad||2015-11-08 19:16:59.702837@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:17:00.744006||measurement||ad||2015-11-08 19:16:59.702837@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:17:00.744264||measurement||loadtime||0:00:11.035933||3||1
+2015-11-08 19:17:06.785133||measurement||ad||2015-11-08 19:17:06.337512@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:17:07.378687||measurement||ad||2015-11-08 19:17:06.337512@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:17:07.828349||measurement||ad||2015-11-08 19:17:06.337512@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:17:07.828960||measurement||loadtime||0:00:09.451006||2||1
+2015-11-08 19:17:12.477258||measurement||ad||2015-11-08 19:17:11.983349@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:17:12.563148||measurement||ad||2015-11-08 19:17:11.983349@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:17:12.632563||measurement||ad||2015-11-08 19:17:11.983349@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:17:12.634318||measurement||loadtime||0:00:06.888881||3||1
+2015-11-08 19:17:14.818821||measurement||ad||2015-11-08 19:17:14.582567@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:17:15.006057||measurement||ad||2015-11-08 19:17:14.582567@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:17:15.170331||measurement||ad||2015-11-08 19:17:14.582567@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:17:15.170629||measurement||loadtime||0:00:41.040292||0||0
+2015-11-08 19:17:24.380547||measurement||ad||2015-11-08 19:17:23.889339@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:17:24.650035||measurement||ad||2015-11-08 19:17:23.889339@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:17:24.850107||measurement||ad||2015-11-08 19:17:23.889339@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:17:24.850430||measurement||loadtime||0:00:07.214357||3||1
+2015-11-08 19:17:27.533290||measurement||ad||2015-11-08 19:17:27.197381@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:17:27.717408||measurement||ad||2015-11-08 19:17:27.197381@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:17:27.858330||measurement||ad||2015-11-08 19:17:27.197381@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||2||1
+2015-11-08 19:17:27.858564||measurement||loadtime||0:00:15.028168||2||1
+2015-11-08 19:17:27.940216||measurement||ad||2015-11-08 19:17:27.576945@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:17:28.084129||measurement||ad||2015-11-08 19:17:27.576945@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:17:28.208672||measurement||ad||2015-11-08 19:17:27.576945@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:17:28.208979||measurement||loadtime||0:00:08.037588||0||0
+2015-11-08 19:17:32.516452||error||collecting ads||Error||1||0
+2015-11-08 19:17:35.664566||measurement||ad||2015-11-08 19:17:34.986811@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:17:35.784526||measurement||ad||2015-11-08 19:17:34.986811@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:17:35.854274||measurement||ad||2015-11-08 19:17:34.986811@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:17:35.854647||measurement||loadtime||0:00:06.003235||3||1
+2015-11-08 19:17:39.233841||measurement||ad||2015-11-08 19:17:33.000709@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:17:39.344638||measurement||ad||2015-11-08 19:17:33.000709@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:17:39.503411||measurement||ad||2015-11-08 19:17:33.000709@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:17:39.503964||measurement||loadtime||0:00:06.643934||2||1
+2015-11-08 19:17:39.850225||measurement||ad||2015-11-08 19:17:39.459781@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:17:40.267627||measurement||ad||2015-11-08 19:17:39.459781@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:17:40.476449||measurement||ad||2015-11-08 19:17:39.459781@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:17:40.476735||measurement||loadtime||0:00:07.266909||0||0
+2015-11-08 19:17:44.309360||measurement||ad||2015-11-08 19:17:44.084465@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:17:44.454890||measurement||ad||2015-11-08 19:17:44.084465@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:17:44.599831||measurement||ad||2015-11-08 19:17:44.084465@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:17:44.600325||measurement||loadtime||0:00:07.081895||1||0
+2015-11-08 19:17:51.815219||measurement||ad||2015-11-08 19:17:51.616020@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:17:52.196556||measurement||ad||2015-11-08 19:17:51.616020@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:17:52.399028||measurement||ad||2015-11-08 19:17:51.616020@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 19:17:52.399359||measurement||loadtime||0:00:06.921675||0||0
+2015-11-08 19:17:52.656521||measurement||ad||2015-11-08 19:17:52.411770@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:17:52.842190||measurement||ad||2015-11-08 19:17:51.244473@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:17:53.056086||measurement||ad||2015-11-08 19:17:52.411770@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:17:53.230928||measurement||ad||2015-11-08 19:17:51.244473@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:17:53.512704||measurement||ad||2015-11-08 19:17:52.411770@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:17:53.512961||measurement||loadtime||0:00:12.657822||3||1
+2015-11-08 19:17:53.630670||measurement||ad||2015-11-08 19:17:51.244473@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:17:53.630905||measurement||loadtime||0:00:09.125855||2||1
+2015-11-08 19:17:56.420546||measurement||ad||2015-11-08 19:17:56.126002@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:17:56.521842||measurement||ad||2015-11-08 19:17:56.126002@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||0
+2015-11-08 19:17:56.611462||measurement||ad||2015-11-08 19:17:56.126002@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:17:56.611763||measurement||loadtime||0:00:07.010367||1||0
+2015-11-08 19:18:04.106589||measurement||ad||2015-11-08 19:18:03.833540@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:18:04.393578||measurement||ad||2015-11-08 19:18:03.833540@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:18:04.546826||measurement||ad||2015-11-08 19:18:03.833540@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:18:04.547074||measurement||loadtime||0:00:07.146222||0||0
+2015-11-08 19:18:05.489794||measurement||ad||2015-11-08 19:18:05.297723@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:18:05.614479||measurement||ad||2015-11-08 19:18:05.297723@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:18:05.805958||measurement||ad||2015-11-08 19:18:05.297723@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:18:05.806197||measurement||loadtime||0:00:07.174889||2||1
+2015-11-08 19:18:07.211891||measurement||ad||2015-11-08 19:18:06.020475@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:18:07.308544||measurement||ad||2015-11-08 19:18:06.020475@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:18:07.374667||measurement||ad||2015-11-08 19:18:06.020475@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:18:07.374935||measurement||loadtime||0:00:08.860747||3||1
+2015-11-08 19:18:09.117302||measurement||ad||2015-11-08 19:18:08.969609@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:18:09.299202||measurement||ad||2015-11-08 19:18:08.969609@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:18:09.385701||measurement||ad||2015-11-08 19:18:08.969609@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||0
+2015-11-08 19:18:09.385905||measurement||loadtime||0:00:07.773518||1||0
+2015-11-08 19:18:14.891932||measurement||ad||2015-11-08 19:18:14.614020@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:18:15.176811||measurement||ad||2015-11-08 19:18:14.614020@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:18:15.707861||measurement||ad||2015-11-08 19:18:14.614020@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:18:15.708336||measurement||loadtime||0:00:06.160617||0||0
+2015-11-08 19:18:18.922494||measurement||ad||2015-11-08 19:18:18.020713@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:18:19.072471||measurement||ad||2015-11-08 19:18:18.020713@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:18:19.360423||measurement||ad||2015-11-08 19:18:18.020713@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:18:19.360741||measurement||loadtime||0:00:08.553851||2||1
+2015-11-08 19:18:20.147571||measurement||ad||2015-11-08 19:18:19.434339@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:18:20.485958||measurement||ad||2015-11-08 19:18:19.434339@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:18:20.809624||measurement||ad||2015-11-08 19:18:19.434339@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||3||1
+2015-11-08 19:18:20.809941||measurement||loadtime||0:00:08.434408||3||1
+2015-11-08 19:18:20.810154||event||progress-marker||measurement-end||3||1
+2015-11-08 19:18:23.087774||measurement||ad||2015-11-08 19:18:22.950177@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:18:23.203055||measurement||ad||2015-11-08 19:18:22.950177@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:18:23.612737||measurement||ad||2015-11-08 19:18:22.950177@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:18:23.613046||measurement||loadtime||0:00:09.225550||1||0
+2015-11-08 19:18:28.030987||measurement||ad||2015-11-08 19:18:27.895702@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:18:28.125331||measurement||ad||2015-11-08 19:18:27.895702@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:18:28.250653||measurement||ad||2015-11-08 19:18:27.895702@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||0||0
+2015-11-08 19:18:28.250952||measurement||loadtime||0:00:07.541078||0||0
+2015-11-08 19:18:31.156299||measurement||ad||2015-11-08 19:18:30.872778@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:18:31.205956||measurement||ad||2015-11-08 19:18:30.872778@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:18:31.265858||measurement||ad||2015-11-08 19:18:30.872778@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:18:31.266128||measurement||loadtime||0:00:06.903577||2||1
+2015-11-08 19:18:31.266286||event||progress-marker||measurement-end||2||1
+2015-11-08 19:18:33.851436||measurement||ad||2015-11-08 19:18:33.192148@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:18:33.941287||measurement||ad||2015-11-08 19:18:33.192148@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:18:34.033138||measurement||ad||2015-11-08 19:18:33.192148@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:18:34.033483||measurement||loadtime||0:00:05.419389||1||0
+2015-11-08 19:18:56.084542||measurement||ad||2015-11-08 19:18:55.972262@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:18:56.167440||measurement||ad||2015-11-08 19:18:55.972262@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:18:56.597950||measurement||ad||2015-11-08 19:18:55.972262@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||1||0
+2015-11-08 19:18:56.598424||measurement||loadtime||0:00:17.563577||1||0
+2015-11-08 19:18:56.598995||event||progress-marker||measurement-end||1||0
+2015-11-08 19:19:33.316138||error||collecting ads||Error||0||0
+2015-11-08 19:19:33.316345||event||progress-marker||measurement-end||0||0
+2015-11-08 19:19:33.852437||meta||block_id end||0
+2015-11-08 19:19:33.854382||meta||block_id start||1
+2015-11-08 19:19:33.854510||meta||assignment||0@|2@|3@|1
+2015-11-08 19:19:36.829900||event||progress-marker||training-start||2||0
+2015-11-08 19:19:36.854139||event||progress-marker||training-start||0||0
+2015-11-08 19:19:38.487872||event||progress-marker||training-start||1||1
+2015-11-08 19:19:38.532762||event||progress-marker||training-start||3||1
+2015-11-08 19:19:45.400053||treatment||visit website||http://irs.gov||2||0
+2015-11-08 19:19:45.545022||treatment||visit website||http://irs.gov||0||0
+2015-11-08 19:19:46.564734||treatment||visit website||http://irs.gov||1||1
+2015-11-08 19:19:46.594225||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:19:55.108469||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 19:19:56.043837||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 19:19:56.195745||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:20:00.746584||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 19:20:05.824121||treatment||visit website||http://pwc.com||0||0
+2015-11-08 19:20:06.203159||treatment||visit website||http://pwc.com||2||0
+2015-11-08 19:20:08.549317||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:20:10.273358||treatment||visit website||http://pwc.com||1||1
+2015-11-08 19:20:13.244619||treatment||visit website||http://ey.com||0||0
+2015-11-08 19:20:13.756592||treatment||visit website||http://ey.com||2||0
+2015-11-08 19:20:15.414152||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:20:16.896674||treatment||visit website||http://ey.com||1||1
+2015-11-08 19:20:20.629251||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 19:20:20.629476||event||progress-marker||training-end||0||0
+2015-11-08 19:20:22.220522||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 19:20:22.221019||event||progress-marker||training-end||2||0
+2015-11-08 19:20:23.378177||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:20:23.379367||event||progress-marker||training-end||3||1
+2015-11-08 19:20:24.434835||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 19:20:24.435098||event||progress-marker||training-end||1||1
+2015-11-08 19:20:25.635848||event||progress-marker||measurement-start||0||0
+2015-11-08 19:20:27.225488||event||progress-marker||measurement-start||2||0
+2015-11-08 19:20:28.383131||event||progress-marker||measurement-start||3||1
+2015-11-08 19:20:29.439890||event||progress-marker||measurement-start||1||1
+2015-11-08 19:20:45.898856||measurement||ad||2015-11-08 19:20:45.336870@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||0
+2015-11-08 19:20:46.290114||measurement||ad||2015-11-08 19:20:45.336870@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:20:46.632202||measurement||ad||2015-11-08 19:20:45.336870@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:20:46.632460||measurement||loadtime||0:00:15.994971||0||0
+2015-11-08 19:20:47.976076||measurement||ad||2015-11-08 19:20:46.921205@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:20:48.071185||measurement||ad||2015-11-08 19:20:46.921205@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-08 19:20:48.170464||measurement||ad||2015-11-08 19:20:46.921205@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 19:20:48.170854||measurement||loadtime||0:00:14.785556||3||1
+2015-11-08 19:20:48.295699||measurement||ad||2015-11-08 19:20:47.271839@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:20:48.479630||measurement||ad||2015-11-08 19:20:47.271839@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:20:48.581811||measurement||ad||2015-11-08 19:20:47.271839@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 19:20:48.582145||measurement||loadtime||0:00:14.141413||1||1
+2015-11-08 19:20:50.152229||measurement||ad||2015-11-08 19:20:49.669966@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:20:50.339696||measurement||ad||2015-11-08 19:20:49.669966@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:20:50.440721||measurement||ad||2015-11-08 19:20:49.669966@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:20:50.441000||measurement||loadtime||0:00:18.214004||2||0
+2015-11-08 19:21:05.770927||measurement||ad||2015-11-08 19:21:04.963919@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:21:06.184927||measurement||ad||2015-11-08 19:21:04.963919@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:21:06.515359||measurement||ad||2015-11-08 19:21:04.963919@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:21:06.515631||measurement||loadtime||0:00:13.344412||3||1
+2015-11-08 19:21:12.167768||measurement||ad||2015-11-08 19:21:11.003841@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:21:12.625687||measurement||ad||2015-11-08 19:21:11.003841@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||1
+2015-11-08 19:21:12.844861||measurement||ad||2015-11-08 19:21:11.003841@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:21:12.845756||measurement||loadtime||0:00:19.262656||1||1
+2015-11-08 19:21:19.733664||measurement||ad||2015-11-08 19:21:18.324204@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:21:20.338749||measurement||ad||2015-11-08 19:21:18.324204@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:21:20.797388||measurement||ad||2015-11-08 19:21:18.324204@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:21:20.797678||measurement||loadtime||0:00:29.164372||0||0
+2015-11-08 19:21:25.632576||measurement||ad||2015-11-08 19:21:24.786383@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:21:26.050331||measurement||ad||2015-11-08 19:21:24.786383@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:21:26.467095||measurement||ad||2015-11-08 19:21:24.786383@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 19:21:26.467413||measurement||loadtime||0:00:14.950766||3||1
+2015-11-08 19:21:28.451553||measurement||ad||2015-11-08 19:21:27.920124@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:21:28.547458||measurement||ad||2015-11-08 19:21:27.920124@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||1
+2015-11-08 19:21:28.624542||measurement||ad||2015-11-08 19:21:27.920124@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:21:28.624832||measurement||loadtime||0:00:10.777529||1||1
+2015-11-08 19:21:36.059856||measurement||ad||2015-11-08 19:21:35.554437@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:21:36.390707||measurement||ad||2015-11-08 19:21:35.554437@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:21:36.722562||measurement||ad||2015-11-08 19:21:35.554437@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:21:36.723294||measurement||loadtime||0:00:10.924350||0||0
+2015-11-08 19:21:40.650000||measurement||ad||2015-11-08 19:21:40.335254@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:21:40.813465||measurement||ad||2015-11-08 19:21:40.335254@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:21:41.057327||measurement||ad||2015-11-08 19:21:40.335254@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:21:41.057592||measurement||loadtime||0:00:09.589439||3||1
+2015-11-08 19:21:44.754878||measurement||ad||2015-11-08 19:21:42.702131@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:21:44.838796||measurement||ad||2015-11-08 19:21:42.702131@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:21:44.985384||measurement||ad||2015-11-08 19:21:42.702131@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||1
+2015-11-08 19:21:44.985643||measurement||loadtime||0:00:11.360231||1||1
+2015-11-08 19:21:49.935382||measurement||ad||2015-11-08 19:21:49.719545@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||0
+2015-11-08 19:21:51.345606||measurement||ad||2015-11-08 19:21:49.719545@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:21:52.024348||measurement||ad||2015-11-08 19:21:49.719545@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 19:21:52.024646||measurement||loadtime||0:00:10.299623||0||0
+2015-11-08 19:21:55.599350||error||collecting ads||Error||2||0
+2015-11-08 19:21:57.366234||measurement||ad||2015-11-08 19:21:46.222171@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:21:57.965600||measurement||ad||2015-11-08 19:21:46.222171@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:21:58.168403||measurement||ad||2015-11-08 19:21:46.222171@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:21:58.169903||measurement||loadtime||0:00:12.111044||3||1
+2015-11-08 19:21:59.842627||measurement||ad||2015-11-08 19:21:59.229510@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:22:00.066487||measurement||ad||2015-11-08 19:21:59.229510@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:22:00.151017||measurement||ad||2015-11-08 19:21:59.229510@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||1
+2015-11-08 19:22:00.151322||measurement||loadtime||0:00:10.164486||1||1
+2015-11-08 19:22:06.414092||measurement||ad||2015-11-08 19:22:05.692636@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:22:06.796027||measurement||ad||2015-11-08 19:22:05.692636@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:22:07.019553||measurement||ad||2015-11-08 19:22:05.692636@|Business To Business@|www.hoovers.com/B2B@|85 million company listings. Reach decision makers. Free Trial.||0||0
+2015-11-08 19:22:07.019797||measurement||loadtime||0:00:09.994670||0||0
+2015-11-08 19:22:14.531308||measurement||ad||2015-11-08 19:22:14.014147@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:22:14.668591||measurement||ad||2015-11-08 19:22:14.014147@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:22:14.822443||measurement||ad||2015-11-08 19:22:14.014147@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:22:14.822710||measurement||loadtime||0:00:11.652029||3||1
+2015-11-08 19:22:15.365608||measurement||ad||2015-11-08 19:22:14.504955@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:22:15.934415||measurement||ad||2015-11-08 19:22:14.504955@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:22:16.478606||measurement||ad||2015-11-08 19:22:14.504955@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:22:16.478918||measurement||loadtime||0:00:15.877908||2||0
+2015-11-08 19:22:17.042404||measurement||ad||2015-11-08 19:22:15.363671@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:22:17.351675||measurement||ad||2015-11-08 19:22:15.363671@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||1||1
+2015-11-08 19:22:17.622737||measurement||ad||2015-11-08 19:22:15.363671@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||1
+2015-11-08 19:22:17.623054||measurement||loadtime||0:00:12.470337||1||1
+2015-11-08 19:22:20.337163||measurement||ad||2015-11-08 19:22:20.044882@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:22:20.565984||measurement||ad||2015-11-08 19:22:20.044882@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||0
+2015-11-08 19:22:20.815260||measurement||ad||2015-11-08 19:22:20.044882@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||0
+2015-11-08 19:22:20.815499||measurement||loadtime||0:00:08.795193||0||0
+2015-11-08 19:22:28.414632||measurement||ad||2015-11-08 19:22:27.510377@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:22:28.564723||measurement||ad||2015-11-08 19:22:27.510377@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:22:28.721008||measurement||ad||2015-11-08 19:22:27.510377@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:22:28.721241||measurement||loadtime||0:00:08.898190||3||1
+2015-11-08 19:22:40.919257||measurement||ad||2015-11-08 19:22:40.711473@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:22:40.921073||measurement||ad||2015-11-08 19:22:40.690831@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||0||0
+2015-11-08 19:22:41.361615||measurement||ad||2015-11-08 19:22:40.711473@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:22:41.637581||measurement||ad||2015-11-08 19:22:40.690831@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||0
+2015-11-08 19:22:41.653921||measurement||ad||2015-11-08 19:22:40.711473@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:22:41.654189||measurement||loadtime||0:00:07.932474||3||1
+2015-11-08 19:22:41.768397||measurement||ad||2015-11-08 19:22:40.690831@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:22:41.768646||measurement||loadtime||0:00:15.951836||0||0
+2015-11-08 19:22:54.663815||measurement||ad||2015-11-08 19:22:54.463196@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:22:54.839216||measurement||ad||2015-11-08 19:22:54.463196@|Boingo® Unlimited Wi-Fi@|boingo.com/Unlimited-Wi-Fi@|10X Faster Than 3G/4G. 1st Mo $4.98 No Contracts. Sign Up From Mobile.||0||0
+2015-11-08 19:22:55.005595||measurement||ad||2015-11-08 19:22:54.463196@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-08 19:22:55.005793||measurement||loadtime||0:00:08.236573||0||0
+2015-11-08 19:22:58.711684||measurement||ad||2015-11-08 19:22:58.582752@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:22:58.808596||measurement||ad||2015-11-08 19:22:58.582752@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||0
+2015-11-08 19:22:58.914419||measurement||ad||2015-11-08 19:22:58.582752@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Your Destination. Get Directions with FreeMaps App||2||0
+2015-11-08 19:22:58.914624||measurement||loadtime||0:00:37.434395||2||0
+2015-11-08 19:23:07.958610||measurement||ad||2015-11-08 19:23:07.843016@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:23:08.078168||measurement||ad||2015-11-08 19:23:07.843016@|Business To Business@|www.hoovers.com/B2B@|85 million company listings. Reach decision makers. Free Trial.||0||0
+2015-11-08 19:23:08.169863||measurement||ad||2015-11-08 19:23:07.843016@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:23:08.170104||measurement||loadtime||0:00:08.163700||0||0
+2015-11-08 19:23:16.726355||measurement||ad||2015-11-08 19:23:16.621190@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:23:17.035146||measurement||ad||2015-11-08 19:23:16.621190@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Your Destination. Get Directions with FreeMaps App||2||0
+2015-11-08 19:23:17.035416||measurement||loadtime||0:00:13.119302||2||0
+2015-11-08 19:23:18.027125||measurement||ad||2015-11-08 19:23:17.837346@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:23:18.144270||measurement||ad||2015-11-08 19:23:17.837346@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:23:18.243731||measurement||ad||2015-11-08 19:23:17.837346@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:23:18.243936||measurement||loadtime||0:00:05.073135||0||0
+2015-11-08 19:23:18.244773||event||progress-marker||measurement-end||0||0
+2015-11-08 19:23:44.283544||measurement||ad||2015-11-08 19:23:44.196372@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:23:44.354671||measurement||ad||2015-11-08 19:23:44.196372@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:23:44.432555||measurement||ad||2015-11-08 19:23:44.196372@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 19:23:44.432905||measurement||loadtime||0:00:22.395551||2||0
+2015-11-08 19:23:46.694667||error||collecting ads||Error||3||1
+2015-11-08 19:23:55.628030||measurement||ad||2015-11-08 19:23:55.377037@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:23:55.796039||measurement||ad||2015-11-08 19:23:55.377037@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||2||0
+2015-11-08 19:23:55.796496||measurement||loadtime||0:00:06.362094||2||0
+2015-11-08 19:23:59.412307||measurement||ad||2015-11-08 19:23:59.191737@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:23:59.509386||measurement||ad||2015-11-08 19:23:59.191737@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:23:59.599949||measurement||ad||2015-11-08 19:23:59.191737@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:23:59.600289||measurement||loadtime||0:00:07.904673||3||1
+2015-11-08 19:23:59.600429||event||progress-marker||measurement-end||3||1
+2015-11-08 19:24:00.380329||measurement||ad||2015-11-08 19:22:34.955773@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:24:00.429223||measurement||ad||2015-11-08 19:22:34.955773@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 19:24:00.467734||measurement||ad||2015-11-08 19:22:34.955773@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||1||1
+2015-11-08 19:24:00.468075||measurement||loadtime||0:01:37.842925||1||1
+2015-11-08 19:24:04.598183||measurement||ad||2015-11-08 19:24:04.507301@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:24:04.692466||measurement||ad||2015-11-08 19:24:04.507301@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:24:04.764655||measurement||ad||2015-11-08 19:24:04.507301@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:24:04.764886||measurement||loadtime||0:00:03.968014||2||0
+2015-11-08 19:24:13.356079||measurement||ad||2015-11-08 19:24:13.253318@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:24:13.429379||measurement||ad||2015-11-08 19:24:13.253318@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:24:13.497590||measurement||ad||2015-11-08 19:24:13.253318@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:24:13.497847||measurement||loadtime||0:00:03.731571||2||0
+2015-11-08 19:24:22.965398||measurement||ad||2015-11-08 19:24:22.772753@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:24:23.319584||measurement||ad||2015-11-08 19:24:22.772753@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:24:23.495982||measurement||ad||2015-11-08 19:24:22.772753@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:24:23.496279||measurement||loadtime||0:00:04.997497||2||0
+2015-11-08 19:24:23.496524||event||progress-marker||measurement-end||2||0
+2015-11-08 19:24:43.491192||measurement||ad||2015-11-08 19:24:43.311966@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:24:43.532840||measurement||ad||2015-11-08 19:24:43.311966@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-08 19:24:43.566556||measurement||ad||2015-11-08 19:24:43.311966@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||1
+2015-11-08 19:24:43.566813||measurement||loadtime||0:00:38.097305||1||1
+2015-11-08 19:25:10.759611||measurement||ad||2015-11-08 19:25:10.358614@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:25:10.805481||measurement||ad||2015-11-08 19:25:10.358614@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-08 19:25:10.858230||measurement||ad||2015-11-08 19:25:10.358614@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||1||1
+2015-11-08 19:25:10.858524||measurement||loadtime||0:00:22.290267||1||1
+2015-11-08 19:25:19.262593||measurement||ad||2015-11-08 19:25:19.093453@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:25:19.301031||measurement||ad||2015-11-08 19:25:19.093453@|Boingo® Unlimited Wi-Fi@|boingo.com/Unlimited-Wi-Fi@|10X Faster Than 3G/4G. 1st Mo $4.98 No Contracts. Sign Up From Mobile.||1||1
+2015-11-08 19:25:19.343108||measurement||ad||2015-11-08 19:25:19.093453@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||1||1
+2015-11-08 19:25:19.343326||measurement||loadtime||0:00:03.483476||1||1
+2015-11-08 19:25:19.343506||event||progress-marker||measurement-end||1||1
+2015-11-08 19:25:19.711656||meta||block_id end||1
+2015-11-08 19:25:19.713364||meta||block_id start||2
+2015-11-08 19:25:19.713450||meta||assignment||0@|2@|1@|3
+2015-11-08 19:25:22.456844||event||progress-marker||training-start||2||0
+2015-11-08 19:25:22.483315||event||progress-marker||training-start||0||0
+2015-11-08 19:25:24.121672||event||progress-marker||training-start||3||1
+2015-11-08 19:25:24.303843||event||progress-marker||training-start||1||1
+2015-11-08 19:25:30.850874||treatment||visit website||http://irs.gov||0||0
+2015-11-08 19:25:30.997156||treatment||visit website||http://irs.gov||2||0
+2015-11-08 19:25:32.644355||treatment||visit website||http://irs.gov||1||1
+2015-11-08 19:25:32.646584||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:25:38.901660||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 19:25:39.173735||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 19:25:40.907168||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 19:25:41.041155||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:25:50.172430||treatment||visit website||http://pwc.com||0||0
+2015-11-08 19:25:51.177160||treatment||visit website||http://pwc.com||2||0
+2015-11-08 19:25:52.426709||treatment||visit website||http://pwc.com||1||1
+2015-11-08 19:25:52.506116||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:25:57.336699||treatment||visit website||http://ey.com||0||0
+2015-11-08 19:25:59.617557||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:25:59.623167||treatment||visit website||http://ey.com||1||1
+2015-11-08 19:26:00.775300||treatment||visit website||http://ey.com||2||0
+2015-11-08 19:26:04.725263||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 19:26:04.725516||event||progress-marker||training-end||0||0
+2015-11-08 19:26:06.992347||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 19:26:06.992655||event||progress-marker||training-end||1||1
+2015-11-08 19:26:07.013038||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:26:07.013261||event||progress-marker||training-end||3||1
+2015-11-08 19:26:09.848181||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 19:26:09.848487||event||progress-marker||training-end||2||0
+2015-11-08 19:26:12.000118||event||progress-marker||measurement-start||1||1
+2015-11-08 19:26:12.018509||event||progress-marker||measurement-start||3||1
+2015-11-08 19:26:14.735726||event||progress-marker||measurement-start||0||0
+2015-11-08 19:26:14.855712||event||progress-marker||measurement-start||2||0
+2015-11-08 19:26:27.521960||measurement||ad||2015-11-08 19:26:26.824172@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||1||1
+2015-11-08 19:26:27.787307||measurement||ad||2015-11-08 19:26:26.824172@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 19:26:27.971311||measurement||ad||2015-11-08 19:26:26.824172@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||1
+2015-11-08 19:26:27.971679||measurement||loadtime||0:00:10.969821||1||1
+2015-11-08 19:26:30.975443||measurement||ad||2015-11-08 19:26:30.787960@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:26:31.081719||measurement||ad||2015-11-08 19:26:30.787960@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:26:31.197326||measurement||ad||2015-11-08 19:26:30.787960@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:26:31.197655||measurement||loadtime||0:00:11.460686||0||0
+2015-11-08 19:26:32.237290||measurement||ad||2015-11-08 19:26:32.062751@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:26:32.433707||measurement||ad||2015-11-08 19:26:32.062751@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:26:32.568907||measurement||ad||2015-11-08 19:26:32.062751@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:26:32.569227||measurement||loadtime||0:00:12.712331||2||0
+2015-11-08 19:26:41.239267||measurement||ad||2015-11-08 19:26:40.951314@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:26:41.367184||measurement||ad||2015-11-08 19:26:40.951314@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:26:41.464733||measurement||ad||2015-11-08 19:26:40.951314@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:26:41.465005||measurement||loadtime||0:00:08.492611||1||1
+2015-11-08 19:26:41.650291||measurement||ad||2015-11-08 19:26:41.062061@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:26:41.766208||measurement||ad||2015-11-08 19:26:41.062061@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:26:41.854993||measurement||ad||2015-11-08 19:26:41.062061@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||3||1
+2015-11-08 19:26:41.855360||measurement||loadtime||0:00:24.835784||3||1
+2015-11-08 19:26:47.139110||measurement||ad||2015-11-08 19:26:46.642069@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:26:47.571258||measurement||ad||2015-11-08 19:26:46.642069@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:26:47.859817||measurement||ad||2015-11-08 19:26:46.642069@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:26:47.860076||measurement||loadtime||0:00:11.661939||0||0
+2015-11-08 19:26:55.954238||measurement||ad||2015-11-08 19:26:55.412637@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:26:56.321920||measurement||ad||2015-11-08 19:26:55.412637@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:26:56.680059||measurement||ad||2015-11-08 19:26:55.412637@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:26:56.680329||measurement||loadtime||0:00:19.109556||2||0
+2015-11-08 19:26:58.984324||measurement||ad||2015-11-08 19:26:58.010345@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:26:59.211696||measurement||ad||2015-11-08 19:26:58.010345@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:26:59.377040||measurement||ad||2015-11-08 19:26:58.010345@|2015 Car Lease Specials@|www.newcar-leases.com@|Lease a Car at the Lowest Payment. Check Car Dealers for Lease Deals!||3||1
+2015-11-08 19:26:59.377372||measurement||loadtime||0:00:12.521006||3||1
+2015-11-08 19:26:59.707197||measurement||ad||2015-11-08 19:26:58.786339@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||1
+2015-11-08 19:26:59.841952||measurement||ad||2015-11-08 19:26:58.786339@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||1||1
+2015-11-08 19:26:59.945438||measurement||ad||2015-11-08 19:26:58.786339@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 19:26:59.945700||measurement||loadtime||0:00:13.479831||1||1
+2015-11-08 19:27:05.690087||measurement||ad||2015-11-08 19:27:05.329229@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:27:06.206813||measurement||ad||2015-11-08 19:27:05.329229@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 19:27:07.092311||measurement||ad||2015-11-08 19:27:05.329229@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:27:07.092918||measurement||loadtime||0:00:14.231494||0||0
+2015-11-08 19:27:13.196529||measurement||ad||2015-11-08 19:27:12.876195@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:27:13.693485||measurement||ad||2015-11-08 19:27:13.402232@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:27:13.766132||measurement||ad||2015-11-08 19:27:12.876195@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:27:13.819812||measurement||ad||2015-11-08 19:27:13.402232@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:27:13.922578||measurement||ad||2015-11-08 19:27:13.402232@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 19:27:13.922840||measurement||loadtime||0:00:09.544640||3||1
+2015-11-08 19:27:13.955180||measurement||ad||2015-11-08 19:27:12.876195@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:27:13.955531||measurement||loadtime||0:00:12.274121||2||0
+2015-11-08 19:27:14.049406||measurement||ad||2015-11-08 19:27:13.946766@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||1
+2015-11-08 19:27:14.141225||measurement||ad||2015-11-08 19:27:13.946766@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:27:14.206546||measurement||ad||2015-11-08 19:27:13.946766@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 19:27:14.206837||measurement||loadtime||0:00:09.259791||1||1
+2015-11-08 19:27:19.961638||measurement||ad||2015-11-08 19:27:19.259680@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:27:20.273287||measurement||ad||2015-11-08 19:27:19.259680@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:27:20.652598||measurement||ad||2015-11-08 19:27:19.259680@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:27:20.652854||measurement||loadtime||0:00:08.559366||0||0
+2015-11-08 19:27:29.328511||measurement||ad||2015-11-08 19:27:29.123602@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:27:29.533042||measurement||ad||2015-11-08 19:27:29.123602@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||3||1
+2015-11-08 19:27:29.993382||measurement||ad||2015-11-08 19:27:29.123602@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||1
+2015-11-08 19:27:29.993765||measurement||loadtime||0:00:11.070430||3||1
+2015-11-08 19:27:31.938383||measurement||ad||2015-11-08 19:27:30.049617@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:27:32.652825||measurement||ad||2015-11-08 19:27:30.049617@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:27:34.734945||measurement||ad||2015-11-08 19:27:30.049617@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 19:27:34.735510||measurement||loadtime||0:00:15.528060||1||1
+2015-11-08 19:27:35.801299||measurement||ad||2015-11-08 19:27:34.851065@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:27:36.720649||measurement||ad||2015-11-08 19:27:34.851065@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:27:37.065945||measurement||ad||2015-11-08 19:27:34.851065@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-08 19:27:37.066511||measurement||loadtime||0:00:18.110164||2||0
+2015-11-08 19:27:48.005840||measurement||ad||2015-11-08 19:27:46.457099@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:27:48.462872||measurement||ad||2015-11-08 19:27:46.457099@|Klohn Crippen Berger@|www.klohn.com@|Global Engineering, Environmental and Geoscience Consulting Firm||3||1
+2015-11-08 19:27:48.598309||measurement||ad||2015-11-08 19:27:46.457099@|Site Closure@|www.terra-petra.com@|National Environmental Engineering firm to assist on site closures||3||1
+2015-11-08 19:27:48.599365||measurement||loadtime||0:00:13.604396||3||1
+2015-11-08 19:27:49.337449||measurement||ad||2015-11-08 19:27:49.156430@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:27:49.530983||measurement||ad||2015-11-08 19:27:49.156430@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:27:49.773983||measurement||ad||2015-11-08 19:27:49.156430@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:27:49.774265||measurement||loadtime||0:00:10.037303||1||1
+2015-11-08 19:27:57.768118||measurement||ad||2015-11-08 19:27:56.766212@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 19:27:58.513421||measurement||ad||2015-11-08 19:27:56.766212@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:27:59.122302||measurement||ad||2015-11-08 19:27:56.766212@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:27:59.122645||measurement||loadtime||0:00:17.054640||2||0
+2015-11-08 19:28:02.179507||measurement||ad||2015-11-08 19:28:02.035167@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:28:02.249632||measurement||ad||2015-11-08 19:28:02.035167@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:28:02.402838||measurement||ad||2015-11-08 19:28:02.035167@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 19:28:02.403093||measurement||loadtime||0:00:07.628135||1||1
+2015-11-08 19:28:08.870313||measurement||ad||2015-11-08 19:28:08.679955@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:28:09.070227||measurement||ad||2015-11-08 19:28:08.679955@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:28:09.347823||measurement||ad||2015-11-08 19:28:08.679955@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||2||0
+2015-11-08 19:28:09.348118||measurement||loadtime||0:00:05.223827||2||0
+2015-11-08 19:28:18.148832||measurement||ad||2015-11-08 19:28:17.817187@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:28:18.397130||measurement||ad||2015-11-08 19:28:17.817187@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:28:18.758919||measurement||ad||2015-11-08 19:28:17.817187@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 19:28:18.759210||measurement||loadtime||0:00:53.105772||0||0
+2015-11-08 19:28:20.769409||measurement||ad||2015-11-08 19:28:20.646348@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:28:20.877555||measurement||ad||2015-11-08 19:28:20.646348@|Klohn Crippen Berger@|www.klohn.com@|Global Engineering, Environmental and Geoscience Consulting Firm||3||1
+2015-11-08 19:28:21.032909||measurement||ad||2015-11-08 19:28:20.646348@|Site Closure@|www.terra-petra.com@|National Environmental Engineering firm to assist on site closures||3||1
+2015-11-08 19:28:21.033198||measurement||loadtime||0:00:27.431873||3||1
+2015-11-08 19:28:21.660138||measurement||ad||2015-11-08 19:28:21.460124@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:28:21.810329||measurement||ad||2015-11-08 19:28:21.460124@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:28:21.950604||measurement||ad||2015-11-08 19:28:21.460124@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:28:21.951001||measurement||loadtime||0:00:07.602420||2||0
+2015-11-08 19:28:32.666573||measurement||ad||2015-11-08 19:28:32.214695@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:28:33.030696||measurement||ad||2015-11-08 19:28:32.214695@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:28:33.477273||measurement||ad||2015-11-08 19:28:32.214695@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 19:28:33.477815||measurement||loadtime||0:00:09.716697||0||0
+2015-11-08 19:28:33.708110||measurement||ad||2015-11-08 19:28:32.653926@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:28:33.915659||measurement||ad||2015-11-08 19:28:32.653926@|Klohn Crippen Berger@|www.klohn.com@|Global Engineering, Environmental and Geoscience Consulting Firm||3||1
+2015-11-08 19:28:34.086966||measurement||ad||2015-11-08 19:28:32.653926@|Environmental Ed Grants@|sca.com/us/grants@|Funding for outdoor education Up to $5000 per project||3||1
+2015-11-08 19:28:34.087213||measurement||loadtime||0:00:08.053663||3||1
+2015-11-08 19:28:43.316887||measurement||ad||2015-11-08 19:28:43.176910@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:28:43.432428||measurement||ad||2015-11-08 19:28:43.176910@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||0||0
+2015-11-08 19:28:43.549656||measurement||ad||2015-11-08 19:28:43.176910@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:28:43.549916||measurement||loadtime||0:00:05.070437||0||0
+2015-11-08 19:28:46.397766||measurement||ad||2015-11-08 19:28:46.259840@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 19:28:46.481244||measurement||ad||2015-11-08 19:28:46.259840@|Tablets For Kids@|shopsales.us@|Huge Black Friday Clearance Sale! Compare Prices - Tablets For Kids||3||1
+2015-11-08 19:28:46.532037||measurement||ad||2015-11-08 19:28:46.259840@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:28:46.532263||measurement||loadtime||0:00:07.443714||3||1
+2015-11-08 19:28:56.249169||measurement||ad||2015-11-08 19:28:55.926229@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:28:56.599004||measurement||ad||2015-11-08 19:28:55.926229@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:28:56.776545||measurement||ad||2015-11-08 19:28:55.926229@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 19:28:56.776759||measurement||loadtime||0:00:08.225819||0||0
+2015-11-08 19:28:56.916713||measurement||ad||2015-11-08 19:28:56.359471@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:28:56.962314||measurement||ad||2015-11-08 19:28:56.359471@|2015 Car Lease Specials@|www.newcar-leases.com@|Lease a Car at the Lowest Payment. Check Car Dealers for Lease Deals!||3||1
+2015-11-08 19:28:57.012327||measurement||ad||2015-11-08 19:28:56.359471@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||3||1
+2015-11-08 19:28:57.012672||measurement||loadtime||0:00:05.479359||3||1
+2015-11-08 19:29:07.465988||error||collecting ads||Error||1||1
+2015-11-08 19:29:08.499354||measurement||ad||2015-11-08 19:29:08.348948@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:29:08.649015||measurement||ad||2015-11-08 19:29:08.348948@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:29:08.802114||measurement||ad||2015-11-08 19:29:08.348948@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 19:29:08.802381||measurement||loadtime||0:00:07.024433||0||0
+2015-11-08 19:29:09.634194||measurement||ad||2015-11-08 19:29:09.101729@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:29:09.757945||measurement||ad||2015-11-08 19:29:09.101729@|Klohn Crippen Berger@|www.klohn.com@|Global Engineering, Environmental and Geoscience Consulting Firm||3||1
+2015-11-08 19:29:09.888115||measurement||ad||2015-11-08 19:29:09.101729@|Site Closure@|www.terra-petra.com@|National Environmental Engineering firm to assist on site closures||3||1
+2015-11-08 19:29:09.888470||measurement||loadtime||0:00:07.873942||3||1
+2015-11-08 19:29:09.888835||event||progress-marker||measurement-end||3||1
+2015-11-08 19:29:22.613676||measurement||ad||2015-11-08 19:29:12.850218@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:29:22.749830||measurement||ad||2015-11-08 19:29:12.850218@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 19:29:22.857888||measurement||ad||2015-11-08 19:29:12.850218@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:29:22.858144||measurement||loadtime||0:00:10.390889||1||1
+2015-11-08 19:29:27.058119||error||collecting ads||Error||2||0
+2015-11-08 19:29:32.033892||measurement||ad||2015-11-08 19:29:27.968568@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:29:32.085783||measurement||ad||2015-11-08 19:29:27.968568@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:29:32.145661||measurement||ad||2015-11-08 19:29:27.968568@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 19:29:32.145910||measurement||loadtime||0:00:04.286354||1||1
+2015-11-08 19:29:32.146099||event||progress-marker||measurement-end||1||1
+2015-11-08 19:29:38.265991||measurement||ad||2015-11-08 19:29:38.124238@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:29:38.398910||measurement||ad||2015-11-08 19:29:38.124238@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 19:29:38.547357||measurement||ad||2015-11-08 19:29:38.124238@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 19:29:38.547660||measurement||loadtime||0:00:06.488608||2||0
+2015-11-08 19:29:47.428273||measurement||ad||2015-11-08 19:29:47.317327@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:29:47.504728||measurement||ad||2015-11-08 19:29:47.317327@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 19:29:47.615950||measurement||ad||2015-11-08 19:29:47.317327@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:29:47.616200||measurement||loadtime||0:00:04.067667||2||0
+2015-11-08 19:29:47.616865||event||progress-marker||measurement-end||2||0
+2015-11-08 19:30:13.868911||error||collecting ads||Error||0||0
+2015-11-08 19:30:13.869119||event||progress-marker||measurement-end||0||0
+2015-11-08 19:30:14.424417||meta||block_id end||2
+2015-11-08 19:30:14.426602||meta||block_id start||3
+2015-11-08 19:30:14.427061||meta||assignment||0@|3@|2@|1
+2015-11-08 19:30:17.738471||event||progress-marker||training-start||0||0
+2015-11-08 19:30:17.798821||event||progress-marker||training-start||3||0
+2015-11-08 19:30:21.198014||event||progress-marker||training-start||2||1
+2015-11-08 19:30:21.369844||event||progress-marker||training-start||1||1
+2015-11-08 19:30:27.197021||treatment||visit website||http://irs.gov||0||0
+2015-11-08 19:30:27.474247||treatment||visit website||http://irs.gov||3||0
+2015-11-08 19:30:29.313045||treatment||visit website||http://irs.gov||2||1
+2015-11-08 19:30:29.575732||treatment||visit website||http://irs.gov||1||1
+2015-11-08 19:30:35.643645||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 19:30:35.764379||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 19:30:37.855036||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 19:30:37.867635||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 19:30:47.385757||treatment||visit website||http://pwc.com||0||0
+2015-11-08 19:30:47.605783||treatment||visit website||http://pwc.com||3||0
+2015-11-08 19:30:49.059873||treatment||visit website||http://pwc.com||1||1
+2015-11-08 19:30:49.091998||treatment||visit website||http://pwc.com||2||1
+2015-11-08 19:30:54.402151||treatment||visit website||http://ey.com||0||0
+2015-11-08 19:30:55.928523||treatment||visit website||http://ey.com||3||0
+2015-11-08 19:30:57.130506||treatment||visit website||http://ey.com||2||1
+2015-11-08 19:30:57.264626||treatment||visit website||http://ey.com||1||1
+2015-11-08 19:31:02.082652||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 19:31:02.082967||event||progress-marker||training-end||0||0
+2015-11-08 19:31:04.038013||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 19:31:04.038283||event||progress-marker||training-end||3||0
+2015-11-08 19:31:04.756064||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 19:31:04.756683||event||progress-marker||training-end||2||1
+2015-11-08 19:31:05.517951||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 19:31:05.518190||event||progress-marker||training-end||1||1
+2015-11-08 19:31:07.093351||event||progress-marker||measurement-start||0||0
+2015-11-08 19:31:09.048161||event||progress-marker||measurement-start||3||0
+2015-11-08 19:31:09.767373||event||progress-marker||measurement-start||2||1
+2015-11-08 19:31:10.525593||event||progress-marker||measurement-start||1||1
+2015-11-08 19:31:21.802604||measurement||ad||2015-11-08 19:31:21.264748@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:31:22.237947||measurement||ad||2015-11-08 19:31:21.264748@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 19:31:22.678719||measurement||ad||2015-11-08 19:31:21.264748@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:31:22.679104||measurement||loadtime||0:00:10.583669||0||0
+2015-11-08 19:31:24.917977||measurement||ad||2015-11-08 19:31:24.123540@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-08 19:31:25.661873||measurement||ad||2015-11-08 19:31:24.451007@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:31:25.752327||measurement||ad||2015-11-08 19:31:24.123540@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:31:26.152491||measurement||ad||2015-11-08 19:31:24.451007@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 19:31:26.250509||measurement||ad||2015-11-08 19:31:24.123540@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:31:26.250798||measurement||loadtime||0:00:12.202132||3||0
+2015-11-08 19:31:26.503648||measurement||ad||2015-11-08 19:31:24.451007@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:31:26.503957||measurement||loadtime||0:00:11.735125||2||1
+2015-11-08 19:31:29.171529||measurement||ad||2015-11-08 19:31:28.441619@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:31:29.489914||measurement||ad||2015-11-08 19:31:28.441619@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 19:31:29.778097||measurement||ad||2015-11-08 19:31:28.441619@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:31:29.778534||measurement||loadtime||0:00:14.251334||1||1
+2015-11-08 19:31:37.291689||measurement||ad||2015-11-08 19:31:37.040550@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:31:37.558655||measurement||ad||2015-11-08 19:31:37.040550@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:31:37.870866||measurement||ad||2015-11-08 19:31:37.040550@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:31:37.871147||measurement||loadtime||0:00:10.190730||0||0
+2015-11-08 19:31:41.080040||measurement||ad||2015-11-08 19:31:40.737402@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 19:31:41.375711||measurement||ad||2015-11-08 19:31:40.737402@|7 Signs of Parkinson's@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Parkinson's Is Coming. See Video.||3||0
+2015-11-08 19:31:41.571338||measurement||ad||2015-11-08 19:31:40.737402@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||0
+2015-11-08 19:31:41.571705||measurement||loadtime||0:00:10.320233||3||0
+2015-11-08 19:31:43.880746||measurement||ad||2015-11-08 19:31:42.811383@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 19:31:44.096634||measurement||ad||2015-11-08 19:31:42.811383@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:31:44.350044||measurement||ad||2015-11-08 19:31:42.811383@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||1
+2015-11-08 19:31:44.350306||measurement||loadtime||0:00:12.844501||2||1
+2015-11-08 19:31:45.387888||measurement||ad||2015-11-08 19:31:44.507092@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:31:45.486044||measurement||ad||2015-11-08 19:31:44.507092@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:31:45.601604||measurement||ad||2015-11-08 19:31:44.507092@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:31:45.601906||measurement||loadtime||0:00:10.822025||1||1
+2015-11-08 19:31:51.358833||measurement||ad||2015-11-08 19:31:50.988184@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:31:51.548822||measurement||ad||2015-11-08 19:31:50.988184@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:31:51.810150||measurement||ad||2015-11-08 19:31:50.988184@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-08 19:31:51.810416||measurement||loadtime||0:00:08.938682||0||0
+2015-11-08 19:31:57.522825||measurement||ad||2015-11-08 19:31:57.153400@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 19:31:57.819945||measurement||ad||2015-11-08 19:31:57.153400@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 19:31:58.201511||measurement||ad||2015-11-08 19:31:57.153400@|Alternative Oncology@|drforsythe.com/Cancer-Options@|You Do Have Options. Call Now  Schedule a Consultation.||3||0
+2015-11-08 19:31:58.201796||measurement||loadtime||0:00:11.629248||3||0
+2015-11-08 19:31:59.127179||measurement||ad||2015-11-08 19:31:58.726175@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:31:59.342823||measurement||ad||2015-11-08 19:31:58.726175@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 19:31:59.472193||measurement||ad||2015-11-08 19:31:58.726175@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:31:59.472452||measurement||loadtime||0:00:10.121641||2||1
+2015-11-08 19:32:01.574915||measurement||ad||2015-11-08 19:32:00.981871@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:32:01.674372||measurement||ad||2015-11-08 19:32:00.981871@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:32:01.761687||measurement||ad||2015-11-08 19:32:00.981871@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:32:01.762122||measurement||loadtime||0:00:11.159256||1||1
+2015-11-08 19:32:02.572753||measurement||ad||2015-11-08 19:32:02.450304@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:32:02.667884||measurement||ad||2015-11-08 19:32:02.450304@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:32:02.780436||measurement||ad||2015-11-08 19:32:02.450304@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:32:02.780794||measurement||loadtime||0:00:05.969778||0||0
+2015-11-08 19:32:09.749873||measurement||ad||2015-11-08 19:32:09.077487@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-08 19:32:10.162296||measurement||ad||2015-11-08 19:32:09.077487@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:32:10.541696||measurement||ad||2015-11-08 19:32:09.077487@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 19:32:10.542072||measurement||loadtime||0:00:07.336222||3||0
+2015-11-08 19:32:17.480830||measurement||ad||2015-11-08 19:32:16.589701@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:32:17.753418||measurement||ad||2015-11-08 19:32:16.589701@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 19:32:17.993190||measurement||ad||2015-11-08 19:32:16.589701@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:32:17.993577||measurement||loadtime||0:00:13.520601||2||1
+2015-11-08 19:32:24.089980||measurement||ad||2015-11-08 19:32:23.778539@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:32:24.205910||measurement||ad||2015-11-08 19:32:23.778539@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||1
+2015-11-08 19:32:24.301283||measurement||ad||2015-11-08 19:32:23.778539@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 19:32:24.301912||measurement||loadtime||0:00:17.538378||1||1
+2015-11-08 19:32:27.141529||measurement||ad||2015-11-08 19:32:26.259285@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-08 19:32:27.516248||measurement||ad||2015-11-08 19:32:26.259285@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:32:27.808288||measurement||ad||2015-11-08 19:32:26.259285@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:32:27.808585||measurement||loadtime||0:00:12.265090||3||0
+2015-11-08 19:32:32.102527||measurement||ad||2015-11-08 19:32:31.080516@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:32:33.660735||measurement||ad||2015-11-08 19:32:31.080516@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||1
+2015-11-08 19:32:33.863800||measurement||ad||2015-11-08 19:32:31.080516@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:32:33.864236||measurement||loadtime||0:00:10.869269||2||1
+2015-11-08 19:32:39.205033||measurement||ad||2015-11-08 19:32:38.579238@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:32:39.514533||measurement||ad||2015-11-08 19:32:38.579238@|Forensic Science Training@|forensics.comparetopschools.com@|Find Accredited Online Schools With Forensic Science Degree Programs.||1||1
+2015-11-08 19:32:39.722368||measurement||ad||2015-11-08 19:32:38.579238@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-08 19:32:39.722626||measurement||loadtime||0:00:10.419333||1||1
+2015-11-08 19:32:41.601149||measurement||ad||2015-11-08 19:32:40.906150@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-08 19:32:41.972340||measurement||ad||2015-11-08 19:32:40.906150@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:32:42.442766||measurement||ad||2015-11-08 19:32:40.906150@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:32:42.443114||measurement||loadtime||0:00:09.633994||3||0
+2015-11-08 19:32:48.338481||measurement||ad||2015-11-08 19:32:48.015506@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:32:48.544392||measurement||ad||2015-11-08 19:32:48.015506@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:32:48.612142||measurement||ad||2015-11-08 19:32:48.015506@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:32:48.612410||measurement||loadtime||0:00:09.747794||2||1
+2015-11-08 19:32:52.115327||measurement||ad||2015-11-08 19:32:51.608645@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:32:52.211410||measurement||ad||2015-11-08 19:32:51.608645@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:32:52.293800||measurement||ad||2015-11-08 19:32:51.608645@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:32:52.294071||measurement||loadtime||0:00:07.571019||1||1
+2015-11-08 19:32:52.754216||measurement||ad||2015-11-08 19:32:52.633929@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-08 19:32:52.840337||measurement||ad||2015-11-08 19:32:52.633929@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:32:52.941948||measurement||ad||2015-11-08 19:32:52.633929@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:32:52.942188||measurement||loadtime||0:00:05.498142||3||0
+2015-11-08 19:32:58.649697||measurement||ad||2015-11-08 19:32:58.535771@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:32:58.725075||measurement||ad||2015-11-08 19:32:58.535771@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:32:58.838743||measurement||ad||2015-11-08 19:32:58.535771@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:32:58.839064||measurement||loadtime||0:00:05.225306||2||1
+2015-11-08 19:33:03.586749||measurement||ad||2015-11-08 19:33:02.922059@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 19:33:03.776461||measurement||ad||2015-11-08 19:33:02.922059@|Forensic Science Training@|forensics.comparetopschools.com@|Find Accredited Online Schools With Forensic Science Degree Programs.||1||1
+2015-11-08 19:33:03.863006||measurement||ad||2015-11-08 19:33:02.922059@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-08 19:33:03.863625||measurement||loadtime||0:00:06.568143||1||1
+2015-11-08 19:33:04.750237||measurement||ad||2015-11-08 19:33:04.554740@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:33:04.901930||measurement||ad||2015-11-08 19:33:04.554740@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 19:33:05.084647||measurement||ad||2015-11-08 19:33:04.554740@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 19:33:05.084887||measurement||loadtime||0:00:07.141683||3||0
+2015-11-08 19:33:07.851256||error||collecting ads||Error||0||0
+2015-11-08 19:33:18.105120||measurement||ad||2015-11-08 19:33:17.843192@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||0
+2015-11-08 19:33:18.350144||measurement||ad||2015-11-08 19:33:17.843192@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:33:18.771477||measurement||ad||2015-11-08 19:33:17.843192@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 19:33:18.772036||measurement||loadtime||0:00:08.686250||3||0
+2015-11-08 19:33:19.435244||measurement||ad||2015-11-08 19:33:16.794101@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:33:19.608265||measurement||ad||2015-11-08 19:33:16.794101@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:33:19.735378||measurement||ad||2015-11-08 19:33:16.794101@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 19:33:19.735702||measurement||loadtime||0:00:15.896001||2||1
+2015-11-08 19:33:33.976566||measurement||ad||2015-11-08 19:33:33.769019@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:33:34.069604||measurement||ad||2015-11-08 19:33:33.769019@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:33:34.182949||measurement||ad||2015-11-08 19:33:33.769019@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||2||1
+2015-11-08 19:33:34.183219||measurement||loadtime||0:00:09.446994||2||1
+2015-11-08 19:33:37.670082||measurement||ad||2015-11-08 19:33:37.567678@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:33:37.751180||measurement||ad||2015-11-08 19:33:37.567678@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:33:37.844180||measurement||ad||2015-11-08 19:33:37.567678@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:33:37.844544||measurement||loadtime||0:00:24.991757||0||0
+2015-11-08 19:33:44.497601||measurement||ad||2015-11-08 19:33:43.693555@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:33:44.664998||measurement||ad||2015-11-08 19:33:43.693555@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:33:44.775308||measurement||ad||2015-11-08 19:33:43.693555@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:33:44.775631||measurement||loadtime||0:00:05.591730||2||1
+2015-11-08 19:33:44.775843||event||progress-marker||measurement-end||2||1
+2015-11-08 19:33:48.839761||measurement||ad||2015-11-08 19:33:48.726625@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:33:48.919797||measurement||ad||2015-11-08 19:33:48.726625@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:33:49.030809||measurement||ad||2015-11-08 19:33:48.726625@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:33:49.031060||measurement||loadtime||0:00:06.185163||0||0
+2015-11-08 19:33:58.223182||measurement||ad||2015-11-08 19:33:58.139486@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:33:58.318138||measurement||ad||2015-11-08 19:33:58.139486@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:33:58.412615||measurement||ad||2015-11-08 19:33:58.139486@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-08 19:33:58.412903||measurement||loadtime||0:00:04.381289||0||0
+2015-11-08 19:34:07.140082||measurement||ad||2015-11-08 19:34:07.048627@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||0
+2015-11-08 19:34:07.215407||measurement||ad||2015-11-08 19:34:07.048627@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:34:07.296645||measurement||ad||2015-11-08 19:34:07.048627@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 19:34:07.296888||measurement||loadtime||0:00:03.882540||0||0
+2015-11-08 19:34:15.654161||measurement||ad||2015-11-08 19:34:15.566968@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:34:15.724295||measurement||ad||2015-11-08 19:34:15.566968@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||0
+2015-11-08 19:34:15.797736||measurement||ad||2015-11-08 19:34:15.566968@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-08 19:34:15.797991||measurement||loadtime||0:00:03.499804||0||0
+2015-11-08 19:34:15.798138||event||progress-marker||measurement-end||0||0
+2015-11-08 19:34:23.846716||error||collecting ads||Error||3||0
+2015-11-08 19:34:23.846962||event||progress-marker||measurement-end||3||0
+2015-11-08 19:34:41.168814||measurement||ad||2015-11-08 19:33:23.171106@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:34:41.206298||measurement||ad||2015-11-08 19:33:23.171106@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:34:41.237070||measurement||ad||2015-11-08 19:33:23.171106@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:34:41.237350||measurement||loadtime||0:01:32.373205||1||1
+2015-11-08 19:34:50.697892||measurement||ad||2015-11-08 19:34:50.500717@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:34:50.768059||measurement||ad||2015-11-08 19:34:50.500717@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:34:50.865276||measurement||ad||2015-11-08 19:34:50.500717@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:34:50.865801||measurement||loadtime||0:00:04.627026||1||1
+2015-11-08 19:35:00.421224||measurement||ad||2015-11-08 19:35:00.062649@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 19:35:00.524386||measurement||ad||2015-11-08 19:35:00.062649@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 19:35:00.625516||measurement||ad||2015-11-08 19:35:00.062649@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 19:35:00.625969||measurement||loadtime||0:00:04.759624||1||1
+2015-11-08 19:35:00.626425||event||progress-marker||measurement-end||1||1
+2015-11-08 19:35:00.910753||meta||block_id end||3
+2015-11-08 19:35:00.912713||meta||block_id start||4
+2015-11-08 19:35:00.912752||meta||assignment||2@|1@|3@|0
+2015-11-08 19:35:03.635802||event||progress-marker||training-start||2||0
+2015-11-08 19:35:03.849501||event||progress-marker||training-start||1||0
+2015-11-08 19:35:05.498189||event||progress-marker||training-start||0||1
+2015-11-08 19:35:05.590473||event||progress-marker||training-start||3||1
+2015-11-08 19:35:12.193660||treatment||visit website||http://irs.gov||2||0
+2015-11-08 19:35:12.286023||treatment||visit website||http://irs.gov||1||0
+2015-11-08 19:35:13.219162||treatment||visit website||http://irs.gov||0||1
+2015-11-08 19:35:13.342383||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:35:21.578284||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 19:35:21.675392||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 19:35:22.662044||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:35:22.735117||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 19:35:33.249910||treatment||visit website||http://pwc.com||1||0
+2015-11-08 19:35:33.572969||treatment||visit website||http://pwc.com||2||0
+2015-11-08 19:35:34.711183||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:35:34.877787||treatment||visit website||http://pwc.com||0||1
+2015-11-08 19:35:40.557894||treatment||visit website||http://ey.com||1||0
+2015-11-08 19:35:41.398845||treatment||visit website||http://ey.com||2||0
+2015-11-08 19:35:42.108332||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:35:42.893533||treatment||visit website||http://ey.com||0||1
+2015-11-08 19:35:49.035972||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 19:35:49.036288||event||progress-marker||training-end||1||0
+2015-11-08 19:35:50.043000||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 19:35:50.044399||event||progress-marker||training-end||2||0
+2015-11-08 19:35:50.704840||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:35:50.705084||event||progress-marker||training-end||3||1
+2015-11-08 19:35:50.882071||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 19:35:50.882464||event||progress-marker||training-end||0||1
+2015-11-08 19:35:54.048885||event||progress-marker||measurement-start||1||0
+2015-11-08 19:35:55.056905||event||progress-marker||measurement-start||2||0
+2015-11-08 19:35:55.713805||event||progress-marker||measurement-start||3||1
+2015-11-08 19:35:55.891574||event||progress-marker||measurement-start||0||1
+2015-11-08 19:36:10.837131||measurement||ad||2015-11-08 19:36:10.249770@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:36:11.026844||measurement||ad||2015-11-08 19:36:10.249770@|Business To Business@|www.hoovers.com/B2B@|85 million company listings. Reach decision makers. Free Trial.||1||0
+2015-11-08 19:36:11.027136||measurement||loadtime||0:00:11.976806||1||0
+2015-11-08 19:36:11.991404||measurement||ad||2015-11-08 19:36:11.659753@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:36:12.237833||measurement||ad||2015-11-08 19:36:11.659753@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:36:12.523101||measurement||ad||2015-11-08 19:36:11.659753@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 19:36:12.523439||measurement||loadtime||0:00:12.466021||2||0
+2015-11-08 19:36:14.177722||measurement||ad||2015-11-08 19:36:13.514897@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 19:36:14.357848||measurement||ad||2015-11-08 19:36:13.514897@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 19:36:14.358134||measurement||loadtime||0:00:13.465244||0||1
+2015-11-08 19:36:14.653106||measurement||ad||2015-11-08 19:36:14.127697@|7 Signs of Parkinson's@|w3.blaylockwellness.com@|Your Body Will Send 7 Signals That Parkinson's Is Coming. See Video.||3||1
+2015-11-08 19:36:14.717997||measurement||ad||2015-11-08 19:36:14.127697@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:36:14.795601||measurement||ad||2015-11-08 19:36:14.127697@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||1
+2015-11-08 19:36:14.795868||measurement||loadtime||0:00:14.081208||3||1
+2015-11-08 19:36:28.756831||measurement||ad||2015-11-08 19:36:28.086580@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:36:29.386035||measurement||ad||2015-11-08 19:36:28.086580@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:36:29.918624||measurement||ad||2015-11-08 19:36:28.086580@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:36:29.919086||measurement||loadtime||0:00:13.890775||1||0
+2015-11-08 19:36:30.331614||measurement||ad||2015-11-08 19:36:29.801998@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:36:30.950888||measurement||ad||2015-11-08 19:36:29.801998@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:36:31.460646||measurement||ad||2015-11-08 19:36:29.801998@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||2||0
+2015-11-08 19:36:31.460963||measurement||loadtime||0:00:13.937075||2||0
+2015-11-08 19:36:32.358078||measurement||ad||2015-11-08 19:36:31.326242@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:36:32.760608||measurement||ad||2015-11-08 19:36:31.326242@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 19:36:33.177692||measurement||ad||2015-11-08 19:36:31.326242@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:36:33.177958||measurement||loadtime||0:00:13.819046||0||1
+2015-11-08 19:36:41.862824||measurement||ad||2015-11-08 19:36:40.289773@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:36:43.771335||measurement||ad||2015-11-08 19:36:40.289773@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:36:44.041224||measurement||ad||2015-11-08 19:36:40.289773@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:36:44.041497||measurement||loadtime||0:00:24.244744||3||1
+2015-11-08 19:36:44.730709||measurement||ad||2015-11-08 19:36:44.386721@|Concealed Carry Mistakes:@|Can Do  More Concealed Carry Tips:@|The Worst Thing a Permit Holder ||1||0
+2015-11-08 19:36:44.730982||measurement||loadtime||0:00:09.811018||1||0
+2015-11-08 19:36:45.526378||measurement||ad||2015-11-08 19:36:45.333407@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:36:45.658381||measurement||ad||2015-11-08 19:36:45.333407@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:36:45.794661||measurement||ad||2015-11-08 19:36:45.333407@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||2||0
+2015-11-08 19:36:45.795028||measurement||loadtime||0:00:09.332677||2||0
+2015-11-08 19:36:48.988699||measurement||ad||2015-11-08 19:36:48.654725@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 19:36:49.092687||measurement||ad||2015-11-08 19:36:48.654725@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 19:36:49.093042||measurement||loadtime||0:00:10.914316||0||1
+2015-11-08 19:36:58.580384||measurement||ad||2015-11-08 19:36:57.508630@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:36:58.902316||measurement||ad||2015-11-08 19:36:57.508630@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:36:59.235874||measurement||ad||2015-11-08 19:36:57.508630@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-08 19:36:59.236263||measurement||loadtime||0:00:09.503481||1||0
+2015-11-08 19:37:01.408854||measurement||ad||2015-11-08 19:37:00.992336@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:37:01.589600||measurement||ad||2015-11-08 19:37:00.992336@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:37:01.689295||measurement||ad||2015-11-08 19:37:00.992336@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||3||1
+2015-11-08 19:37:01.689602||measurement||loadtime||0:00:12.647463||3||1
+2015-11-08 19:37:06.121086||measurement||ad||2015-11-08 19:37:05.972116@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:37:07.109751||measurement||ad||2015-11-08 19:37:05.972116@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||1
+2015-11-08 19:37:07.473069||measurement||ad||2015-11-08 19:37:05.972116@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||0||1
+2015-11-08 19:37:07.473543||measurement||loadtime||0:00:13.379717||0||1
+2015-11-08 19:37:21.953952||measurement||ad||2015-11-08 19:37:21.536600@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:37:22.063819||measurement||ad||2015-11-08 19:37:21.536600@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||1
+2015-11-08 19:37:22.156486||measurement||ad||2015-11-08 19:37:21.536600@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||0||1
+2015-11-08 19:37:22.156809||measurement||loadtime||0:00:09.682722||0||1
+2015-11-08 19:37:33.455842||measurement||ad||2015-11-08 19:37:32.635358@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 19:37:33.877232||measurement||ad||2015-11-08 19:37:32.635358@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 19:37:33.877506||measurement||loadtime||0:00:06.720141||0||1
+2015-11-08 19:37:35.756007||measurement||ad||2015-11-08 19:37:15.734519@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:37:35.828520||measurement||ad||2015-11-08 19:37:15.734519@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:37:35.915575||measurement||ad||2015-11-08 19:37:15.734519@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:37:35.915873||measurement||loadtime||0:00:29.224893||3||1
+2015-11-08 19:37:44.127896||measurement||ad||2015-11-08 19:37:43.756062@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:37:44.251806||measurement||ad||2015-11-08 19:37:43.756062@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 19:37:44.717867||measurement||ad||2015-11-08 19:37:43.756062@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:37:44.718113||measurement||loadtime||0:00:05.839262||0||1
+2015-11-08 19:37:46.147818||measurement||ad||2015-11-08 19:37:45.848875@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:37:46.197277||measurement||ad||2015-11-08 19:37:45.848875@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:37:46.252404||measurement||ad||2015-11-08 19:37:45.848875@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:37:46.252584||measurement||loadtime||0:00:05.336185||3||1
+2015-11-08 19:37:50.865095||error||collecting ads||Error||2||0
+2015-11-08 19:37:56.242094||measurement||ad||2015-11-08 19:37:55.666324@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:37:56.461280||measurement||ad||2015-11-08 19:37:55.666324@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||0||1
+2015-11-08 19:37:56.620467||measurement||ad||2015-11-08 19:37:56.054093@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:37:56.747316||measurement||ad||2015-11-08 19:37:56.054093@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:37:56.762811||measurement||ad||2015-11-08 19:37:55.666324@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 19:37:56.763175||measurement||loadtime||0:00:07.043179||0||1
+2015-11-08 19:37:56.799539||measurement||ad||2015-11-08 19:37:56.054093@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:37:56.799831||measurement||loadtime||0:00:05.546157||3||1
+2015-11-08 19:38:00.498489||measurement||ad||2015-11-08 19:38:00.374148@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:38:00.590216||measurement||ad||2015-11-08 19:38:00.374148@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||2||0
+2015-11-08 19:38:00.590444||measurement||loadtime||0:00:04.724581||2||0
+2015-11-08 19:38:04.308053||error||collecting ads||Error||1||0
+2015-11-08 19:38:08.471499||measurement||ad||2015-11-08 19:38:01.939289@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:38:08.551614||measurement||ad||2015-11-08 19:38:01.939289@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:38:08.614403||measurement||ad||2015-11-08 19:38:08.447757@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:38:08.624414||measurement||ad||2015-11-08 19:38:01.939289@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:38:08.624690||measurement||loadtime||0:00:06.824463||3||1
+2015-11-08 19:38:08.679593||measurement||ad||2015-11-08 19:38:08.447757@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||0||1
+2015-11-08 19:38:08.727121||measurement||ad||2015-11-08 19:38:08.447757@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 19:38:08.727338||measurement||loadtime||0:00:06.963802||0||1
+2015-11-08 19:38:16.812686||measurement||ad||2015-11-08 19:38:16.349968@|Concealed Carry Mistakes:@|Can Do  More Concealed Carry Tips:@|The Worst Thing a Permit Holder ||1||0
+2015-11-08 19:38:16.812982||measurement||loadtime||0:00:07.504034||1||0
+2015-11-08 19:38:21.859779||measurement||ad||2015-11-08 19:38:13.864915@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:38:22.203310||measurement||ad||2015-11-08 19:38:13.864915@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 19:38:22.309055||measurement||ad||2015-11-08 19:38:22.075605@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:38:22.412570||measurement||ad||2015-11-08 19:38:22.075605@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:38:22.421113||measurement||ad||2015-11-08 19:38:13.864915@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:38:22.421429||measurement||loadtime||0:00:08.693691||0||1
+2015-11-08 19:38:22.421779||event||progress-marker||measurement-end||0||1
+2015-11-08 19:38:22.523517||measurement||ad||2015-11-08 19:38:22.075605@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||1
+2015-11-08 19:38:22.523810||measurement||loadtime||0:00:08.897765||3||1
+2015-11-08 19:38:32.184116||measurement||ad||2015-11-08 19:38:32.015333@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||0
+2015-11-08 19:38:32.305524||measurement||ad||2015-11-08 19:38:32.015333@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||2||0
+2015-11-08 19:38:32.437478||measurement||ad||2015-11-08 19:38:32.015333@|ATP Flight Training@|atpflightschool.com@|Commercial  Private Pilot Schools, Nationwide. Free Pilot Career Coach||2||0
+2015-11-08 19:38:32.437724||measurement||loadtime||0:00:26.846686||2||0
+2015-11-08 19:38:35.940832||measurement||ad||2015-11-08 19:38:35.811904@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:38:36.057734||measurement||ad||2015-11-08 19:38:35.811904@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||1||0
+2015-11-08 19:38:36.147520||measurement||ad||2015-11-08 19:38:35.811904@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:38:36.147817||measurement||loadtime||0:00:14.332751||1||0
+2015-11-08 19:38:36.255954||measurement||ad||2015-11-08 19:38:36.012867@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:38:36.311506||measurement||ad||2015-11-08 19:38:36.012867@|Alternative Oncology@|drforsythe.com/Cancer-Options@|You Do Have Options. Call Now  Schedule a Consultation.||3||1
+2015-11-08 19:38:36.363340||measurement||ad||2015-11-08 19:38:36.012867@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:38:36.363685||measurement||loadtime||0:00:08.838415||3||1
+2015-11-08 19:38:42.827063||measurement||ad||2015-11-08 19:38:42.694207@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||2||0
+2015-11-08 19:38:42.998666||measurement||ad||2015-11-08 19:38:42.694207@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||0
+2015-11-08 19:38:43.180345||measurement||ad||2015-11-08 19:38:42.694207@|ATP Flight Training@|atpflightschool.com@|Commercial  Private Pilot Schools, Nationwide. Free Pilot Career Coach||2||0
+2015-11-08 19:38:43.180706||measurement||loadtime||0:00:05.742644||2||0
+2015-11-08 19:38:53.900970||measurement||ad||2015-11-08 19:38:53.567347@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:38:54.715694||measurement||ad||2015-11-08 19:38:53.567347@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:38:54.934048||measurement||ad||2015-11-08 19:38:53.567347@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-08 19:38:54.934302||measurement||loadtime||0:00:13.786031||1||0
+2015-11-08 19:38:56.868189||measurement||ad||2015-11-08 19:38:56.294814@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 19:38:57.232593||measurement||ad||2015-11-08 19:38:56.294814@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 19:38:57.672031||measurement||ad||2015-11-08 19:38:56.294814@|Free Obituary Search@|obituaries.ancestry.com@|Find obituaries, death  cemetery records  view online now.||2||0
+2015-11-08 19:38:57.672348||measurement||loadtime||0:00:09.490798||2||0
+2015-11-08 19:39:04.765604||measurement||ad||2015-11-08 19:39:04.648599@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:39:05.049810||measurement||ad||2015-11-08 19:39:04.648599@|Business To Business@|www.hoovers.com/B2B@|85 million company listings. Reach decision makers. Free Trial.||1||0
+2015-11-08 19:39:05.050134||measurement||loadtime||0:00:05.115243||1||0
+2015-11-08 19:39:09.237738||measurement||ad||2015-11-08 19:39:08.900457@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||2||0
+2015-11-08 19:39:09.575601||measurement||ad||2015-11-08 19:39:08.900457@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||0
+2015-11-08 19:39:09.824320||measurement||ad||2015-11-08 19:39:08.900457@|ATP Flight Training@|atpflightschool.com@|Commercial  Private Pilot Schools, Nationwide. Free Pilot Career Coach||2||0
+2015-11-08 19:39:09.824592||measurement||loadtime||0:00:07.151066||2||0
+2015-11-08 19:39:16.040290||measurement||ad||2015-11-08 19:39:15.948865@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:39:16.117292||measurement||ad||2015-11-08 19:39:15.948865@|Business To Business@|www.hoovers.com/B2B@|85 million company listings. Reach decision makers. Free Trial.||1||0
+2015-11-08 19:39:16.117678||measurement||loadtime||0:00:06.065227||1||0
+2015-11-08 19:39:16.117881||event||progress-marker||measurement-end||1||0
+2015-11-08 19:39:19.097501||measurement||ad||2015-11-08 19:39:19.012716@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||2||0
+2015-11-08 19:39:19.181987||measurement||ad||2015-11-08 19:39:19.012716@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:39:19.246810||measurement||ad||2015-11-08 19:39:19.012716@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||0
+2015-11-08 19:39:19.247126||measurement||loadtime||0:00:04.421718||2||0
+2015-11-08 19:39:19.247217||event||progress-marker||measurement-end||2||0
+2015-11-08 19:40:37.682093||measurement||ad||2015-11-08 19:38:51.104201@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:41:12.611572||measurement||ad||2015-11-08 19:38:51.104201@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||3||1
+2015-11-08 19:41:45.690251||measurement||ad||2015-11-08 19:38:51.104201@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:41:45.690466||measurement||loadtime||0:03:04.326389||3||1
+2015-11-08 19:41:45.690541||event||progress-marker||measurement-end||3||1
+2015-11-08 19:41:45.997261||meta||block_id end||4
+2015-11-08 19:41:45.998395||meta||block_id start||5
+2015-11-08 19:41:45.998541||meta||assignment||0@|1@|2@|3
+2015-11-08 19:41:48.774891||event||progress-marker||training-start||0||0
+2015-11-08 19:41:48.830850||event||progress-marker||training-start||1||0
+2015-11-08 19:41:50.469398||event||progress-marker||training-start||3||1
+2015-11-08 19:41:50.601008||event||progress-marker||training-start||2||1
+2015-11-08 19:41:57.250067||treatment||visit website||http://irs.gov||0||0
+2015-11-08 19:41:59.224066||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:41:59.224619||treatment||visit website||http://irs.gov||2||1
+2015-11-08 19:41:59.859850||treatment||visit website||http://irs.gov||1||0
+2015-11-08 19:42:04.789759||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 19:42:07.851700||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:42:07.974791||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 19:42:09.031414||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 19:42:13.795507||treatment||visit website||http://pwc.com||0||0
+2015-11-08 19:42:19.595367||treatment||visit website||http://pwc.com||1||0
+2015-11-08 19:42:19.879384||treatment||visit website||http://pwc.com||2||1
+2015-11-08 19:42:20.183674||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:42:21.181618||treatment||visit website||http://ey.com||0||0
+2015-11-08 19:42:26.927146||treatment||visit website||http://ey.com||1||0
+2015-11-08 19:42:27.206656||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:42:28.818438||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 19:42:28.818696||event||progress-marker||training-end||0||0
+2015-11-08 19:42:29.298836||treatment||visit website||http://ey.com||2||1
+2015-11-08 19:42:34.516252||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:42:34.516441||event||progress-marker||training-end||3||1
+2015-11-08 19:42:34.879860||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 19:42:34.880171||event||progress-marker||training-end||1||0
+2015-11-08 19:42:36.739674||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 19:42:36.739974||event||progress-marker||training-end||2||1
+2015-11-08 19:42:38.834031||event||progress-marker||measurement-start||0||0
+2015-11-08 19:42:39.526886||event||progress-marker||measurement-start||3||1
+2015-11-08 19:42:39.893440||event||progress-marker||measurement-start||1||0
+2015-11-08 19:42:41.751803||event||progress-marker||measurement-start||2||1
+2015-11-08 19:42:59.832875||measurement||ad||2015-11-08 19:42:59.189811@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:43:00.259684||measurement||ad||2015-11-08 19:42:59.189811@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||0||0
+2015-11-08 19:43:00.579616||measurement||ad||2015-11-08 19:42:59.189811@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:43:00.579898||measurement||loadtime||0:00:16.745409||0||0
+2015-11-08 19:43:00.639960||measurement||ad||2015-11-08 19:42:59.932828@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||1
+2015-11-08 19:43:00.749463||measurement||ad||2015-11-08 19:42:59.932828@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||1
+2015-11-08 19:43:00.879717||measurement||ad||2015-11-08 19:42:59.932828@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 19:43:00.879998||measurement||loadtime||0:00:16.351527||3||1
+2015-11-08 19:43:00.931493||measurement||ad||2015-11-08 19:42:59.591207@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:43:01.524784||measurement||ad||2015-11-08 19:42:59.591207@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:43:01.801022||measurement||ad||2015-11-08 19:42:59.591207@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:43:01.801394||measurement||loadtime||0:00:15.049001||2||1
+2015-11-08 19:43:02.874919||measurement||ad||2015-11-08 19:43:02.331157@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:43:03.104172||measurement||ad||2015-11-08 19:43:02.331157@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:43:03.492940||measurement||ad||2015-11-08 19:43:02.331157@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 19:43:03.493253||measurement||loadtime||0:00:18.599285||1||0
+2015-11-08 19:43:22.494498||measurement||ad||2015-11-08 19:43:21.757804@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:43:22.916748||measurement||ad||2015-11-08 19:43:21.757804@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:43:23.457383||measurement||ad||2015-11-08 19:43:21.757804@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 19:43:23.458577||measurement||loadtime||0:00:17.878221||0||0
+2015-11-08 19:43:24.607107||measurement||ad||2015-11-08 19:43:23.954786@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:43:25.020685||measurement||ad||2015-11-08 19:43:23.954786@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 19:43:25.284925||measurement||ad||2015-11-08 19:43:23.954786@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:43:25.285209||measurement||loadtime||0:00:16.791131||1||0
+2015-11-08 19:43:25.485866||measurement||ad||2015-11-08 19:43:25.002752@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:43:25.609111||measurement||ad||2015-11-08 19:43:25.002752@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:43:25.722903||measurement||ad||2015-11-08 19:43:25.002752@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||1
+2015-11-08 19:43:25.723163||measurement||loadtime||0:00:18.920785||2||1
+2015-11-08 19:43:26.160875||measurement||ad||2015-11-08 19:43:25.526801@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:43:26.799703||measurement||ad||2015-11-08 19:43:25.526801@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:43:26.904938||measurement||ad||2015-11-08 19:43:25.526801@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:43:26.905120||measurement||loadtime||0:00:21.024399||3||1
+2015-11-08 19:43:36.805414||measurement||ad||2015-11-08 19:43:36.065299@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:43:37.416889||measurement||ad||2015-11-08 19:43:36.065299@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:43:38.635748||measurement||ad||2015-11-08 19:43:36.065299@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||0||0
+2015-11-08 19:43:38.636052||measurement||loadtime||0:00:10.176129||0||0
+2015-11-08 19:43:45.690966||measurement||ad||2015-11-08 19:43:45.154840@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:43:46.351030||measurement||ad||2015-11-08 19:43:45.154840@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 19:43:46.724165||measurement||ad||2015-11-08 19:43:45.154840@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:43:46.724502||measurement||loadtime||0:00:16.438485||1||0
+2015-11-08 19:43:51.305799||measurement||ad||2015-11-08 19:43:50.670791@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:43:51.698137||measurement||ad||2015-11-08 19:43:50.670791@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:43:52.172212||measurement||ad||2015-11-08 19:43:50.670791@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:43:52.172560||measurement||loadtime||0:00:20.266604||3||1
+2015-11-08 19:43:53.941675||measurement||ad||2015-11-08 19:43:53.005672@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:43:54.041637||measurement||ad||2015-11-08 19:43:53.005672@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:43:54.116293||measurement||ad||2015-11-08 19:43:53.005672@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:43:54.116588||measurement||loadtime||0:00:23.392906||2||1
+2015-11-08 19:43:56.415093||measurement||ad||2015-11-08 19:43:55.953303@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:43:56.621703||measurement||ad||2015-11-08 19:43:55.953303@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||0||0
+2015-11-08 19:43:56.817471||measurement||ad||2015-11-08 19:43:55.953303@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||0||0
+2015-11-08 19:43:56.817792||measurement||loadtime||0:00:13.179350||0||0
+2015-11-08 19:44:10.088766||measurement||ad||2015-11-08 19:44:08.195642@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:44:10.944268||measurement||ad||2015-11-08 19:44:08.195642@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||1
+2015-11-08 19:44:11.588352||measurement||ad||2015-11-08 19:44:08.195642@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:44:11.589680||measurement||loadtime||0:00:14.415809||3||1
+2015-11-08 19:44:11.799771||measurement||ad||2015-11-08 19:44:11.265950@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:44:12.010301||measurement||ad||2015-11-08 19:44:11.265950@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:44:12.230112||measurement||ad||2015-11-08 19:44:11.265950@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:44:12.230352||measurement||loadtime||0:00:10.411693||0||0
+2015-11-08 19:44:13.196416||measurement||ad||2015-11-08 19:44:13.017798@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:44:13.418760||measurement||ad||2015-11-08 19:44:13.017798@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:44:13.517273||measurement||ad||2015-11-08 19:44:13.017798@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:44:13.517531||measurement||loadtime||0:00:14.400325||2||1
+2015-11-08 19:44:19.019834||measurement||ad||2015-11-08 19:44:18.882434@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:44:19.146279||measurement||ad||2015-11-08 19:44:18.882434@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 19:44:19.305140||measurement||ad||2015-11-08 19:44:18.882434@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 19:44:19.305828||measurement||loadtime||0:00:27.580656||1||0
+2015-11-08 19:44:24.285998||measurement||ad||2015-11-08 19:44:16.666749@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:44:24.660126||measurement||ad||2015-11-08 19:44:16.666749@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:44:25.092962||measurement||ad||2015-11-08 19:44:16.666749@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:44:25.093205||measurement||loadtime||0:00:08.501907||3||1
+2015-11-08 19:44:25.716482||measurement||ad||2015-11-08 19:44:25.408060@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:44:25.807853||measurement||ad||2015-11-08 19:44:25.408060@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:44:25.912452||measurement||ad||2015-11-08 19:44:25.408060@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:44:25.912730||measurement||loadtime||0:00:07.393872||2||1
+2015-11-08 19:44:36.764032||measurement||ad||2015-11-08 19:44:36.572309@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:44:36.874614||measurement||ad||2015-11-08 19:44:36.572309@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:44:37.078013||measurement||ad||2015-11-08 19:44:36.572309@|Top 10 Cable Tv@|2015prices.com/Cable-Tv@|2015 Hot Deals on Cable Tv. Find Lowest Possible Prices!||3||1
+2015-11-08 19:44:37.079144||measurement||loadtime||0:00:06.983777||3||1
+2015-11-08 19:44:37.594839||measurement||ad||2015-11-08 19:44:37.126629@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:44:37.752715||measurement||ad||2015-11-08 19:44:37.126629@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:44:37.891384||measurement||ad||2015-11-08 19:44:37.126629@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:44:37.891603||measurement||loadtime||0:00:06.977989||2||1
+2015-11-08 19:44:41.271371||measurement||ad||2015-11-08 19:44:40.793632@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:44:41.379595||measurement||ad||2015-11-08 19:44:40.793632@|Fast Business Loans@|listscoop.com/BusinessLoan@|Fast  Easy Processes for Small Business Loans. Apply Online Now!||0||0
+2015-11-08 19:44:41.455050||measurement||ad||2015-11-08 19:44:40.793632@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 19:44:41.455314||measurement||loadtime||0:00:24.220389||0||0
+2015-11-08 19:44:50.562717||measurement||ad||2015-11-08 19:44:50.134280@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:44:51.016814||measurement||ad||2015-11-08 19:44:50.134280@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:44:51.233492||measurement||ad||2015-11-08 19:44:50.134280@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:44:51.233838||measurement||loadtime||0:00:08.341883||2||1
+2015-11-08 19:44:51.296546||measurement||ad||2015-11-08 19:44:49.309537@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:44:51.465532||measurement||ad||2015-11-08 19:44:49.309537@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||1
+2015-11-08 19:44:51.598085||measurement||ad||2015-11-08 19:44:49.309537@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:44:51.598360||measurement||loadtime||0:00:09.518278||3||1
+2015-11-08 19:44:53.447818||measurement||ad||2015-11-08 19:44:53.317784@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:44:53.574674||measurement||ad||2015-11-08 19:44:53.317784@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:44:53.707847||measurement||ad||2015-11-08 19:44:53.317784@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:44:53.708089||measurement||loadtime||0:00:07.251974||0||0
+2015-11-08 19:45:04.307204||measurement||ad||2015-11-08 19:45:03.758414@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:45:04.454250||measurement||ad||2015-11-08 19:45:03.758414@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:45:04.604052||measurement||ad||2015-11-08 19:45:03.758414@|Top 10 Cable Tv@|2015prices.com/Cable-Tv@|2015 Hot Deals on Cable Tv. Find Lowest Possible Prices!||3||1
+2015-11-08 19:45:04.604399||measurement||loadtime||0:00:08.005633||3||1
+2015-11-08 19:45:07.542212||measurement||ad||2015-11-08 19:45:06.370230@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 19:45:07.782534||measurement||ad||2015-11-08 19:45:05.503077@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:45:07.931028||measurement||ad||2015-11-08 19:45:05.503077@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:45:07.942562||measurement||ad||2015-11-08 19:45:06.370230@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||0||0
+2015-11-08 19:45:08.095663||measurement||ad||2015-11-08 19:45:05.503077@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:45:08.096732||measurement||loadtime||0:00:11.860700||2||1
+2015-11-08 19:45:08.184174||measurement||ad||2015-11-08 19:45:06.370230@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:45:08.185231||measurement||loadtime||0:00:09.475154||0||0
+2015-11-08 19:45:21.423679||measurement||ad||2015-11-08 19:45:21.018231@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:45:21.597114||measurement||ad||2015-11-08 19:45:21.018231@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:45:21.829245||measurement||ad||2015-11-08 19:45:21.018231@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:45:21.829712||measurement||loadtime||0:00:08.732629||2||1
+2015-11-08 19:45:24.377977||error||collecting ads||Error||1||0
+2015-11-08 19:45:35.212519||measurement||ad||2015-11-08 19:45:34.653237@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:45:35.385598||measurement||ad||2015-11-08 19:45:34.653237@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||1
+2015-11-08 19:45:35.453394||measurement||ad||2015-11-08 19:45:34.653237@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:45:35.453652||measurement||loadtime||0:00:08.622945||2||1
+2015-11-08 19:45:35.454003||event||progress-marker||measurement-end||2||1
+2015-11-08 19:45:41.696476||measurement||ad||2015-11-08 19:45:41.586897@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:45:41.785853||measurement||ad||2015-11-08 19:45:41.586897@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||1||0
+2015-11-08 19:45:41.786131||measurement||loadtime||0:00:12.407526||1||0
+2015-11-08 19:45:50.395795||measurement||ad||2015-11-08 19:45:50.309226@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:45:50.475747||measurement||ad||2015-11-08 19:45:50.309226@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 19:45:50.543174||measurement||ad||2015-11-08 19:45:50.309226@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:45:50.543402||measurement||loadtime||0:00:03.756728||1||0
+2015-11-08 19:46:00.070833||measurement||ad||2015-11-08 19:45:59.949197@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:46:00.192011||measurement||ad||2015-11-08 19:45:59.949197@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 19:46:00.321892||measurement||ad||2015-11-08 19:45:59.949197@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 19:46:00.322206||measurement||loadtime||0:00:04.778126||1||0
+2015-11-08 19:46:09.684244||measurement||ad||2015-11-08 19:46:09.589617@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:46:09.773412||measurement||ad||2015-11-08 19:46:09.589617@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 19:46:09.846593||measurement||ad||2015-11-08 19:46:09.589617@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:46:09.846806||measurement||loadtime||0:00:04.522707||1||0
+2015-11-08 19:46:13.267088||error||collecting ads||Error||0||0
+2015-11-08 19:46:20.319065||measurement||ad||2015-11-08 19:46:20.166016@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:46:20.420696||measurement||ad||2015-11-08 19:46:20.166016@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 19:46:20.581197||measurement||ad||2015-11-08 19:46:20.166016@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 19:46:20.581502||measurement||loadtime||0:00:05.733299||1||0
+2015-11-08 19:46:20.581733||event||progress-marker||measurement-end||1||0
+2015-11-08 19:46:24.119062||measurement||ad||2015-11-08 19:46:24.016967@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:46:24.200654||measurement||ad||2015-11-08 19:46:24.016967@|Fast Business Loans@|listscoop.com/BusinessLoan@|Fast  Easy Processes for Small Business Loans. Apply Online Now!||0||0
+2015-11-08 19:46:24.279490||measurement||ad||2015-11-08 19:46:24.016967@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||0||0
+2015-11-08 19:46:24.279694||measurement||loadtime||0:00:06.012069||0||0
+2015-11-08 19:46:24.279837||event||progress-marker||measurement-end||0||0
+2015-11-08 19:46:38.409219||measurement||ad||2015-11-08 19:45:20.490265@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-08 19:46:38.443742||measurement||ad||2015-11-08 19:45:20.490265@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||1
+2015-11-08 19:46:38.476108||measurement||ad||2015-11-08 19:45:20.490265@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 19:46:38.476365||measurement||loadtime||0:01:28.870658||3||1
+2015-11-08 19:46:47.394379||measurement||ad||2015-11-08 19:46:47.282896@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:46:47.435798||measurement||ad||2015-11-08 19:46:47.282896@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:46:47.475132||measurement||ad||2015-11-08 19:46:47.282896@|Top 10 Cable Tv@|2015prices.com/Cable-Tv@|2015 Hot Deals on Cable Tv. Find Lowest Possible Prices!||3||1
+2015-11-08 19:46:47.475349||measurement||loadtime||0:00:03.998231||3||1
+2015-11-08 19:46:47.475529||event||progress-marker||measurement-end||3||1
+2015-11-08 19:46:47.834203||meta||block_id end||5
+2015-11-08 19:46:47.836037||meta||block_id start||6
+2015-11-08 19:46:47.836080||meta||assignment||1@|3@|2@|0
+2015-11-08 19:46:50.646307||event||progress-marker||training-start||3||0
+2015-11-08 19:46:50.662735||event||progress-marker||training-start||1||0
+2015-11-08 19:46:52.287394||event||progress-marker||training-start||0||1
+2015-11-08 19:46:52.417160||event||progress-marker||training-start||2||1
+2015-11-08 19:46:58.899864||treatment||visit website||http://irs.gov||1||0
+2015-11-08 19:47:00.158413||treatment||visit website||http://irs.gov||3||0
+2015-11-08 19:47:00.300917||treatment||visit website||http://irs.gov||0||1
+2015-11-08 19:47:00.360679||treatment||visit website||http://irs.gov||2||1
+2015-11-08 19:47:06.824551||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 19:47:08.708084||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 19:47:09.410504||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 19:47:09.422812||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 19:47:17.454078||treatment||visit website||http://pwc.com||1||0
+2015-11-08 19:47:19.776686||treatment||visit website||http://pwc.com||3||0
+2015-11-08 19:47:21.001909||treatment||visit website||http://pwc.com||0||1
+2015-11-08 19:47:21.197376||treatment||visit website||http://pwc.com||2||1
+2015-11-08 19:47:23.824437||treatment||visit website||http://ey.com||1||0
+2015-11-08 19:47:27.169057||treatment||visit website||http://ey.com||3||0
+2015-11-08 19:47:28.602707||treatment||visit website||http://ey.com||2||1
+2015-11-08 19:47:28.679930||treatment||visit website||http://ey.com||0||1
+2015-11-08 19:47:31.277752||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 19:47:31.278276||event||progress-marker||training-end||1||0
+2015-11-08 19:47:36.149097||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 19:47:36.149310||event||progress-marker||training-end||3||0
+2015-11-08 19:47:36.796244||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 19:47:36.796486||event||progress-marker||training-end||2||1
+2015-11-08 19:47:37.430633||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 19:47:37.431253||event||progress-marker||training-end||0||1
+2015-11-08 19:47:41.161233||event||progress-marker||measurement-start||3||0
+2015-11-08 19:47:41.299562||event||progress-marker||measurement-start||1||0
+2015-11-08 19:47:41.808963||event||progress-marker||measurement-start||2||1
+2015-11-08 19:47:42.445206||event||progress-marker||measurement-start||0||1
+2015-11-08 19:47:56.855925||measurement||ad||2015-11-08 19:47:56.621234@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 19:47:57.173788||measurement||ad||2015-11-08 19:47:56.621234@|Login To Your Email Now@|email.loginfaster.com/new@|One-Click Access To All Your Email! Download Free App  Login Now.||3||0
+2015-11-08 19:47:57.399376||measurement||ad||2015-11-08 19:47:56.621234@|3.9 to 12.8% Annuity Rate@|advisorworld.com/CompareAnnuities@|How Much In Monthly Income Can You‎ Receive?State Specific Rates Here.‎||3||0
+2015-11-08 19:47:57.399670||measurement||loadtime||0:00:11.236968||3||0
+2015-11-08 19:47:58.730602||measurement||ad||2015-11-08 19:47:58.250572@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:47:58.934686||measurement||ad||2015-11-08 19:47:58.250572@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:47:59.401194||measurement||ad||2015-11-08 19:47:58.250572@|Submit Your Proposal@|thesocialsciences.com/@|Interdisciplinary Social Sciences Local Conference Rates Available!||1||0
+2015-11-08 19:47:59.401517||measurement||loadtime||0:00:13.101523||1||0
+2015-11-08 19:47:59.660971||measurement||ad||2015-11-08 19:47:59.144324@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:47:59.735624||measurement||ad||2015-11-08 19:47:59.144324@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 19:47:59.813264||measurement||ad||2015-11-08 19:47:59.144324@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:47:59.814479||measurement||loadtime||0:00:12.367732||0||1
+2015-11-08 19:48:01.072976||measurement||ad||2015-11-08 19:48:00.293391@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:48:01.181072||measurement||ad||2015-11-08 19:48:00.293391@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||1
+2015-11-08 19:48:01.267665||measurement||ad||2015-11-08 19:48:00.293391@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:48:01.268032||measurement||loadtime||0:00:14.457704||2||1
+2015-11-08 19:48:15.202107||measurement||ad||2015-11-08 19:48:14.731031@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:48:15.804566||measurement||ad||2015-11-08 19:48:14.731031@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 19:48:16.037275||measurement||ad||2015-11-08 19:48:14.731031@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||0
+2015-11-08 19:48:16.037544||measurement||loadtime||0:00:13.637013||3||0
+2015-11-08 19:48:16.486971||measurement||ad||2015-11-08 19:48:16.218437@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:48:16.626975||measurement||ad||2015-11-08 19:48:16.218437@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:48:16.699420||measurement||ad||2015-11-08 19:48:16.218437@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:48:16.699715||measurement||loadtime||0:00:11.884240||0||1
+2015-11-08 19:48:17.486982||measurement||ad||2015-11-08 19:48:17.150005@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:48:17.752512||measurement||ad||2015-11-08 19:48:17.150005@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:48:17.991494||measurement||ad||2015-11-08 19:48:17.150005@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||1||0
+2015-11-08 19:48:17.991766||measurement||loadtime||0:00:13.588794||1||0
+2015-11-08 19:48:18.108251||measurement||ad||2015-11-08 19:48:17.855467@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 19:48:18.197919||measurement||ad||2015-11-08 19:48:17.855467@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:48:18.322597||measurement||ad||2015-11-08 19:48:17.855467@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-08 19:48:18.322961||measurement||loadtime||0:00:12.053302||2||1
+2015-11-08 19:48:34.771464||measurement||ad||2015-11-08 19:48:34.101059@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:48:35.252108||measurement||ad||2015-11-08 19:48:34.101059@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:48:35.538311||measurement||ad||2015-11-08 19:48:34.101059@|Submit Your Proposal@|thesocialsciences.com/@|Interdisciplinary Social Sciences Local Conference Rates Available!||1||0
+2015-11-08 19:48:35.538753||measurement||loadtime||0:00:12.546378||1||0
+2015-11-08 19:48:43.956322||measurement||ad||2015-11-08 19:48:43.039258@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:48:44.418048||measurement||ad||2015-11-08 19:48:43.039258@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 19:48:44.855730||measurement||ad||2015-11-08 19:48:43.039258@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:48:44.856057||measurement||loadtime||0:00:21.531809||2||1
+2015-11-08 19:48:44.974778||measurement||ad||2015-11-08 19:48:42.608023@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:48:45.928058||measurement||ad||2015-11-08 19:48:42.608023@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:48:46.578295||measurement||ad||2015-11-08 19:48:42.608023@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-08 19:48:46.578928||measurement||loadtime||0:00:24.878155||0||1
+2015-11-08 19:48:50.479802||measurement||ad||2015-11-08 19:48:49.964188@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:48:50.914259||measurement||ad||2015-11-08 19:48:49.964188@|Submit Your Proposal@|thesocialsciences.com/@|Interdisciplinary Social Sciences Local Conference Rates Available!||1||0
+2015-11-08 19:48:51.334204||measurement||ad||2015-11-08 19:48:49.964188@|Environmental Analysis MS@|www.profms.rice.edu/Environmental@|Our Degrees Combine Science with Business Training  Internship.||1||0
+2015-11-08 19:48:51.334972||measurement||loadtime||0:00:10.795505||1||0
+2015-11-08 19:49:03.145937||measurement||ad||2015-11-08 19:49:02.536312@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:49:03.468381||measurement||ad||2015-11-08 19:49:02.958934@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:49:03.509676||measurement||ad||2015-11-08 19:49:02.536312@|Submit Your Proposal@|thesocialsciences.com/@|Interdisciplinary Social Sciences Local Conference Rates Available!||1||0
+2015-11-08 19:49:03.607767||measurement||ad||2015-11-08 19:49:02.958934@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:49:03.700897||measurement||ad||2015-11-08 19:49:02.536312@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:49:03.701188||measurement||loadtime||0:00:07.365311||1||0
+2015-11-08 19:49:03.878188||measurement||ad||2015-11-08 19:49:02.958934@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-08 19:49:03.879550||measurement||loadtime||0:00:12.299429||0||1
+2015-11-08 19:49:14.665623||measurement||ad||2015-11-08 19:49:14.381987@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:49:14.861974||measurement||ad||2015-11-08 19:49:14.381987@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:49:14.949197||measurement||ad||2015-11-08 19:49:14.381987@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 19:49:14.949693||measurement||loadtime||0:00:25.093185||2||1
+2015-11-08 19:49:15.699629||measurement||ad||2015-11-08 19:49:15.370878@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:49:15.953276||measurement||ad||2015-11-08 19:49:15.370878@|Submit Your Proposal@|thesocialsciences.com/@|Interdisciplinary Social Sciences Local Conference Rates Available!||1||0
+2015-11-08 19:49:16.205333||measurement||ad||2015-11-08 19:49:15.370878@|Environmental Analysis MS@|www.profms.rice.edu/Environmental@|Our Degrees Combine Science with Business Training  Internship.||1||0
+2015-11-08 19:49:16.205617||measurement||loadtime||0:00:07.503112||1||0
+2015-11-08 19:49:16.637934||measurement||ad||2015-11-08 19:49:16.488479@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:49:16.726219||measurement||ad||2015-11-08 19:49:16.488479@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:49:16.812263||measurement||ad||2015-11-08 19:49:16.488479@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:49:16.812555||measurement||loadtime||0:00:07.925810||0||1
+2015-11-08 19:49:21.164863||error||collecting ads||Error||3||0
+2015-11-08 19:49:29.356780||measurement||ad||2015-11-08 19:49:29.029848@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:49:29.674162||measurement||ad||2015-11-08 19:49:29.029848@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 19:49:29.837796||measurement||ad||2015-11-08 19:49:29.029848@|B-to-B Marketing@|www.mediaoptimize.it@|Uncover the media channels that will optimize your B-to-B marketing||1||0
+2015-11-08 19:49:29.838112||measurement||loadtime||0:00:08.631375||1||0
+2015-11-08 19:49:32.974077||measurement||ad||2015-11-08 19:49:30.531853@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:49:33.995987||measurement||ad||2015-11-08 19:49:30.531853@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:49:34.486340||measurement||ad||2015-11-08 19:49:30.531853@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:49:34.486618||measurement||loadtime||0:00:14.535657||2||1
+2015-11-08 19:49:36.230995||measurement||ad||2015-11-08 19:49:34.628310@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:49:37.651694||measurement||ad||2015-11-08 19:49:34.628310@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 19:49:37.916992||measurement||ad||2015-11-08 19:49:37.360348@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:49:38.030170||measurement||ad||2015-11-08 19:49:34.628310@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-08 19:49:38.030446||measurement||loadtime||0:00:16.217449||0||1
+2015-11-08 19:49:38.383601||measurement||ad||2015-11-08 19:49:37.360348@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 19:49:38.750552||measurement||ad||2015-11-08 19:49:37.360348@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:49:38.750897||measurement||loadtime||0:00:12.584985||3||0
+2015-11-08 19:49:52.340919||measurement||ad||2015-11-08 19:49:52.119694@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 19:49:52.761265||measurement||ad||2015-11-08 19:49:52.119694@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||1
+2015-11-08 19:49:52.875217||measurement||ad||2015-11-08 19:49:52.119694@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:49:52.875498||measurement||loadtime||0:00:13.387497||2||1
+2015-11-08 19:49:54.405472||measurement||ad||2015-11-08 19:49:43.592319@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:49:54.623128||measurement||ad||2015-11-08 19:49:43.592319@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 19:49:54.777507||measurement||ad||2015-11-08 19:49:43.592319@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:49:54.777780||measurement||loadtime||0:00:11.744622||0||1
+2015-11-08 19:49:56.218507||measurement||ad||2015-11-08 19:49:55.974563@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 19:49:56.845206||measurement||ad||2015-11-08 19:49:55.974563@|Login To Your Email Now@|email.loginfaster.com/new@|One-Click Access To All Your Email! Download Free App  Login Now.||3||0
+2015-11-08 19:49:57.113341||measurement||ad||2015-11-08 19:49:55.974563@|15% Annuity Return@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||0
+2015-11-08 19:49:57.113635||measurement||loadtime||0:00:13.359935||3||0
+2015-11-08 19:50:07.017535||measurement||ad||2015-11-08 19:50:06.535403@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:50:07.114029||measurement||ad||2015-11-08 19:50:06.535403@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||1
+2015-11-08 19:50:07.190180||measurement||ad||2015-11-08 19:50:06.535403@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:50:07.190462||measurement||loadtime||0:00:09.313689||2||1
+2015-11-08 19:50:07.937582||measurement||ad||2015-11-08 19:50:07.173636@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:50:08.126453||measurement||ad||2015-11-08 19:50:07.173636@|16 Biggest Dogs Ever@|pressroomvip.com/16-Biggest-Dogs@|See the Biggest Dogs of All Time! You'll Never Believe #6.||0||1
+2015-11-08 19:50:08.227951||measurement||ad||2015-11-08 19:50:08.055604@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:50:08.252214||measurement||ad||2015-11-08 19:50:07.173636@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:50:08.252527||measurement||loadtime||0:00:08.473660||0||1
+2015-11-08 19:50:08.343988||measurement||ad||2015-11-08 19:50:08.055604@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 19:50:08.438025||measurement||ad||2015-11-08 19:50:08.055604@|Don’t Buy an Annuity@|www.seniorannuityalert.com@|Until You Watch This Video Report! Top Annuity Flaws - Warning.||3||0
+2015-11-08 19:50:08.438391||measurement||loadtime||0:00:06.323064||3||0
+2015-11-08 19:50:19.781056||measurement||ad||2015-11-08 19:50:19.258992@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:50:20.066688||measurement||ad||2015-11-08 19:50:19.258992@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 19:50:20.406026||measurement||ad||2015-11-08 19:50:19.258992@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:50:20.406292||measurement||loadtime||0:00:06.966602||3||0
+2015-11-08 19:50:20.887522||measurement||ad||2015-11-08 19:50:19.346833@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 19:50:21.892069||measurement||ad||2015-11-08 19:50:19.346833@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 19:50:22.215865||measurement||ad||2015-11-08 19:50:19.346833@|How to Invest in Graphene@|moneymorningresearch.com/@|1 atom thick, graphene is easily the most valuable resource on earth||2||1
+2015-11-08 19:50:22.216101||measurement||loadtime||0:00:10.024207||2||1
+2015-11-08 19:50:24.245052||measurement||ad||2015-11-08 19:50:23.073975@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:50:24.380029||measurement||ad||2015-11-08 19:50:23.073975@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:50:24.550452||measurement||ad||2015-11-08 19:50:23.073975@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:50:24.550748||measurement||loadtime||0:00:11.296639||0||1
+2015-11-08 19:50:31.297527||measurement||ad||2015-11-08 19:50:31.069704@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:50:31.446820||measurement||ad||2015-11-08 19:50:31.069704@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 19:50:31.594891||measurement||ad||2015-11-08 19:50:31.069704@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 19:50:31.595175||measurement||loadtime||0:00:06.187985||3||0
+2015-11-08 19:50:34.837409||measurement||ad||2015-11-08 19:50:34.690735@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:50:34.937150||measurement||ad||2015-11-08 19:50:34.690735@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||1
+2015-11-08 19:50:35.067636||measurement||ad||2015-11-08 19:50:34.690735@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-08 19:50:35.068870||measurement||loadtime||0:00:05.516723||0||1
+2015-11-08 19:50:35.069347||event||progress-marker||measurement-end||0||1
+2015-11-08 19:50:36.217406||error||collecting ads||Error||1||0
+2015-11-08 19:50:40.682653||measurement||ad||2015-11-08 19:50:40.531102@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:50:40.830617||measurement||ad||2015-11-08 19:50:40.531102@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 19:50:40.964032||measurement||ad||2015-11-08 19:50:40.531102@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||0
+2015-11-08 19:50:40.964332||measurement||loadtime||0:00:04.368413||3||0
+2015-11-08 19:50:47.646874||measurement||ad||2015-11-08 19:50:47.386367@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:50:47.955243||measurement||ad||2015-11-08 19:50:47.386367@|Submit Your Proposal@|thesocialsciences.com/@|Interdisciplinary Social Sciences Local Conference Rates Available!||1||0
+2015-11-08 19:50:48.206173||measurement||ad||2015-11-08 19:50:47.386367@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 19:50:48.206480||measurement||loadtime||0:00:06.987797||1||0
+2015-11-08 19:50:52.973439||measurement||ad||2015-11-08 19:50:52.700967@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 19:50:53.289519||measurement||ad||2015-11-08 19:50:52.700967@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 19:50:53.740531||measurement||ad||2015-11-08 19:50:52.700967@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||0
+2015-11-08 19:50:53.740824||measurement||loadtime||0:00:07.774809||3||0
+2015-11-08 19:50:53.741638||event||progress-marker||measurement-end||3||0
+2015-11-08 19:50:58.319543||measurement||ad||2015-11-08 19:50:58.182774@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:50:58.418988||measurement||ad||2015-11-08 19:50:58.182774@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:50:58.524663||measurement||ad||2015-11-08 19:50:58.182774@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||1||0
+2015-11-08 19:50:58.524907||measurement||loadtime||0:00:05.317970||1||0
+2015-11-08 19:50:58.525553||event||progress-marker||measurement-end||1||0
+2015-11-08 19:51:50.810042||measurement||ad||2015-11-08 19:50:33.653366@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:51:50.869488||measurement||ad||2015-11-08 19:50:33.653366@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||1
+2015-11-08 19:51:50.924771||measurement||ad||2015-11-08 19:50:33.653366@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||2||1
+2015-11-08 19:51:50.925104||measurement||loadtime||0:01:23.707796||2||1
+2015-11-08 19:52:05.076386||measurement||ad||2015-11-08 19:52:04.691125@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:52:05.115654||measurement||ad||2015-11-08 19:52:04.691125@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||1
+2015-11-08 19:52:05.151803||measurement||ad||2015-11-08 19:52:04.691125@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||2||1
+2015-11-08 19:52:05.152100||measurement||loadtime||0:00:09.226589||2||1
+2015-11-08 19:52:05.152252||event||progress-marker||measurement-end||2||1
+2015-11-08 19:52:05.500396||meta||block_id end||6
+2015-11-08 19:52:05.502495||meta||block_id start||7
+2015-11-08 19:52:05.502535||meta||assignment||2@|1@|0@|3
+2015-11-08 19:52:08.198012||event||progress-marker||training-start||2||0
+2015-11-08 19:52:08.357509||event||progress-marker||training-start||1||0
+2015-11-08 19:52:09.906540||event||progress-marker||training-start||0||1
+2015-11-08 19:52:09.978545||event||progress-marker||training-start||3||1
+2015-11-08 19:52:17.191344||treatment||visit website||http://irs.gov||2||0
+2015-11-08 19:52:17.511147||treatment||visit website||http://irs.gov||1||0
+2015-11-08 19:52:18.021551||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:52:18.121492||treatment||visit website||http://irs.gov||0||1
+2015-11-08 19:52:25.304811||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 19:52:27.113663||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 19:52:27.221075||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:52:27.314922||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 19:52:36.796886||treatment||visit website||http://pwc.com||2||0
+2015-11-08 19:52:38.244999||treatment||visit website||http://pwc.com||1||0
+2015-11-08 19:52:39.075321||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:52:39.284913||treatment||visit website||http://pwc.com||0||1
+2015-11-08 19:52:43.834431||treatment||visit website||http://ey.com||2||0
+2015-11-08 19:52:45.882674||treatment||visit website||http://ey.com||1||0
+2015-11-08 19:52:46.699384||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:52:47.083671||treatment||visit website||http://ey.com||0||1
+2015-11-08 19:52:51.306676||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 19:52:51.306949||event||progress-marker||training-end||2||0
+2015-11-08 19:52:53.909475||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 19:52:53.909733||event||progress-marker||training-end||1||0
+2015-11-08 19:52:54.673051||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:52:54.673599||event||progress-marker||training-end||3||1
+2015-11-08 19:52:54.830661||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 19:52:54.830925||event||progress-marker||training-end||0||1
+2015-11-08 19:52:56.323375||event||progress-marker||measurement-start||2||0
+2015-11-08 19:52:58.921126||event||progress-marker||measurement-start||1||0
+2015-11-08 19:52:59.687568||event||progress-marker||measurement-start||3||1
+2015-11-08 19:52:59.845768||event||progress-marker||measurement-start||0||1
+2015-11-08 19:53:14.277183||measurement||ad||2015-11-08 19:53:14.027779@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:53:14.491999||measurement||ad||2015-11-08 19:53:14.027779@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 19:53:14.668513||measurement||ad||2015-11-08 19:53:14.027779@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:53:14.669644||measurement||loadtime||0:00:13.345195||2||0
+2015-11-08 19:53:17.237650||measurement||ad||2015-11-08 19:53:16.946433@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:53:17.703556||measurement||ad||2015-11-08 19:53:16.946433@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:53:17.941790||measurement||ad||2015-11-08 19:53:16.946433@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:53:17.942392||measurement||loadtime||0:00:14.019824||1||0
+2015-11-08 19:53:18.102424||measurement||ad||2015-11-08 19:53:17.463239@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||1
+2015-11-08 19:53:18.220409||measurement||ad||2015-11-08 19:53:17.463239@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-08 19:53:18.386055||measurement||ad||2015-11-08 19:53:17.463239@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 19:53:18.387079||measurement||loadtime||0:00:13.540088||0||1
+2015-11-08 19:53:19.367734||measurement||ad||2015-11-08 19:53:19.058228@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:53:19.429052||measurement||ad||2015-11-08 19:53:19.058228@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:53:19.650056||measurement||ad||2015-11-08 19:53:19.058228@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:53:19.650310||measurement||loadtime||0:00:14.961301||3||1
+2015-11-08 19:53:28.578046||measurement||ad||2015-11-08 19:53:28.003432@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:53:29.070555||measurement||ad||2015-11-08 19:53:28.003432@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-08 19:53:29.416865||measurement||ad||2015-11-08 19:53:28.003432@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:53:29.417200||measurement||loadtime||0:00:09.747103||2||0
+2015-11-08 19:53:34.149512||measurement||ad||2015-11-08 19:53:33.774209@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-08 19:53:34.302822||measurement||ad||2015-11-08 19:53:33.774209@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:53:34.303083||measurement||loadtime||0:00:10.914840||0||1
+2015-11-08 19:53:35.686762||measurement||ad||2015-11-08 19:53:35.187704@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:53:35.763453||measurement||ad||2015-11-08 19:53:35.187704@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:53:35.851821||measurement||ad||2015-11-08 19:53:35.187704@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:53:35.852214||measurement||loadtime||0:00:11.201396||3||1
+2015-11-08 19:53:41.604323||measurement||ad||2015-11-08 19:53:41.436839@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:53:41.799516||measurement||ad||2015-11-08 19:53:41.436839@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 19:53:42.001271||measurement||ad||2015-11-08 19:53:41.436839@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 19:53:42.001520||measurement||loadtime||0:00:07.583271||2||0
+2015-11-08 19:53:50.361488||measurement||ad||2015-11-08 19:53:49.900672@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:53:50.508196||measurement||ad||2015-11-08 19:53:49.900672@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:53:50.761901||measurement||ad||2015-11-08 19:53:49.900672@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:53:50.762173||measurement||loadtime||0:00:09.909158||3||1
+2015-11-08 19:53:50.910100||measurement||ad||2015-11-08 19:53:50.606930@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-08 19:53:51.051611||measurement||ad||2015-11-08 19:53:50.606930@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:53:51.051872||measurement||loadtime||0:00:11.748416||0||1
+2015-11-08 19:54:01.639525||measurement||ad||2015-11-08 19:54:01.443190@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:54:01.700570||measurement||ad||2015-11-08 19:54:01.443190@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:54:01.789862||measurement||ad||2015-11-08 19:54:01.443190@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:54:01.790136||measurement||loadtime||0:00:06.027495||3||1
+2015-11-08 19:54:01.991396||measurement||ad||2015-11-08 19:54:01.904215@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:54:02.051454||measurement||ad||2015-11-08 19:54:01.904215@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:54:02.266815||measurement||ad||2015-11-08 19:54:01.904215@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 19:54:02.267309||measurement||loadtime||0:00:06.214144||0||1
+2015-11-08 19:54:22.976757||measurement||ad||2015-11-08 19:54:22.878914@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:54:23.016884||error||collecting ads||Error||1||0
+2015-11-08 19:54:23.051479||measurement||ad||2015-11-08 19:54:22.878914@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:54:23.113797||measurement||ad||2015-11-08 19:54:22.878914@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:54:23.114097||measurement||loadtime||0:00:16.323477||3||1
+2015-11-08 19:54:30.761317||measurement||ad||2015-11-08 19:54:30.183221@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||1
+2015-11-08 19:54:31.078683||measurement||ad||2015-11-08 19:54:30.183221@|Cute Plus Size Clothing@|www.zulily.com/womens-plus@|Up to 70% Off Women's Plus Size Clothing. Sign Up and Shop Now!||0||1
+2015-11-08 19:54:31.079047||measurement||loadtime||0:00:23.810320||0||1
+2015-11-08 19:54:33.944656||measurement||ad||2015-11-08 19:54:33.792176@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:54:34.077589||measurement||ad||2015-11-08 19:54:33.792176@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:54:34.200323||measurement||ad||2015-11-08 19:54:33.792176@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:54:34.200664||measurement||loadtime||0:00:06.182907||1||0
+2015-11-08 19:54:36.798549||measurement||ad||2015-11-08 19:54:36.501907@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:54:37.128126||measurement||ad||2015-11-08 19:54:36.501907@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:54:37.786537||measurement||ad||2015-11-08 19:54:36.501907@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||3||1
+2015-11-08 19:54:37.786809||measurement||loadtime||0:00:09.671548||3||1
+2015-11-08 19:54:43.401334||measurement||ad||2015-11-08 19:54:43.260665@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 19:54:43.401817||measurement||loadtime||0:00:07.321435||0||1
+2015-11-08 19:54:47.129483||error||collecting ads||Error||2||0
+2015-11-08 19:54:47.690043||measurement||ad||2015-11-08 19:54:47.477024@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:54:47.837737||measurement||ad||2015-11-08 19:54:47.477024@|Free EBT Cell Phone@|qlinkwireless.com/Free-Cell-Phone@|EBT Recipients Get a Free Phone. 1000 Texts / 250 Mins, Get It Now!||1||0
+2015-11-08 19:54:47.956146||measurement||ad||2015-11-08 19:54:47.477024@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:54:47.956500||measurement||loadtime||0:00:08.754663||1||0
+2015-11-08 19:54:49.718675||measurement||ad||2015-11-08 19:54:49.292307@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:54:49.856947||measurement||ad||2015-11-08 19:54:49.292307@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:54:49.939793||measurement||ad||2015-11-08 19:54:49.292307@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:54:49.940076||measurement||loadtime||0:00:07.151999||3||1
+2015-11-08 19:54:57.587406||measurement||ad||2015-11-08 19:54:56.362257@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 19:54:57.588330||measurement||loadtime||0:00:09.185094||0||1
+2015-11-08 19:55:00.107285||measurement||ad||2015-11-08 19:54:59.967665@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:55:00.228517||measurement||ad||2015-11-08 19:54:59.967665@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||2||0
+2015-11-08 19:55:00.389509||measurement||ad||2015-11-08 19:54:59.967665@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 19:55:00.389949||measurement||loadtime||0:00:08.259074||2||0
+2015-11-08 19:55:01.229127||measurement||ad||2015-11-08 19:55:01.053392@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:55:01.323110||measurement||ad||2015-11-08 19:55:01.053392@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:55:01.438621||measurement||ad||2015-11-08 19:55:01.053392@|Audio Video Specialists@|www.cmsav.com@|AV Planning, Designing, Engineering And Consulting for Over 20 Years||1||0
+2015-11-08 19:55:01.438929||measurement||loadtime||0:00:08.480697||1||0
+2015-11-08 19:55:12.582691||measurement||ad||2015-11-08 19:55:12.382764@|The "Ultimate Currency"?@|www.palmbeachgroup.com@|A currency created 30 years before the dollar is making a comeback||0||1
+2015-11-08 19:55:12.671121||measurement||ad||2015-11-08 19:55:12.382764@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:55:12.671366||measurement||loadtime||0:00:10.081680||0||1
+2015-11-08 19:55:16.222004||measurement||ad||2015-11-08 19:55:15.978364@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:55:16.557977||measurement||ad||2015-11-08 19:55:15.978364@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:55:16.821124||measurement||ad||2015-11-08 19:55:15.978364@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:55:16.821394||measurement||loadtime||0:00:11.429944||2||0
+2015-11-08 19:55:18.635078||measurement||ad||2015-11-08 19:55:17.985068@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:55:18.912954||measurement||ad||2015-11-08 19:55:17.985068@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 19:55:19.172123||measurement||ad||2015-11-08 19:55:17.985068@|Free EBT Cell Phone@|qlinkwireless.com/Free-Cell-Phone@|EBT Recipients Get a Free Phone. 1000 Texts / 250 Mins, Get It Now!||1||0
+2015-11-08 19:55:19.172395||measurement||loadtime||0:00:12.732583||1||0
+2015-11-08 19:55:29.258215||measurement||ad||2015-11-08 19:55:29.078162@|Ericsson Radio Dot System@|www.ericsson.com/indoor@|Quality Access To Mobile Broadband And Voice Services. Learn More||1||0
+2015-11-08 19:55:29.379833||measurement||ad||2015-11-08 19:55:29.078162@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:55:29.510381||measurement||ad||2015-11-08 19:55:29.078162@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 19:55:29.510588||measurement||loadtime||0:00:05.337631||1||0
+2015-11-08 19:55:31.542427||measurement||ad||2015-11-08 19:55:31.417884@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:55:31.957879||measurement||ad||2015-11-08 19:55:31.417884@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:55:32.055297||measurement||ad||2015-11-08 19:55:31.417884@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:55:32.055575||measurement||loadtime||0:00:10.231978||2||0
+2015-11-08 19:55:40.963680||measurement||ad||2015-11-08 19:55:40.807194@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 19:55:41.120965||measurement||ad||2015-11-08 19:55:40.807194@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:55:41.244285||measurement||ad||2015-11-08 19:55:40.807194@|Audio Video Specialists@|www.cmsav.com@|AV Planning, Designing, Engineering And Consulting for Over 20 Years||1||0
+2015-11-08 19:55:41.244554||measurement||loadtime||0:00:06.732011||1||0
+2015-11-08 19:55:42.796601||measurement||ad||2015-11-08 19:55:42.668501@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:55:43.123160||measurement||ad||2015-11-08 19:55:42.668501@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-08 19:55:43.262813||measurement||ad||2015-11-08 19:55:42.668501@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||2||0
+2015-11-08 19:55:43.263074||measurement||loadtime||0:00:06.207169||2||0
+2015-11-08 19:55:51.360329||measurement||ad||2015-11-08 19:55:51.194974@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:55:51.510568||measurement||ad||2015-11-08 19:55:51.194974@|Forensic Science Training@|forensics.comparetopschools.com@|Request Free Info From Schools With Forensic Science Degree Programs.||1||0
+2015-11-08 19:55:51.648289||measurement||ad||2015-11-08 19:55:51.194974@|Free EBT Cell Phone@|qlinkwireless.com/Free-Cell-Phone@|EBT Recipients Get a Free Phone. 1000 Texts / 250 Mins, Get It Now!||1||0
+2015-11-08 19:55:51.648588||measurement||loadtime||0:00:05.403452||1||0
+2015-11-08 19:55:53.350667||measurement||ad||2015-11-08 19:55:53.155811@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 19:55:53.527264||measurement||ad||2015-11-08 19:55:53.155811@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 19:55:53.614820||measurement||ad||2015-11-08 19:55:53.155811@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 19:55:53.615075||measurement||loadtime||0:00:05.350141||2||0
+2015-11-08 19:56:43.167984||measurement||ad||2015-11-08 19:55:02.291374@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:56:43.620489||measurement||ad||2015-11-08 19:55:25.287555@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 19:56:43.620837||measurement||loadtime||0:01:25.949108||0||1
+2015-11-08 19:56:53.776051||measurement||ad||2015-11-08 19:55:02.291374@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:56:55.202223||measurement||ad||2015-11-08 19:56:55.086275@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 19:56:55.242643||measurement||ad||2015-11-08 19:56:55.086275@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 19:56:55.310580||measurement||ad||2015-11-08 19:56:55.086275@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 19:56:55.310869||measurement||loadtime||0:00:06.688624||0||1
+2015-11-08 19:56:55.311069||event||progress-marker||measurement-end||0||1
+2015-11-08 19:56:55.593417||measurement||ad||2015-11-08 19:55:02.291374@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:56:55.593688||measurement||loadtime||0:02:00.653246||3||1
+2015-11-08 19:56:57.352937||error||collecting ads||Error||1||0
+2015-11-08 19:56:57.353113||event||progress-marker||measurement-end||1||0
+2015-11-08 19:56:58.651905||error||collecting ads||Error||2||0
+2015-11-08 19:56:58.652080||event||progress-marker||measurement-end||2||0
+2015-11-08 19:57:06.506532||measurement||ad||2015-11-08 19:57:06.164772@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:57:06.600824||measurement||ad||2015-11-08 19:57:06.164772@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:57:06.673812||measurement||ad||2015-11-08 19:57:06.164772@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 19:57:06.674560||measurement||loadtime||0:00:06.079225||3||1
+2015-11-08 19:57:17.822453||measurement||ad||2015-11-08 19:57:17.249660@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:57:17.899477||measurement||ad||2015-11-08 19:57:17.249660@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 19:57:17.972967||measurement||ad||2015-11-08 19:57:17.249660@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 19:57:17.973244||measurement||loadtime||0:00:06.297978||3||1
+2015-11-08 19:57:17.973346||event||progress-marker||measurement-end||3||1
+2015-11-08 19:57:18.284128||meta||block_id end||7
+2015-11-08 19:57:18.284783||meta||block_id start||8
+2015-11-08 19:57:18.284811||meta||assignment||0@|1@|3@|2
+2015-11-08 19:57:20.952112||event||progress-marker||training-start||0||0
+2015-11-08 19:57:21.066398||event||progress-marker||training-start||1||0
+2015-11-08 19:57:22.689298||event||progress-marker||training-start||2||1
+2015-11-08 19:57:22.921256||event||progress-marker||training-start||3||1
+2015-11-08 19:57:29.324928||treatment||visit website||http://irs.gov||0||0
+2015-11-08 19:57:30.349150||treatment||visit website||http://irs.gov||1||0
+2015-11-08 19:57:30.527986||treatment||visit website||http://irs.gov||2||1
+2015-11-08 19:57:30.648211||treatment||visit website||http://irs.gov||3||1
+2015-11-08 19:57:37.400105||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 19:57:39.268373||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 19:57:39.868590||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 19:57:39.884885||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 19:57:48.532605||treatment||visit website||http://pwc.com||0||0
+2015-11-08 19:57:50.478079||treatment||visit website||http://pwc.com||1||0
+2015-11-08 19:57:51.658552||treatment||visit website||http://pwc.com||2||1
+2015-11-08 19:57:51.732302||treatment||visit website||http://pwc.com||3||1
+2015-11-08 19:57:55.336463||treatment||visit website||http://ey.com||0||0
+2015-11-08 19:57:57.720932||treatment||visit website||http://ey.com||1||0
+2015-11-08 19:57:58.953453||treatment||visit website||http://ey.com||2||1
+2015-11-08 19:57:58.962861||treatment||visit website||http://ey.com||3||1
+2015-11-08 19:58:02.975895||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 19:58:02.976061||event||progress-marker||training-end||0||0
+2015-11-08 19:58:06.293434||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 19:58:06.294829||event||progress-marker||training-end||2||1
+2015-11-08 19:58:06.356549||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 19:58:06.356975||event||progress-marker||training-end||1||0
+2015-11-08 19:58:08.410458||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 19:58:08.410714||event||progress-marker||training-end||3||1
+2015-11-08 19:58:11.315176||event||progress-marker||measurement-start||2||1
+2015-11-08 19:58:11.373469||event||progress-marker||measurement-start||1||0
+2015-11-08 19:58:12.997216||event||progress-marker||measurement-start||0||0
+2015-11-08 19:58:13.427781||event||progress-marker||measurement-start||3||1
+2015-11-08 19:58:28.343612||measurement||ad||2015-11-08 19:58:27.579644@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:58:29.003110||measurement||ad||2015-11-08 19:58:27.579644@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:58:29.134043||measurement||ad||2015-11-08 19:58:27.579644@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:58:29.134465||measurement||loadtime||0:00:12.817782||2||1
+2015-11-08 19:58:29.402603||measurement||ad||2015-11-08 19:58:28.605416@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:58:29.808508||measurement||ad||2015-11-08 19:58:28.605416@|¿Quieres aprender inglés?@|abaenglish.com/Cursos-Ingles-Online@|144 videoclases por 0 USD Regístrate ya y aprende gratis.||1||0
+2015-11-08 19:58:29.993427||measurement||ad||2015-11-08 19:58:28.605416@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:58:29.993770||measurement||loadtime||0:00:13.619565||1||0
+2015-11-08 19:58:31.864953||measurement||ad||2015-11-08 19:58:31.580174@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 19:58:32.323674||measurement||ad||2015-11-08 19:58:31.580174@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 19:58:32.498611||measurement||ad||2015-11-08 19:58:31.923879@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 19:58:32.696300||measurement||ad||2015-11-08 19:58:31.580174@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 19:58:32.697144||measurement||loadtime||0:00:14.699214||0||0
+2015-11-08 19:58:32.709272||measurement||ad||2015-11-08 19:58:31.923879@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 19:58:32.907113||measurement||ad||2015-11-08 19:58:31.923879@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-08 19:58:32.907401||measurement||loadtime||0:00:14.478135||3||1
+2015-11-08 19:58:46.668751||measurement||ad||2015-11-08 19:58:45.963405@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:58:47.223102||measurement||ad||2015-11-08 19:58:45.963405@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:58:47.802296||measurement||ad||2015-11-08 19:58:46.773464@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:58:47.987651||measurement||ad||2015-11-08 19:58:46.773464@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||3||1
+2015-11-08 19:58:48.233905||measurement||ad||2015-11-08 19:58:46.773464@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:58:48.234165||measurement||loadtime||0:00:10.326299||3||1
+2015-11-08 19:58:48.243414||measurement||ad||2015-11-08 19:58:45.963405@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 19:58:48.243680||measurement||loadtime||0:00:13.249327||1||0
+2015-11-08 19:58:48.591656||measurement||ad||2015-11-08 19:58:34.218248@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:58:48.756185||measurement||ad||2015-11-08 19:58:48.433225@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 19:58:48.940951||measurement||ad||2015-11-08 19:58:48.433225@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-08 19:58:49.072256||measurement||ad||2015-11-08 19:58:34.218248@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:58:49.117744||measurement||ad||2015-11-08 19:58:48.433225@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 19:58:49.118049||measurement||loadtime||0:00:11.419350||0||0
+2015-11-08 19:58:49.264617||measurement||ad||2015-11-08 19:58:34.218248@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:58:49.264886||measurement||loadtime||0:00:15.129802||2||1
+2015-11-08 19:59:04.687934||measurement||loadtime||0:00:11.452877||3||1
+2015-11-08 19:59:08.241532||measurement||ad||2015-11-08 19:59:06.929785@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 19:59:09.055981||measurement||ad||2015-11-08 19:59:06.929785@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 19:59:09.876070||measurement||ad||2015-11-08 19:59:06.929785@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 19:59:09.876409||measurement||loadtime||0:00:16.631377||1||0
+2015-11-08 19:59:12.746269||measurement||ad||2015-11-08 19:59:12.160029@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 19:59:13.375806||measurement||ad||2015-11-08 19:59:12.160029@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||2||1
+2015-11-08 19:59:13.486645||measurement||ad||2015-11-08 19:59:12.160029@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||1
+2015-11-08 19:59:13.486931||measurement||loadtime||0:00:19.221574||2||1
+2015-11-08 19:59:23.820088||measurement||ad||2015-11-08 19:59:23.328736@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:59:24.106726||measurement||ad||2015-11-08 19:59:23.328736@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:59:24.403511||measurement||ad||2015-11-08 19:59:23.328736@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 19:59:24.403875||measurement||loadtime||0:00:14.715147||3||1
+2015-11-08 19:59:27.883016||measurement||ad||2015-11-08 19:59:18.771278@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:59:28.250610||measurement||ad||2015-11-08 19:59:18.771278@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 19:59:28.580258||measurement||ad||2015-11-08 19:59:18.771278@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 19:59:28.580951||measurement||loadtime||0:00:10.092930||2||1
+2015-11-08 19:59:34.594967||measurement||ad||2015-11-08 19:59:34.319232@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:59:34.720912||measurement||ad||2015-11-08 19:59:34.319232@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:59:34.836049||measurement||ad||2015-11-08 19:59:34.319232@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 19:59:34.836541||measurement||loadtime||0:00:05.430498||3||1
+2015-11-08 19:59:39.463134||measurement||ad||2015-11-08 19:59:38.784743@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 19:59:39.614599||measurement||ad||2015-11-08 19:59:38.784743@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 19:59:39.711927||measurement||ad||2015-11-08 19:59:38.784743@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 19:59:39.712158||measurement||loadtime||0:00:06.130578||2||1
+2015-11-08 19:59:45.195705||measurement||ad||2015-11-08 19:59:44.972708@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 19:59:45.374483||measurement||ad||2015-11-08 19:59:44.972708@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 19:59:45.484910||measurement||ad||2015-11-08 19:59:44.972708@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 19:59:45.486176||measurement||loadtime||0:00:05.647944||3||1
+2015-11-08 19:59:53.850860||measurement||ad||2015-11-08 19:59:53.732316@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 19:59:53.932493||measurement||ad||2015-11-08 19:59:53.732316@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||2||1
+2015-11-08 19:59:54.006510||measurement||ad||2015-11-08 19:59:53.732316@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-08 19:59:54.006883||measurement||loadtime||0:00:09.294343||2||1
+2015-11-08 19:59:54.186102||error||collecting ads||Error||0||0
+2015-11-08 19:59:55.725241||measurement||ad||2015-11-08 19:59:55.372631@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||3||1
+2015-11-08 19:59:55.936860||measurement||ad||2015-11-08 19:59:55.372631@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 19:59:56.031925||measurement||ad||2015-11-08 19:59:55.372631@|Green Adventure Travel@|www.youtube.com/user/alicelogan1@|Be Green  Be Adventuresome Subscribe for weekly Tips and Video||3||1
+2015-11-08 19:59:56.032174||measurement||loadtime||0:00:05.545228||3||1
+2015-11-08 20:00:06.263427||measurement||ad||2015-11-08 20:00:06.087484@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:00:06.441969||measurement||ad||2015-11-08 20:00:06.087484@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:00:06.630694||measurement||ad||2015-11-08 20:00:06.087484@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 20:00:06.630949||measurement||loadtime||0:00:07.443437||0||0
+2015-11-08 20:00:08.504855||measurement||ad||2015-11-08 20:00:08.182181@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:00:08.628336||measurement||ad||2015-11-08 20:00:08.182181@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:00:08.772884||measurement||ad||2015-11-08 20:00:08.182181@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||3||1
+2015-11-08 20:00:08.773173||measurement||loadtime||0:00:07.740666||3||1
+2015-11-08 20:00:10.594363||measurement||ad||2015-11-08 20:00:07.934207@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:00:11.023653||measurement||ad||2015-11-08 20:00:07.934207@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 20:00:11.578383||measurement||ad||2015-11-08 20:00:07.934207@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 20:00:11.578718||measurement||loadtime||0:00:12.571397||2||1
+2015-11-08 20:00:14.931491||error||collecting ads||Error||1||0
+2015-11-08 20:00:18.479748||measurement||ad||2015-11-08 20:00:18.245923@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:00:18.640907||measurement||ad||2015-11-08 20:00:18.245923@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:00:18.773949||measurement||ad||2015-11-08 20:00:18.245923@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 20:00:18.774375||measurement||loadtime||0:00:07.141724||0||0
+2015-11-08 20:00:21.653773||measurement||ad||2015-11-08 20:00:20.002995@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:00:22.028063||measurement||ad||2015-11-08 20:00:20.002995@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:00:22.254392||measurement||ad||2015-11-08 20:00:20.002995@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:00:22.254675||measurement||loadtime||0:00:08.480424||3||1
+2015-11-08 20:00:28.053149||measurement||ad||2015-11-08 20:00:26.361949@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:00:28.557932||measurement||ad||2015-11-08 20:00:28.064718@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 20:00:28.853555||measurement||ad||2015-11-08 20:00:26.361949@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 20:00:28.970802||measurement||ad||2015-11-08 20:00:28.064718@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:00:29.021152||measurement||ad||2015-11-08 20:00:26.361949@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 20:00:29.021500||measurement||loadtime||0:00:12.441746||2||1
+2015-11-08 20:00:29.244802||measurement||ad||2015-11-08 20:00:28.064718@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:00:29.245044||measurement||loadtime||0:00:09.312544||1||0
+2015-11-08 20:00:31.810435||measurement||ad||2015-11-08 20:00:31.578107@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||0||0
+2015-11-08 20:00:31.959878||measurement||ad||2015-11-08 20:00:31.578107@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-08 20:00:32.134147||measurement||ad||2015-11-08 20:00:31.578107@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 20:00:32.134510||measurement||loadtime||0:00:08.359479||0||0
+2015-11-08 20:00:34.537442||measurement||ad||2015-11-08 20:00:34.099416@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:00:34.650037||measurement||ad||2015-11-08 20:00:34.099416@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:00:34.782186||measurement||ad||2015-11-08 20:00:34.099416@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||3||1
+2015-11-08 20:00:34.782439||measurement||loadtime||0:00:07.526152||3||1
+2015-11-08 20:00:34.782671||event||progress-marker||measurement-end||3||1
+2015-11-08 20:00:39.562170||measurement||ad||2015-11-08 20:00:39.391232@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:00:39.641324||measurement||ad||2015-11-08 20:00:39.159436@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:00:39.691650||measurement||ad||2015-11-08 20:00:39.391232@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:00:39.818886||measurement||ad||2015-11-08 20:00:39.159436@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||1
+2015-11-08 20:00:39.876190||measurement||ad||2015-11-08 20:00:39.391232@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:00:39.876553||measurement||loadtime||0:00:05.631138||1||0
+2015-11-08 20:00:39.938196||measurement||ad||2015-11-08 20:00:39.159436@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:00:39.938512||measurement||loadtime||0:00:05.916231||2||1
+2015-11-08 20:00:42.720315||measurement||ad||2015-11-08 20:00:42.488317@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:00:42.883552||measurement||ad||2015-11-08 20:00:42.488317@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 20:00:43.038757||measurement||ad||2015-11-08 20:00:42.488317@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:00:43.039163||measurement||loadtime||0:00:05.903864||0||0
+2015-11-08 20:00:53.864220||measurement||ad||2015-11-08 20:00:53.725711@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||1
+2015-11-08 20:00:53.960841||measurement||ad||2015-11-08 20:00:53.725711@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||2||1
+2015-11-08 20:00:54.066757||measurement||ad||2015-11-08 20:00:53.725711@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:00:54.067039||measurement||loadtime||0:00:09.127050||2||1
+2015-11-08 20:00:54.067158||event||progress-marker||measurement-end||2||1
+2015-11-08 20:00:55.642501||measurement||ad||2015-11-08 20:00:55.370392@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:00:55.740005||measurement||ad||2015-11-08 20:00:55.421691@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:00:55.791099||measurement||ad||2015-11-08 20:00:55.370392@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:00:55.909837||measurement||ad||2015-11-08 20:00:55.370392@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 20:00:55.910073||measurement||loadtime||0:00:07.869057||0||0
+2015-11-08 20:00:55.912006||measurement||ad||2015-11-08 20:00:55.421691@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:00:56.269996||measurement||ad||2015-11-08 20:00:55.421691@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||1||0
+2015-11-08 20:00:56.270226||measurement||loadtime||0:00:11.392251||1||0
+2015-11-08 20:01:06.445995||measurement||ad||2015-11-08 20:01:06.323968@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:01:06.581275||measurement||ad||2015-11-08 20:01:06.323968@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:01:06.762728||measurement||ad||2015-11-08 20:01:06.323968@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||0||0
+2015-11-08 20:01:06.762962||measurement||loadtime||0:00:05.852379||0||0
+2015-11-08 20:01:09.095673||measurement||ad||2015-11-08 20:01:08.402734@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:01:09.294449||measurement||ad||2015-11-08 20:01:08.402734@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:01:09.519498||measurement||ad||2015-11-08 20:01:08.402734@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:01:09.519830||measurement||loadtime||0:00:08.249242||1||0
+2015-11-08 20:01:16.475730||measurement||ad||2015-11-08 20:01:16.344218@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:01:16.618045||measurement||ad||2015-11-08 20:01:16.344218@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:01:16.754074||measurement||ad||2015-11-08 20:01:16.344218@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||0||0
+2015-11-08 20:01:16.754434||measurement||loadtime||0:00:04.989923||0||0
+2015-11-08 20:01:16.755035||event||progress-marker||measurement-end||0||0
+2015-11-08 20:01:19.759064||measurement||ad||2015-11-08 20:01:19.601141@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:01:19.886594||measurement||ad||2015-11-08 20:01:19.601141@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||0
+2015-11-08 20:01:20.023025||measurement||ad||2015-11-08 20:01:19.601141@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:01:20.023238||measurement||loadtime||0:00:05.502147||1||0
+2015-11-08 20:01:29.223945||measurement||ad||2015-11-08 20:01:29.047831@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||1||0
+2015-11-08 20:01:29.405981||measurement||ad||2015-11-08 20:01:29.047831@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-08 20:01:29.612751||measurement||ad||2015-11-08 20:01:29.047831@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:01:29.613100||measurement||loadtime||0:00:04.587689||1||0
+2015-11-08 20:01:29.613724||event||progress-marker||measurement-end||1||0
+2015-11-08 20:01:30.128183||meta||block_id end||8
+2015-11-08 20:01:30.128842||meta||block_id start||9
+2015-11-08 20:01:30.128928||meta||assignment||3@|2@|1@|0
+2015-11-08 20:01:32.782786||event||progress-marker||training-start||2||0
+2015-11-08 20:01:32.933273||event||progress-marker||training-start||3||0
+2015-11-08 20:01:34.653248||event||progress-marker||training-start||1||1
+2015-11-08 20:01:34.684376||event||progress-marker||training-start||0||1
+2015-11-08 20:01:41.073859||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:01:41.780478||treatment||visit website||http://irs.gov||3||0
+2015-11-08 20:01:42.324754||treatment||visit website||http://irs.gov||1||1
+2015-11-08 20:01:42.458405||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:01:50.249140||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:01:50.441453||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 20:01:51.585069||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 20:01:51.655439||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:02:01.630777||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:02:03.961638||treatment||visit website||http://pwc.com||1||1
+2015-11-08 20:02:04.019156||treatment||visit website||http://pwc.com||3||0
+2015-11-08 20:02:04.077472||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:02:08.423998||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:02:11.064167||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:02:11.332223||treatment||visit website||http://ey.com||1||1
+2015-11-08 20:02:14.193311||treatment||visit website||http://ey.com||3||0
+2015-11-08 20:02:16.435234||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:02:16.435495||event||progress-marker||training-end||2||0
+2015-11-08 20:02:18.607728||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:02:18.607977||event||progress-marker||training-end||0||1
+2015-11-08 20:02:18.936731||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 20:02:18.936926||event||progress-marker||training-end||1||1
+2015-11-08 20:02:21.852264||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 20:02:21.852588||event||progress-marker||training-end||3||0
+2015-11-08 20:02:23.628095||event||progress-marker||measurement-start||0||1
+2015-11-08 20:02:23.952732||event||progress-marker||measurement-start||1||1
+2015-11-08 20:02:26.459988||event||progress-marker||measurement-start||2||0
+2015-11-08 20:02:26.868558||event||progress-marker||measurement-start||3||0
+2015-11-08 20:02:38.937441||measurement||ad||2015-11-08 20:02:37.673302@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:02:39.028776||measurement||ad||2015-11-08 20:02:37.673302@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:02:39.283933||measurement||ad||2015-11-08 20:02:37.673302@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||0||1
+2015-11-08 20:02:39.284264||measurement||loadtime||0:00:10.654481||0||1
+2015-11-08 20:02:41.425479||measurement||ad||2015-11-08 20:02:41.083593@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:02:41.624552||measurement||ad||2015-11-08 20:02:41.083593@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:02:41.730965||measurement||ad||2015-11-08 20:02:41.083593@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:02:41.731263||measurement||loadtime||0:00:12.778007||1||1
+2015-11-08 20:02:42.334514||measurement||ad||2015-11-08 20:02:42.133857@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. 100% Free  Easy. No CC Needed!||3||0
+2015-11-08 20:02:42.556080||measurement||ad||2015-11-08 20:02:42.133857@|Start Download@|zipdevil.com@|File size: 487KB. OS: MacOSX. Rating: 5.0 Stars - ZipDevil||3||0
+2015-11-08 20:02:42.556539||measurement||loadtime||0:00:10.687464||3||0
+2015-11-08 20:02:42.751830||measurement||ad||2015-11-08 20:02:42.616137@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:02:42.951316||measurement||ad||2015-11-08 20:02:42.616137@|¿Quieres aprender inglés?@|abaenglish.com/Cursos-Ingles-Online@|144 videoclases por 0 USD Regístrate ya y aprende gratis.||2||0
+2015-11-08 20:02:43.089707||measurement||ad||2015-11-08 20:02:42.616137@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:02:43.089999||measurement||loadtime||0:00:11.629115||2||0
+2015-11-08 20:02:58.387995||measurement||ad||2015-11-08 20:02:58.044650@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:02:58.675592||measurement||ad||2015-11-08 20:02:58.044650@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:02:58.897334||measurement||ad||2015-11-08 20:02:58.044650@|Small Business Loans@|www.massfundingllc.com@|Approvals in 24 Hrs, Funding in 72. No Broker Fees, Net Maximum Funds!||3||0
+2015-11-08 20:02:58.897698||measurement||loadtime||0:00:11.340237||3||0
+2015-11-08 20:03:00.820686||measurement||ad||2015-11-08 20:03:00.534639@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:03:01.149390||measurement||ad||2015-11-08 20:03:00.534639@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:03:01.284237||measurement||ad||2015-11-08 20:03:00.534639@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:03:01.284499||measurement||loadtime||0:00:13.192993||2||0
+2015-11-08 20:03:01.852445||measurement||ad||2015-11-08 20:03:01.420098@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:03:01.988264||measurement||ad||2015-11-08 20:03:01.420098@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:03:02.094262||measurement||ad||2015-11-08 20:03:01.420098@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||1||1
+2015-11-08 20:03:02.094536||measurement||loadtime||0:00:15.361484||1||1
+2015-11-08 20:03:09.990456||measurement||ad||2015-11-08 20:03:09.279962@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:03:10.271827||measurement||ad||2015-11-08 20:03:09.279962@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:03:10.429435||measurement||ad||2015-11-08 20:03:09.279962@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||0||1
+2015-11-08 20:03:10.430026||measurement||loadtime||0:00:26.144089||0||1
+2015-11-08 20:03:11.858642||measurement||ad||2015-11-08 20:03:11.637557@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. 100% Free  Easy. No CC Needed!||3||0
+2015-11-08 20:03:12.080734||measurement||ad||2015-11-08 20:03:11.637557@|Start Download@|zipdevil.com@|File size: 487KB. OS: MacOSX. Rating: 5.0 Stars - ZipDevil||3||0
+2015-11-08 20:03:12.081054||measurement||loadtime||0:00:08.182201||3||0
+2015-11-08 20:03:14.879440||measurement||ad||2015-11-08 20:03:14.621293@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:03:15.021229||measurement||ad||2015-11-08 20:03:14.621293@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:03:15.107920||measurement||ad||2015-11-08 20:03:14.621293@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||1||1
+2015-11-08 20:03:15.108183||measurement||loadtime||0:00:08.012796||1||1
+2015-11-08 20:03:22.662749||measurement||ad||2015-11-08 20:03:22.195485@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 20:03:22.663473||measurement||loadtime||0:00:07.232750||0||1
+2015-11-08 20:03:24.848830||measurement||ad||2015-11-08 20:03:24.597421@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. 100% Free  Easy. No CC Needed!||3||0
+2015-11-08 20:03:25.227856||measurement||ad||2015-11-08 20:03:24.597421@|Start Download@|zipdevil.com@|File size: 487KB. OS: MacOSX. Rating: 5.0 Stars - ZipDevil||3||0
+2015-11-08 20:03:25.228736||measurement||loadtime||0:00:08.146765||3||0
+2015-11-08 20:03:27.134164||measurement||ad||2015-11-08 20:03:26.753056@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:03:27.254394||measurement||ad||2015-11-08 20:03:26.753056@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:03:27.329699||measurement||ad||2015-11-08 20:03:26.753056@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||1||1
+2015-11-08 20:03:27.329872||measurement||loadtime||0:00:07.220447||1||1
+2015-11-08 20:03:36.878836||measurement||ad||2015-11-08 20:03:35.289677@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:03:37.145309||measurement||ad||2015-11-08 20:03:35.289677@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||0||1
+2015-11-08 20:03:37.408514||measurement||ad||2015-11-08 20:03:35.289677@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||0||1
+2015-11-08 20:03:37.408917||measurement||loadtime||0:00:09.742719||0||1
+2015-11-08 20:03:37.852519||measurement||ad||2015-11-08 20:03:37.699410@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:03:38.038338||measurement||ad||2015-11-08 20:03:37.699410@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:03:38.251947||measurement||ad||2015-11-08 20:03:37.699410@|Official Rosetta Stone®@|www.rosettastone.com/Language@|Fast  Fun Way to Learn a Language. Try it for Free and Take the Demo!||3||0
+2015-11-08 20:03:38.252511||measurement||loadtime||0:00:08.021383||3||0
+2015-11-08 20:03:42.023908||measurement||ad||2015-11-08 20:03:41.450429@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:03:42.254739||measurement||ad||2015-11-08 20:03:41.450429@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:03:42.430444||measurement||ad||2015-11-08 20:03:41.450429@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||1||1
+2015-11-08 20:03:42.430837||measurement||loadtime||0:00:10.099490||1||1
+2015-11-08 20:03:50.403418||measurement||ad||2015-11-08 20:03:49.969627@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 20:03:50.404013||measurement||loadtime||0:00:07.994593||0||1
+2015-11-08 20:03:56.060803||measurement||ad||2015-11-08 20:03:55.826769@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:03:56.346639||measurement||ad||2015-11-08 20:03:55.826769@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:03:56.559456||measurement||ad||2015-11-08 20:03:55.826769@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||1||1
+2015-11-08 20:03:56.559855||measurement||loadtime||0:00:09.128178||1||1
+2015-11-08 20:04:00.364154||measurement||ad||2015-11-08 20:04:00.231818@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:04:00.513067||measurement||ad||2015-11-08 20:04:00.231818@|Small Business Loans@|www.massfundingllc.com@|Approvals in 24 Hrs, Funding in 72. No Broker Fees, Net Maximum Funds!||3||0
+2015-11-08 20:04:00.615942||measurement||ad||2015-11-08 20:04:00.231818@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:04:00.616291||measurement||loadtime||0:00:17.363211||3||0
+2015-11-08 20:04:02.376902||measurement||ad||2015-11-08 20:04:01.494241@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 20:04:02.377266||measurement||loadtime||0:00:06.972794||0||1
+2015-11-08 20:04:06.458051||error||collecting ads||Error||2||0
+2015-11-08 20:04:07.085748||measurement||ad||2015-11-08 20:04:01.773106@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:04:07.957241||measurement||ad||2015-11-08 20:04:01.773106@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||1||1
+2015-11-08 20:04:08.595054||measurement||ad||2015-11-08 20:04:01.773106@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||1||1
+2015-11-08 20:04:08.595537||measurement||loadtime||0:00:07.034877||1||1
+2015-11-08 20:04:12.758822||measurement||ad||2015-11-08 20:04:12.358686@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:04:12.862868||measurement||ad||2015-11-08 20:04:12.358686@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:04:13.004085||measurement||ad||2015-11-08 20:04:12.358686@|Official Rosetta Stone®@|www.rosettastone.com/Language@|Fast  Fun Way to Learn a Language. Try it for Free and Take the Demo!||3||0
+2015-11-08 20:04:13.004339||measurement||loadtime||0:00:07.386732||3||0
+2015-11-08 20:04:20.506901||measurement||ad||2015-11-08 20:04:07.580949@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 20:04:20.507472||measurement||loadtime||0:00:13.129725||0||1
+2015-11-08 20:04:22.302379||measurement||ad||2015-11-08 20:04:21.982050@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:04:22.819503||measurement||ad||2015-11-08 20:04:21.982050@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 20:04:23.190823||measurement||ad||2015-11-08 20:04:21.982050@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:04:23.191110||measurement||loadtime||0:00:11.730029||2||0
+2015-11-08 20:04:23.212695||measurement||ad||2015-11-08 20:04:23.011230@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:04:23.365375||measurement||ad||2015-11-08 20:04:23.011230@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:04:23.898129||measurement||ad||2015-11-08 20:04:23.011230@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||1||1
+2015-11-08 20:04:23.898383||measurement||loadtime||0:00:10.302153||1||1
+2015-11-08 20:04:31.865313||measurement||ad||2015-11-08 20:04:31.330914@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||0||1
+2015-11-08 20:04:31.865553||measurement||loadtime||0:00:06.356511||0||1
+2015-11-08 20:04:35.053562||measurement||ad||2015-11-08 20:04:34.945205@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:04:35.149568||measurement||ad||2015-11-08 20:04:34.945205@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:04:35.244897||measurement||ad||2015-11-08 20:04:34.945205@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||1||1
+2015-11-08 20:04:35.245192||measurement||loadtime||0:00:06.345281||1||1
+2015-11-08 20:04:35.295701||measurement||ad||2015-11-08 20:04:35.071646@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:04:35.452157||measurement||ad||2015-11-08 20:04:35.071646@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:04:35.567788||measurement||ad||2015-11-08 20:04:35.071646@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:04:35.568095||measurement||loadtime||0:00:07.375975||2||0
+2015-11-08 20:04:44.682878||measurement||ad||2015-11-08 20:04:44.381257@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:04:44.954667||measurement||ad||2015-11-08 20:04:44.381257@|Sunday Paper Coupons@|sundaypaper.shopathome.com@|Free Coupons Without The Paper. Get Coupons  Free Savings App!||0||1
+2015-11-08 20:04:45.089324||measurement||ad||2015-11-08 20:04:44.381257@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:04:45.089690||measurement||loadtime||0:00:08.223155||0||1
+2015-11-08 20:04:47.654200||measurement||ad||2015-11-08 20:04:47.426069@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:04:47.777744||measurement||ad||2015-11-08 20:04:47.426069@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:04:47.924834||measurement||ad||2015-11-08 20:04:47.426069@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:04:47.925150||measurement||loadtime||0:00:07.353975||2||0
+2015-11-08 20:04:48.796811||measurement||ad||2015-11-08 20:04:48.622191@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:04:48.931250||measurement||ad||2015-11-08 20:04:48.622191@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:04:49.088396||measurement||ad||2015-11-08 20:04:48.622191@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||1||1
+2015-11-08 20:04:49.088686||measurement||loadtime||0:00:08.842668||1||1
+2015-11-08 20:04:49.088804||event||progress-marker||measurement-end||1||1
+2015-11-08 20:04:55.086965||measurement||ad||2015-11-08 20:04:54.669237@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:04:55.177806||measurement||ad||2015-11-08 20:04:54.669237@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||0||1
+2015-11-08 20:04:55.242729||measurement||ad||2015-11-08 20:04:54.669237@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||0||1
+2015-11-08 20:04:55.243033||measurement||loadtime||0:00:05.151823||0||1
+2015-11-08 20:04:55.243158||event||progress-marker||measurement-end||0||1
+2015-11-08 20:04:57.955586||measurement||ad||2015-11-08 20:04:57.792640@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:04:58.035512||measurement||ad||2015-11-08 20:04:57.792640@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:04:58.116963||measurement||ad||2015-11-08 20:04:57.792640@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:04:58.117196||measurement||loadtime||0:00:05.191409||2||0
+2015-11-08 20:05:00.001790||measurement||ad||2015-11-08 20:04:59.895047@|Start Download@|Rating: 5.0 Stars - ZipDevil@|File size: 487KB. OS: MacOSX. ||3||0
+2015-11-08 20:05:00.002043||measurement||loadtime||0:00:41.997349||3||0
+2015-11-08 20:05:08.064397||measurement||ad||2015-11-08 20:05:07.956839@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:05:08.165624||measurement||ad||2015-11-08 20:05:07.956839@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 20:05:08.339287||measurement||ad||2015-11-08 20:05:07.956839@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||2||0
+2015-11-08 20:05:08.339574||measurement||loadtime||0:00:05.222019||2||0
+2015-11-08 20:05:10.189613||measurement||ad||2015-11-08 20:05:10.021502@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:05:10.324175||measurement||ad||2015-11-08 20:05:10.021502@|Small Business Loans@|www.massfundingllc.com@|Approvals in 24 Hrs, Funding in 72. No Broker Fees, Net Maximum Funds!||3||0
+2015-11-08 20:05:10.410785||measurement||ad||2015-11-08 20:05:10.021502@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:05:10.410984||measurement||loadtime||0:00:05.407163||3||0
+2015-11-08 20:05:18.438391||measurement||ad||2015-11-08 20:05:18.224307@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:05:18.586956||measurement||ad||2015-11-08 20:05:18.224307@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||2||0
+2015-11-08 20:05:18.670594||measurement||ad||2015-11-08 20:05:18.224307@|10 Stocks to Hold Forever@|www.streetauthority.com@|Buy them, forget about them, and never sell them.||2||0
+2015-11-08 20:05:18.670890||measurement||loadtime||0:00:05.330733||2||0
+2015-11-08 20:05:19.254769||measurement||ad||2015-11-08 20:05:19.167967@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:05:19.328990||measurement||ad||2015-11-08 20:05:19.167967@|Small Business Loans@|www.massfundingllc.com@|Approvals in 24 Hrs, Funding in 72. No Broker Fees, Net Maximum Funds!||3||0
+2015-11-08 20:05:19.397773||measurement||ad||2015-11-08 20:05:19.167967@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:05:19.398001||measurement||loadtime||0:00:03.986421||3||0
+2015-11-08 20:05:19.398093||event||progress-marker||measurement-end||3||0
+2015-11-08 20:05:27.402453||measurement||ad||2015-11-08 20:05:27.319643@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:05:27.467748||measurement||ad||2015-11-08 20:05:27.319643@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:05:27.535936||measurement||ad||2015-11-08 20:05:27.319643@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:05:27.536161||measurement||loadtime||0:00:03.864532||2||0
+2015-11-08 20:05:27.536259||event||progress-marker||measurement-end||2||0
+2015-11-08 20:05:28.004468||meta||block_id end||9
+2015-11-08 20:05:28.004811||meta||block_id start||10
+2015-11-08 20:05:28.004834||meta||assignment||2@|3@|1@|0
+2015-11-08 20:05:30.680999||event||progress-marker||training-start||3||0
+2015-11-08 20:05:30.747243||event||progress-marker||training-start||2||0
+2015-11-08 20:05:32.311728||event||progress-marker||training-start||1||1
+2015-11-08 20:05:32.461427||event||progress-marker||training-start||0||1
+2015-11-08 20:05:39.571600||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:05:40.292693||treatment||visit website||http://irs.gov||1||1
+2015-11-08 20:05:40.466027||treatment||visit website||http://irs.gov||3||0
+2015-11-08 20:05:40.519487||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:05:47.867211||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:05:49.499544||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 20:05:49.679022||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 20:05:49.703857||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:05:59.170691||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:06:00.880066||treatment||visit website||http://pwc.com||3||0
+2015-11-08 20:06:01.643405||treatment||visit website||http://pwc.com||1||1
+2015-11-08 20:06:01.852684||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:06:05.779506||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:06:08.183534||treatment||visit website||http://ey.com||3||0
+2015-11-08 20:06:08.668346||treatment||visit website||http://ey.com||1||1
+2015-11-08 20:06:10.308079||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:06:13.687311||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:06:13.687667||event||progress-marker||training-end||2||0
+2015-11-08 20:06:15.974589||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 20:06:15.974944||event||progress-marker||training-end||3||0
+2015-11-08 20:06:18.199810||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:06:18.200147||event||progress-marker||training-end||0||1
+2015-11-08 20:06:18.224085||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 20:06:18.224392||event||progress-marker||training-end||1||1
+2015-11-08 20:06:18.707621||event||progress-marker||measurement-start||2||0
+2015-11-08 20:06:20.996488||event||progress-marker||measurement-start||3||0
+2015-11-08 20:06:23.222033||event||progress-marker||measurement-start||0||1
+2015-11-08 20:06:23.247192||event||progress-marker||measurement-start||1||1
+2015-11-08 20:06:33.992021||measurement||ad||2015-11-08 20:06:33.512136@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:06:34.376606||measurement||ad||2015-11-08 20:06:33.512136@|Top 7 Adult Diapers@|comparestores.net/Adult-Diapers@|Compare Latest Offers  Save on Bestselling Adult Diapers!||2||0
+2015-11-08 20:06:34.592745||measurement||ad||2015-11-08 20:06:33.512136@|Discount Airline Tickets@|dealhunter.us@|Top Sale Airline Tickets At Best Prices Ever!||2||0
+2015-11-08 20:06:34.593032||measurement||loadtime||0:00:10.883812||2||0
+2015-11-08 20:06:39.355403||measurement||ad||2015-11-08 20:06:39.130866@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 20:06:39.689932||measurement||ad||2015-11-08 20:06:39.130866@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:06:39.782554||measurement||ad||2015-11-08 20:06:38.970104@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:06:40.009442||measurement||ad||2015-11-08 20:06:39.130866@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-08 20:06:40.010343||measurement||loadtime||0:00:14.012396||3||0
+2015-11-08 20:06:40.013903||measurement||ad||2015-11-08 20:06:38.970104@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||1||1
+2015-11-08 20:06:40.389102||measurement||ad||2015-11-08 20:06:38.970104@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:06:40.389418||measurement||loadtime||0:00:12.141569||1||1
+2015-11-08 20:06:41.753720||measurement||ad||2015-11-08 20:06:40.813905@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:06:41.981209||measurement||ad||2015-11-08 20:06:40.813905@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:06:42.169457||measurement||ad||2015-11-08 20:06:40.813905@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||0||1
+2015-11-08 20:06:42.169784||measurement||loadtime||0:00:13.946548||0||1
+2015-11-08 20:06:48.668541||measurement||ad||2015-11-08 20:06:48.384207@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:06:49.107988||measurement||ad||2015-11-08 20:06:48.384207@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:06:49.341874||measurement||ad||2015-11-08 20:06:48.384207@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:06:49.342196||measurement||loadtime||0:00:09.747932||2||0
+2015-11-08 20:06:59.222831||measurement||ad||2015-11-08 20:06:58.576611@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:06:59.363242||measurement||ad||2015-11-08 20:06:58.576611@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:06:59.388322||measurement||ad||2015-11-08 20:06:58.557804@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:06:59.462757||measurement||ad||2015-11-08 20:06:58.576611@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||1||1
+2015-11-08 20:06:59.463063||measurement||loadtime||0:00:14.072885||1||1
+2015-11-08 20:06:59.674768||measurement||ad||2015-11-08 20:06:58.557804@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:06:59.970453||measurement||ad||2015-11-08 20:06:58.557804@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:06:59.971066||measurement||loadtime||0:00:12.799949||0||1
+2015-11-08 20:07:01.896896||measurement||ad||2015-11-08 20:07:01.771407@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:07:01.980437||measurement||ad||2015-11-08 20:07:01.771407@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||2||0
+2015-11-08 20:07:02.064176||measurement||ad||2015-11-08 20:07:01.771407@|Top 7 Adult Diapers@|comparestores.net/Adult-Diapers@|Compare Latest Offers  Save on Bestselling Adult Diapers!||2||0
+2015-11-08 20:07:02.064437||measurement||loadtime||0:00:07.721894||2||0
+2015-11-08 20:07:12.820319||measurement||ad||2015-11-08 20:07:12.172940@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:07:12.908305||measurement||ad||2015-11-08 20:07:12.172940@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:07:13.000930||measurement||ad||2015-11-08 20:07:12.172940@|Organize Corporate Events@|www.yoursingapore.com/mice@|Plan Meetings  Conferences With Our Diversity Of Culture  Sights.||1||1
+2015-11-08 20:07:13.001773||measurement||loadtime||0:00:08.537140||1||1
+2015-11-08 20:07:14.462305||measurement||ad||2015-11-08 20:07:14.253800@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||2||0
+2015-11-08 20:07:14.462672||measurement||loadtime||0:00:07.397303||2||0
+2015-11-08 20:07:16.350612||measurement||ad||2015-11-08 20:07:15.907977@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:07:16.448419||measurement||ad||2015-11-08 20:07:15.907977@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:07:16.532133||measurement||ad||2015-11-08 20:07:15.907977@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:07:16.532352||measurement||loadtime||0:00:11.559770||0||1
+2015-11-08 20:07:26.093093||measurement||ad||2015-11-08 20:07:25.614849@|Costa Rica All-inclusive@|www.vacationscostarica.com@|We plan Your perfect Costa Rica Vacation package. Save time, stress||2||0
+2015-11-08 20:07:26.380419||measurement||ad||2015-11-08 20:07:25.614849@|Top 7 Adult Diapers@|comparestores.net/Adult-Diapers@|Compare Latest Offers  Save on Bestselling Adult Diapers!||2||0
+2015-11-08 20:07:26.642514||measurement||ad||2015-11-08 20:07:25.614849@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||2||0
+2015-11-08 20:07:26.642886||measurement||loadtime||0:00:07.179796||2||0
+2015-11-08 20:07:29.325586||measurement||ad||2015-11-08 20:07:28.564671@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:07:29.591288||measurement||ad||2015-11-08 20:07:28.564671@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-08 20:07:29.807489||measurement||ad||2015-11-08 20:07:28.564671@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||1||1
+2015-11-08 20:07:29.807793||measurement||loadtime||0:00:11.805602||1||1
+2015-11-08 20:07:38.819936||measurement||ad||2015-11-08 20:07:38.625864@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:07:38.999225||measurement||ad||2015-11-08 20:07:38.625864@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:07:39.175705||measurement||ad||2015-11-08 20:07:38.625864@|Login To Your Email Now@|email.loginfaster.com/new@|One-Click Access To All Your Email! Download Free App  Login Now.||2||0
+2015-11-08 20:07:39.176292||measurement||loadtime||0:00:07.532871||2||0
+2015-11-08 20:07:42.081696||measurement||ad||2015-11-08 20:07:35.011537@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:07:42.203365||measurement||ad||2015-11-08 20:07:35.011537@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:07:42.298290||measurement||ad||2015-11-08 20:07:35.011537@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:07:42.298631||measurement||loadtime||0:00:07.489261||1||1
+2015-11-08 20:07:45.111374||error||collecting ads||Error||3||0
+2015-11-08 20:07:48.747568||measurement||ad||2015-11-08 20:07:48.405956@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:07:48.833676||measurement||ad||2015-11-08 20:07:48.405956@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:07:48.909734||measurement||ad||2015-11-08 20:07:48.405956@|Annuity+Social Security=@|seniorannuityalert.com/TV_CNBC_PBS@|Potentially Double Your Income? Open to See New Strategy Now!||0||1
+2015-11-08 20:07:48.909972||measurement||loadtime||0:00:27.377133||0||1
+2015-11-08 20:07:50.591823||measurement||ad||2015-11-08 20:07:50.412302@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||2||0
+2015-11-08 20:07:50.592095||measurement||loadtime||0:00:06.414777||2||0
+2015-11-08 20:07:57.396828||measurement||ad||2015-11-08 20:07:56.730654@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:07:57.514194||measurement||ad||2015-11-08 20:07:56.730654@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:07:57.818762||measurement||ad||2015-11-08 20:07:56.730654@|Organize Corporate Events@|www.yoursingapore.com/mice@|Plan Meetings  Conferences With Our Diversity Of Culture  Sights.||1||1
+2015-11-08 20:07:57.819075||measurement||loadtime||0:00:10.519094||1||1
+2015-11-08 20:07:59.355696||measurement||ad||2015-11-08 20:07:58.707332@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:07:59.730557||measurement||ad||2015-11-08 20:07:58.707332@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:08:00.125699||measurement||ad||2015-11-08 20:07:58.707332@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:08:00.126305||measurement||loadtime||0:00:10.013955||3||0
+2015-11-08 20:08:03.267564||measurement||ad||2015-11-08 20:08:03.014355@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||2||0
+2015-11-08 20:08:03.267869||measurement||loadtime||0:00:07.674448||2||0
+2015-11-08 20:08:04.933152||measurement||ad||2015-11-08 20:08:04.724677@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:08:04.994771||measurement||ad||2015-11-08 20:08:04.724677@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-08 20:08:05.047661||measurement||ad||2015-11-08 20:08:04.724677@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||0||1
+2015-11-08 20:08:05.047991||measurement||loadtime||0:00:11.137442||0||1
+2015-11-08 20:08:11.609070||measurement||ad||2015-11-08 20:08:11.456594@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:08:11.754766||measurement||ad||2015-11-08 20:08:11.456594@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-08 20:08:11.880258||measurement||ad||2015-11-08 20:08:11.456594@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:08:11.880542||measurement||loadtime||0:00:06.753820||3||0
+2015-11-08 20:08:14.172091||measurement||ad||2015-11-08 20:08:13.755666@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:08:14.372769||measurement||ad||2015-11-08 20:08:13.755666@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:08:14.488723||measurement||ad||2015-11-08 20:08:13.755666@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:08:14.489456||measurement||loadtime||0:00:11.669132||1||1
+2015-11-08 20:08:17.993316||measurement||ad||2015-11-08 20:08:17.874770@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:08:18.122625||measurement||ad||2015-11-08 20:08:17.874770@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||0||1
+2015-11-08 20:08:18.219260||measurement||ad||2015-11-08 20:08:17.874770@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||0||1
+2015-11-08 20:08:18.219643||measurement||loadtime||0:00:08.171078||0||1
+2015-11-08 20:08:26.199424||measurement||ad||2015-11-08 20:08:26.008302@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:08:26.389844||measurement||ad||2015-11-08 20:08:26.008302@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:08:26.639670||measurement||ad||2015-11-08 20:08:26.008302@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:08:26.640004||measurement||loadtime||0:00:09.758617||3||0
+2015-11-08 20:08:30.803884||measurement||ad||2015-11-08 20:08:30.669826@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:08:30.866330||measurement||ad||2015-11-08 20:08:30.669826@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:08:30.944288||measurement||ad||2015-11-08 20:08:30.669826@|Annuity+Social Security=@|seniorannuityalert.com/TV_CNBC_PBS@|Potentially Double Your Income? Open to See New Strategy Now!||0||1
+2015-11-08 20:08:30.944574||measurement||loadtime||0:00:07.724115||0||1
+2015-11-08 20:08:37.257084||measurement||ad||2015-11-08 20:08:37.084949@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:08:37.457509||measurement||ad||2015-11-08 20:08:37.084949@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-08 20:08:37.657823||measurement||ad||2015-11-08 20:08:37.084949@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:08:37.658149||measurement||loadtime||0:00:06.016733||3||0
+2015-11-08 20:08:41.383582||measurement||ad||2015-11-08 20:08:36.066416@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:08:41.808069||measurement||ad||2015-11-08 20:08:36.066416@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:08:41.959651||measurement||ad||2015-11-08 20:08:36.066416@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:08:41.959999||measurement||loadtime||0:00:06.014702||0||1
+2015-11-08 20:08:50.631182||measurement||ad||2015-11-08 20:08:50.449974@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:08:50.907811||measurement||ad||2015-11-08 20:08:50.449974@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:08:51.056240||measurement||ad||2015-11-08 20:08:50.449974@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:08:51.056646||measurement||loadtime||0:00:08.397117||3||0
+2015-11-08 20:08:53.696403||measurement||ad||2015-11-08 20:08:53.116181@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:08:53.757862||measurement||ad||2015-11-08 20:08:53.116181@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:08:53.814732||measurement||ad||2015-11-08 20:08:53.116181@|Annuity+Social Security=@|seniorannuityalert.com/TV_CNBC_PBS@|Potentially Double Your Income? Open to See New Strategy Now!||0||1
+2015-11-08 20:08:53.815055||measurement||loadtime||0:00:06.854526||0||1
+2015-11-08 20:09:04.048751||measurement||ad||2015-11-08 20:09:03.908446@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:09:04.139195||measurement||ad||2015-11-08 20:09:03.908446@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:09:04.212071||measurement||ad||2015-11-08 20:09:03.908446@|QuickBooks™ Official Site@|quickbooksonline.com/Official-Site@|Try QuickBooks™ Online For Free No Credit Card Required To Start||1||1
+2015-11-08 20:09:04.212379||measurement||loadtime||0:00:44.722427||1||1
+2015-11-08 20:09:05.514294||measurement||ad||2015-11-08 20:09:05.331158@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:09:05.719737||measurement||ad||2015-11-08 20:09:05.331158@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:09:06.046457||measurement||ad||2015-11-08 20:09:05.331158@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:09:06.046777||measurement||loadtime||0:00:09.989037||3||0
+2015-11-08 20:09:07.069802||measurement||ad||2015-11-08 20:09:06.882493@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:09:07.181032||measurement||ad||2015-11-08 20:09:06.882493@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:09:07.301394||measurement||ad||2015-11-08 20:09:06.882493@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:09:07.301616||measurement||loadtime||0:00:08.485811||0||1
+2015-11-08 20:09:07.301716||event||progress-marker||measurement-end||0||1
+2015-11-08 20:09:08.342038||error||collecting ads||Error||2||0
+2015-11-08 20:09:15.167490||measurement||ad||2015-11-08 20:09:14.986555@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:09:15.226647||measurement||ad||2015-11-08 20:09:14.986555@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||1||1
+2015-11-08 20:09:15.300498||measurement||ad||2015-11-08 20:09:14.986555@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||1||1
+2015-11-08 20:09:15.300765||measurement||loadtime||0:00:06.087852||1||1
+2015-11-08 20:09:16.440756||measurement||ad||2015-11-08 20:09:16.323106@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:09:16.557716||measurement||ad||2015-11-08 20:09:16.323106@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-08 20:09:16.659994||measurement||ad||2015-11-08 20:09:16.323106@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 20:09:16.660303||measurement||loadtime||0:00:05.612114||3||0
+2015-11-08 20:09:19.367322||measurement||ad||2015-11-08 20:09:19.232916@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:09:19.458124||measurement||ad||2015-11-08 20:09:19.232916@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:09:19.566018||measurement||ad||2015-11-08 20:09:19.232916@|Login To Your Email Now@|email.loginfaster.com/new@|One-Click Access To All Your Email! Download Free App  Login Now.||2||0
+2015-11-08 20:09:19.566342||measurement||loadtime||0:00:06.222780||2||0
+2015-11-08 20:09:19.566998||event||progress-marker||measurement-end||2||0
+2015-11-08 20:09:26.807654||measurement||ad||2015-11-08 20:09:26.599670@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:09:26.947200||measurement||ad||2015-11-08 20:09:26.599670@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||0
+2015-11-08 20:09:27.072717||measurement||ad||2015-11-08 20:09:26.599670@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 20:09:27.073047||measurement||loadtime||0:00:05.410912||3||0
+2015-11-08 20:09:27.073153||event||progress-marker||measurement-end||3||0
+2015-11-08 20:09:28.482941||measurement||ad||2015-11-08 20:09:27.665423@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:09:28.547737||measurement||ad||2015-11-08 20:09:27.665423@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:09:28.606001||measurement||ad||2015-11-08 20:09:27.665423@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:09:28.606292||measurement||loadtime||0:00:08.304007||1||1
+2015-11-08 20:09:28.606407||event||progress-marker||measurement-end||1||1
+2015-11-08 20:09:28.944271||meta||block_id end||10
+2015-11-08 20:09:28.945245||meta||block_id start||11
+2015-11-08 20:09:28.945274||meta||assignment||3@|2@|0@|1
+2015-11-08 20:09:31.495914||event||progress-marker||training-start||2||0
+2015-11-08 20:09:31.644568||event||progress-marker||training-start||3||0
+2015-11-08 20:09:33.520209||event||progress-marker||training-start||0||1
+2015-11-08 20:09:33.751419||event||progress-marker||training-start||1||1
+2015-11-08 20:09:39.645266||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:09:39.926566||treatment||visit website||http://irs.gov||3||0
+2015-11-08 20:09:41.613198||treatment||visit website||http://irs.gov||1||1
+2015-11-08 20:09:41.811829||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:09:47.998888||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:09:50.003878||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:09:50.077744||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 20:09:51.049943||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 20:09:59.432069||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:10:00.876027||treatment||visit website||http://pwc.com||1||1
+2015-11-08 20:10:01.053062||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:10:04.606260||treatment||visit website||http://pwc.com||3||0
+2015-11-08 20:10:07.285734||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:10:08.722563||treatment||visit website||http://ey.com||1||1
+2015-11-08 20:10:11.662432||treatment||visit website||http://ey.com||3||0
+2015-11-08 20:10:11.982034||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:10:15.035497||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:10:15.035721||event||progress-marker||training-end||2||0
+2015-11-08 20:10:17.392040||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 20:10:17.392324||event||progress-marker||training-end||1||1
+2015-11-08 20:10:19.140439||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:10:19.140691||event||progress-marker||training-end||0||1
+2015-11-08 20:10:19.554136||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 20:10:19.554461||event||progress-marker||training-end||3||0
+2015-11-08 20:10:20.054094||event||progress-marker||measurement-start||2||0
+2015-11-08 20:10:22.418736||event||progress-marker||measurement-start||1||1
+2015-11-08 20:10:24.160268||event||progress-marker||measurement-start||0||1
+2015-11-08 20:10:24.573238||event||progress-marker||measurement-start||3||0
+2015-11-08 20:10:35.088653||measurement||ad||2015-11-08 20:10:34.270534@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:10:35.591138||measurement||ad||2015-11-08 20:10:34.270534@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||2||0
+2015-11-08 20:10:36.107998||measurement||ad||2015-11-08 20:10:34.270534@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:10:36.108272||measurement||loadtime||0:00:11.053070||2||0
+2015-11-08 20:10:44.241001||measurement||ad||2015-11-08 20:10:43.571923@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:10:44.494871||measurement||ad||2015-11-08 20:10:43.571923@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:10:44.726505||measurement||ad||2015-11-08 20:10:43.631232@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:10:44.742766||measurement||ad||2015-11-08 20:10:43.571923@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:10:44.743076||measurement||loadtime||0:00:15.169136||3||0
+2015-11-08 20:10:45.114824||measurement||ad||2015-11-08 20:10:43.631232@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:10:45.244627||measurement||ad||2015-11-08 20:10:43.631232@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:10:45.244956||measurement||loadtime||0:00:17.825353||1||1
+2015-11-08 20:10:45.386396||measurement||ad||2015-11-08 20:10:43.898854@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:10:45.700812||measurement||ad||2015-11-08 20:10:43.898854@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:10:46.126948||measurement||ad||2015-11-08 20:10:43.898854@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||0||1
+2015-11-08 20:10:46.127249||measurement||loadtime||0:00:16.965530||0||1
+2015-11-08 20:10:50.575301||measurement||ad||2015-11-08 20:10:50.171291@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:10:50.863253||measurement||ad||2015-11-08 20:10:50.171291@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:10:51.243602||measurement||ad||2015-11-08 20:10:50.171291@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:10:51.243920||measurement||loadtime||0:00:10.134795||2||0
+2015-11-08 20:11:08.449878||measurement||ad||2015-11-08 20:11:07.923913@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:11:08.717558||measurement||ad||2015-11-08 20:11:07.923913@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:11:08.888097||measurement||ad||2015-11-08 20:11:07.923913@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||2||0
+2015-11-08 20:11:08.888409||measurement||loadtime||0:00:12.643860||2||0
+2015-11-08 20:11:08.948178||measurement||ad||2015-11-08 20:11:08.326233@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:11:09.153277||measurement||ad||2015-11-08 20:11:08.326233@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 20:11:09.325703||measurement||ad||2015-11-08 20:11:08.326233@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||3||0
+2015-11-08 20:11:09.325978||measurement||loadtime||0:00:19.582371||3||0
+2015-11-08 20:11:10.990294||measurement||ad||2015-11-08 20:11:10.081361@|Annuity Calculator@|lowerprices.us/Annuity-Calculator@|Looking For Annuity Calculator? Compare Today's Top Offers  Save!||0||1
+2015-11-08 20:11:11.225622||measurement||ad||2015-11-08 20:11:10.081361@|Videos on MS@|www.everydayhealth.com/MS@|Learn About the Causes, Symptoms And Treatment Options of MS.||0||1
+2015-11-08 20:11:11.367718||measurement||ad||2015-11-08 20:11:10.081361@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. No CC Needed. 100% Free. Start Now!||0||1
+2015-11-08 20:11:11.368000||measurement||loadtime||0:00:20.238768||0||1
+2015-11-08 20:11:11.564579||measurement||ad||2015-11-08 20:11:11.023280@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:11:11.788065||measurement||ad||2015-11-08 20:11:11.023280@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:11:11.852470||measurement||ad||2015-11-08 20:11:11.023280@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:11:11.852776||measurement||loadtime||0:00:21.606418||1||1
+2015-11-08 20:11:21.831974||measurement||ad||2015-11-08 20:11:21.614756@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:11:22.265551||measurement||ad||2015-11-08 20:11:21.614756@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:11:22.557256||measurement||ad||2015-11-08 20:11:21.614756@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:11:22.557552||measurement||loadtime||0:00:08.667345||2||0
+2015-11-08 20:11:28.839507||measurement||ad||2015-11-08 20:11:28.445296@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:11:29.128571||measurement||ad||2015-11-08 20:11:28.445296@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:11:29.396522||measurement||ad||2015-11-08 20:11:28.445296@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:11:29.396781||measurement||loadtime||0:00:12.542969||1||1
+2015-11-08 20:11:30.996914||measurement||ad||2015-11-08 20:11:29.983503@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:11:31.378332||measurement||ad||2015-11-08 20:11:29.983503@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:11:31.611419||measurement||ad||2015-11-08 20:11:29.983503@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||0||1
+2015-11-08 20:11:31.611706||measurement||loadtime||0:00:15.242477||0||1
+2015-11-08 20:11:33.095785||measurement||ad||2015-11-08 20:11:32.894177@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:11:33.240523||measurement||ad||2015-11-08 20:11:32.894177@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:11:33.502940||measurement||ad||2015-11-08 20:11:32.894177@|HUD Homes low as $10,000@|www.hudforeclosed.com@|$1 Trial to Search Foreclosures Now Find Homes You can Afford!||3||0
+2015-11-08 20:11:33.503181||measurement||loadtime||0:00:19.176022||3||0
+2015-11-08 20:11:35.649601||measurement||ad||2015-11-08 20:11:35.477963@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:11:35.784746||measurement||ad||2015-11-08 20:11:35.477963@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:11:35.990796||measurement||ad||2015-11-08 20:11:35.477963@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:11:35.991057||measurement||loadtime||0:00:08.432965||2||0
+2015-11-08 20:11:45.942740||measurement||ad||2015-11-08 20:11:45.155446@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:11:46.233862||measurement||ad||2015-11-08 20:11:45.155446@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:11:46.584853||measurement||ad||2015-11-08 20:11:45.155446@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||1||1
+2015-11-08 20:11:46.585223||measurement||loadtime||0:00:12.187013||1||1
+2015-11-08 20:11:48.346212||measurement||ad||2015-11-08 20:11:48.069754@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:11:48.513180||measurement||ad||2015-11-08 20:11:48.069754@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:11:48.687480||measurement||ad||2015-11-08 20:11:48.069754@|Age 55+ Cruise Discounts@|vacationstogo.com@|Extra savings on cruises for travelers age 55+. Huge selection!||3||0
+2015-11-08 20:11:48.687823||measurement||loadtime||0:00:10.183440||3||0
+2015-11-08 20:11:49.854029||measurement||ad||2015-11-08 20:11:49.596850@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:11:49.987509||measurement||ad||2015-11-08 20:11:49.596850@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:11:50.063422||measurement||ad||2015-11-08 20:11:49.596850@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||0||1
+2015-11-08 20:11:50.063682||measurement||loadtime||0:00:13.450508||0||1
+2015-11-08 20:12:00.897591||measurement||ad||2015-11-08 20:12:00.691100@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:12:01.086457||measurement||ad||2015-11-08 20:12:00.691100@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:12:01.302920||measurement||ad||2015-11-08 20:12:00.691100@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:12:01.303192||measurement||loadtime||0:00:07.613394||3||0
+2015-11-08 20:12:04.195742||measurement||ad||2015-11-08 20:12:03.961688@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:12:04.285679||measurement||ad||2015-11-08 20:12:03.961688@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:12:04.347516||measurement||ad||2015-11-08 20:12:03.961688@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:12:04.347849||measurement||loadtime||0:00:09.282790||0||1
+2015-11-08 20:12:07.824474||measurement||ad||2015-11-08 20:11:59.551591@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||1||1
+2015-11-08 20:12:07.913737||measurement||ad||2015-11-08 20:11:59.551591@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||1||1
+2015-11-08 20:12:08.114466||measurement||ad||2015-11-08 20:11:59.551591@|Medicare Supplement Plans@|www.medicaresupplemental.com@|Medigap Options for (65  older). Compare Plans  Prices for 2015.||1||1
+2015-11-08 20:12:08.114803||measurement||loadtime||0:00:16.528399||1||1
+2015-11-08 20:12:12.230278||measurement||ad||2015-11-08 20:12:11.995362@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:12:12.348296||measurement||ad||2015-11-08 20:12:11.995362@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 20:12:12.471760||measurement||ad||2015-11-08 20:12:11.995362@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||3||0
+2015-11-08 20:12:12.472014||measurement||loadtime||0:00:06.168244||3||0
+2015-11-08 20:12:17.224328||measurement||ad||2015-11-08 20:12:16.803335@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:12:17.321376||measurement||ad||2015-11-08 20:12:16.803335@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||0||1
+2015-11-08 20:12:17.399782||measurement||ad||2015-11-08 20:12:16.803335@|Top 7 Carry On Bag@|carry-on-bag.comparestores.net@|Looking for Carry On Bag? Compare Latest Offers  Save Big!||0||1
+2015-11-08 20:12:17.400035||measurement||loadtime||0:00:08.051095||0||1
+2015-11-08 20:12:19.005619||measurement||ad||2015-11-08 20:12:18.772659@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:12:19.091832||measurement||ad||2015-11-08 20:12:18.772659@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:12:19.159605||measurement||ad||2015-11-08 20:12:18.772659@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:12:19.159865||measurement||loadtime||0:00:06.044474||1||1
+2015-11-08 20:12:24.985575||measurement||ad||2015-11-08 20:12:24.724872@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:12:25.264508||measurement||ad||2015-11-08 20:12:24.724872@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:12:25.428934||measurement||ad||2015-11-08 20:12:24.724872@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:12:25.429180||measurement||loadtime||0:00:07.956641||3||0
+2015-11-08 20:12:30.783607||measurement||ad||2015-11-08 20:12:30.329946@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:12:30.881712||measurement||ad||2015-11-08 20:12:30.329946@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:12:31.109317||measurement||ad||2015-11-08 20:12:30.329946@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-08 20:12:31.109583||measurement||loadtime||0:00:08.709176||0||1
+2015-11-08 20:12:32.042800||measurement||ad||2015-11-08 20:12:31.118392@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:12:32.157504||measurement||ad||2015-11-08 20:12:31.118392@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:12:32.257147||measurement||ad||2015-11-08 20:12:31.118392@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:12:32.257561||measurement||loadtime||0:00:08.096983||1||1
+2015-11-08 20:12:41.367163||error||collecting ads||Error||2||0
+2015-11-08 20:12:43.838202||measurement||ad||2015-11-08 20:12:43.650852@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:12:44.529776||measurement||ad||2015-11-08 20:12:43.650852@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-08 20:12:44.982892||measurement||ad||2015-11-08 20:12:43.650852@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:12:44.983259||measurement||loadtime||0:00:07.725048||1||1
+2015-11-08 20:12:45.163555||measurement||ad||2015-11-08 20:12:44.772068@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:12:45.527600||measurement||ad||2015-11-08 20:12:44.772068@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||0
+2015-11-08 20:12:45.919869||measurement||ad||2015-11-08 20:12:44.772068@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||3||0
+2015-11-08 20:12:45.920175||measurement||loadtime||0:00:15.490244||3||0
+2015-11-08 20:12:50.091024||measurement||ad||2015-11-08 20:12:49.800937@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:12:50.325643||measurement||ad||2015-11-08 20:12:49.800937@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||0||1
+2015-11-08 20:12:50.469320||measurement||ad||2015-11-08 20:12:49.800937@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:12:50.469577||measurement||loadtime||0:00:14.358731||0||1
+2015-11-08 20:12:57.558326||measurement||ad||2015-11-08 20:12:57.349304@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:12:57.789398||measurement||ad||2015-11-08 20:12:57.349304@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:12:57.909150||measurement||ad||2015-11-08 20:12:57.349304@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||1
+2015-11-08 20:12:57.909376||measurement||loadtime||0:00:07.925753||1||1
+2015-11-08 20:13:01.673283||measurement||ad||2015-11-08 20:13:01.021560@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:13:02.069371||measurement||ad||2015-11-08 20:13:01.021560@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:13:02.625600||measurement||ad||2015-11-08 20:13:01.021560@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||2||0
+2015-11-08 20:13:02.626222||measurement||loadtime||0:00:16.257402||2||0
+2015-11-08 20:13:04.774869||measurement||ad||2015-11-08 20:13:04.221938@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 20:13:05.163527||measurement||ad||2015-11-08 20:13:04.221938@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:13:05.825769||measurement||ad||2015-11-08 20:13:04.221938@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:13:05.826033||measurement||loadtime||0:00:14.904649||3||0
+2015-11-08 20:13:12.345664||measurement||ad||2015-11-08 20:13:12.089490@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:13:12.516665||measurement||ad||2015-11-08 20:13:12.089490@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:13:12.648859||measurement||ad||2015-11-08 20:13:12.089490@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:13:12.649159||measurement||loadtime||0:00:09.739410||1||1
+2015-11-08 20:13:12.649367||event||progress-marker||measurement-end||1||1
+2015-11-08 20:13:18.979148||measurement||ad||2015-11-08 20:13:18.665370@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||2||0
+2015-11-08 20:13:19.227784||measurement||ad||2015-11-08 20:13:18.665370@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-08 20:13:19.517858||measurement||ad||2015-11-08 20:13:18.665370@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:13:19.518217||measurement||loadtime||0:00:11.890610||2||0
+2015-11-08 20:13:22.666971||measurement||ad||2015-11-08 20:13:22.376156@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:13:22.921805||measurement||ad||2015-11-08 20:13:22.376156@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:13:23.169402||measurement||ad||2015-11-08 20:13:22.376156@|Age 55+ Cruise Discounts@|vacationstogo.com@|Extra savings on cruises for travelers age 55+. Huge selection!||3||0
+2015-11-08 20:13:23.169656||measurement||loadtime||0:00:12.342899||3||0
+2015-11-08 20:13:23.169904||event||progress-marker||measurement-end||3||0
+2015-11-08 20:13:38.129511||measurement||ad||2015-11-08 20:13:37.920926@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-08 20:13:38.616847||measurement||ad||2015-11-08 20:13:37.920926@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||2||0
+2015-11-08 20:13:38.823232||measurement||ad||2015-11-08 20:13:37.920926@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:13:38.823565||measurement||loadtime||0:00:14.303832||2||0
+2015-11-08 20:13:50.877898||measurement||ad||2015-11-08 20:13:50.711078@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:13:51.026971||measurement||ad||2015-11-08 20:13:50.711078@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:13:51.178216||measurement||ad||2015-11-08 20:13:50.711078@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:13:51.178445||measurement||loadtime||0:00:07.352923||2||0
+2015-11-08 20:13:51.179308||event||progress-marker||measurement-end||2||0
+2015-11-08 20:14:19.324901||measurement||ad||2015-11-08 20:13:01.695384@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:14:19.364460||measurement||ad||2015-11-08 20:13:01.695384@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||0||1
+2015-11-08 20:14:19.413482||measurement||ad||2015-11-08 20:13:01.695384@|Top 7 Carry On Bag@|carry-on-bag.comparestores.net@|Looking for Carry On Bag? Compare Latest Offers  Save Big!||0||1
+2015-11-08 20:14:19.413769||measurement||loadtime||0:01:23.942596||0||1
+2015-11-08 20:14:30.177876||measurement||ad||2015-11-08 20:14:30.014513@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:14:30.214245||measurement||ad||2015-11-08 20:14:30.014513@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||0||1
+2015-11-08 20:14:30.255294||measurement||ad||2015-11-08 20:14:30.014513@|Top 7 Carry On Bag@|carry-on-bag.comparestores.net@|Looking for Carry On Bag? Compare Latest Offers  Save Big!||0||1
+2015-11-08 20:14:30.255579||measurement||loadtime||0:00:05.840450||0||1
+2015-11-08 20:14:30.255730||event||progress-marker||measurement-end||0||1
+2015-11-08 20:14:30.555891||meta||block_id end||11
+2015-11-08 20:14:30.557870||meta||block_id start||12
+2015-11-08 20:14:30.557929||meta||assignment||1@|2@|0@|3
+2015-11-08 20:14:33.366707||event||progress-marker||training-start||1||0
+2015-11-08 20:14:33.404264||event||progress-marker||training-start||2||0
+2015-11-08 20:14:35.184128||event||progress-marker||training-start||3||1
+2015-11-08 20:14:35.239580||event||progress-marker||training-start||0||1
+2015-11-08 20:14:42.078982||treatment||visit website||http://irs.gov||1||0
+2015-11-08 20:14:42.230982||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:14:43.623127||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:14:43.767966||treatment||visit website||http://irs.gov||3||1
+2015-11-08 20:14:50.619589||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:14:51.000474||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 20:14:53.446471||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 20:14:53.670276||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:15:13.645172||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:15:13.999571||treatment||visit website||http://pwc.com||1||0
+2015-11-08 20:15:14.372614||treatment||visit website||http://pwc.com||3||1
+2015-11-08 20:15:14.669672||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:15:21.408475||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:15:21.756965||treatment||visit website||http://ey.com||1||0
+2015-11-08 20:15:22.626460||treatment||visit website||http://ey.com||3||1
+2015-11-08 20:15:22.843401||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:15:29.174459||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 20:15:29.174847||event||progress-marker||training-end||1||0
+2015-11-08 20:15:29.918828||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:15:29.919197||event||progress-marker||training-end||2||0
+2015-11-08 20:15:31.412688||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:15:31.412947||event||progress-marker||training-end||0||1
+2015-11-08 20:15:31.728755||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 20:15:31.729150||event||progress-marker||training-end||3||1
+2015-11-08 20:15:34.203277||event||progress-marker||measurement-start||1||0
+2015-11-08 20:15:34.941125||event||progress-marker||measurement-start||2||0
+2015-11-08 20:15:36.436923||event||progress-marker||measurement-start||0||1
+2015-11-08 20:15:36.747981||event||progress-marker||measurement-start||3||1
+2015-11-08 20:15:46.331971||measurement||ad||2015-11-08 20:15:46.082625@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:15:46.511778||measurement||ad||2015-11-08 20:15:46.082625@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||1||0
+2015-11-08 20:15:46.786661||measurement||ad||2015-11-08 20:15:46.082625@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||1||0
+2015-11-08 20:15:46.786968||measurement||loadtime||0:00:07.582099||1||0
+2015-11-08 20:15:49.367690||measurement||ad||2015-11-08 20:15:49.146393@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:15:49.590476||measurement||ad||2015-11-08 20:15:49.146393@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:15:49.753999||measurement||ad||2015-11-08 20:15:49.146393@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:15:49.754376||measurement||loadtime||0:00:09.811583||2||0
+2015-11-08 20:16:00.882692||measurement||ad||2015-11-08 20:16:00.654740@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:16:01.085352||measurement||ad||2015-11-08 20:16:00.654740@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:16:01.251118||measurement||ad||2015-11-08 20:16:00.654740@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:16:01.251470||measurement||loadtime||0:00:09.463185||1||0
+2015-11-08 20:16:05.215829||measurement||ad||2015-11-08 20:16:02.936710@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:16:05.222001||measurement||ad||2015-11-08 20:16:02.150973@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:16:05.781297||measurement||ad||2015-11-08 20:16:02.150973@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 20:16:06.094311||measurement||ad||2015-11-08 20:16:02.936710@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||0||1
+2015-11-08 20:16:06.353443||measurement||ad||2015-11-08 20:16:02.936710@|Data Mining Courses@|stanford.edu/Data-Mining@|Online Data Mining Courses, earn World-Class Credentials. Learn More||0||1
+2015-11-08 20:16:06.353691||measurement||loadtime||0:00:24.915182||0||1
+2015-11-08 20:16:07.354570||measurement||ad||2015-11-08 20:16:02.150973@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-08 20:16:07.354863||measurement||loadtime||0:00:25.605634||3||1
+2015-11-08 20:16:11.257069||measurement||ad||2015-11-08 20:16:11.118597@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. No CC Needed. 100% Free. Start Now!||1||0
+2015-11-08 20:16:11.338805||measurement||ad||2015-11-08 20:16:11.118597@|ITT Tech - Official Site@|www.itt-tech.edu@|Associate, Bachelor Degree Programs Browse Programs Now  Learn More.||1||0
+2015-11-08 20:16:11.421055||measurement||ad||2015-11-08 20:16:11.118597@|sUAS News Drone Stories@|www.suasnews.com@|Multirotor,military, FAA approved Worldwide Unmanned aircraft News||1||0
+2015-11-08 20:16:11.421275||measurement||loadtime||0:00:05.168340||1||0
+2015-11-08 20:16:25.174027||measurement||ad||2015-11-08 20:16:23.558419@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:16:25.298532||measurement||ad||2015-11-08 20:16:23.558419@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||3||1
+2015-11-08 20:16:26.039879||measurement||ad||2015-11-08 20:16:23.558419@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:16:26.040174||measurement||loadtime||0:00:13.684685||3||1
+2015-11-08 20:16:26.256202||measurement||ad||2015-11-08 20:16:23.733181@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:16:26.830103||measurement||ad||2015-11-08 20:16:23.733181@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 20:16:29.297437||measurement||ad||2015-11-08 20:16:23.733181@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:16:29.297717||measurement||loadtime||0:00:17.943423||0||1
+2015-11-08 20:16:39.964210||measurement||ad||2015-11-08 20:16:39.828007@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:16:40.090146||measurement||ad||2015-11-08 20:16:39.828007@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:16:40.278467||measurement||ad||2015-11-08 20:16:39.828007@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 20:16:40.278769||measurement||loadtime||0:00:23.856075||1||0
+2015-11-08 20:16:46.438799||measurement||ad||2015-11-08 20:16:46.041283@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||0||1
+2015-11-08 20:16:47.859528||measurement||ad||2015-11-08 20:16:46.041283@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:16:48.031399||measurement||ad||2015-11-08 20:16:44.202068@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:16:48.133894||measurement||ad||2015-11-08 20:16:46.041283@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:16:48.134149||measurement||loadtime||0:00:13.835837||0||1
+2015-11-08 20:16:48.512201||measurement||ad||2015-11-08 20:16:44.202068@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:16:50.062714||measurement||ad||2015-11-08 20:16:44.202068@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:16:50.062981||measurement||loadtime||0:00:19.021949||3||1
+2015-11-08 20:16:50.163332||measurement||ad||2015-11-08 20:16:50.032668@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. No CC Needed. 100% Free. Start Now!||1||0
+2015-11-08 20:16:50.248992||measurement||ad||2015-11-08 20:16:50.032668@|ITT Tech - Official Site@|www.itt-tech.edu@|Associate, Bachelor Degree Programs Browse Programs Now  Learn More.||1||0
+2015-11-08 20:16:50.367129||measurement||ad||2015-11-08 20:16:50.032668@|sUAS News Drone Stories@|www.suasnews.com@|Multirotor,military, FAA approved Worldwide Unmanned aircraft News||1||0
+2015-11-08 20:16:50.367423||measurement||loadtime||0:00:05.087278||1||0
+2015-11-08 20:16:54.836877||error||collecting ads||Error||2||0
+2015-11-08 20:17:05.742348||measurement||ad||2015-11-08 20:17:05.569935@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:17:05.911594||measurement||ad||2015-11-08 20:17:05.569935@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:17:06.030133||measurement||ad||2015-11-08 20:17:05.569935@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:17:06.030385||measurement||loadtime||0:00:06.192016||2||0
+2015-11-08 20:17:07.362609||measurement||ad||2015-11-08 20:16:53.611061@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:17:10.699886||measurement||ad||2015-11-08 20:16:53.611061@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 20:17:10.734168||measurement||ad||2015-11-08 20:17:10.074669@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:17:10.831746||measurement||ad||2015-11-08 20:17:10.074669@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:17:11.987317||measurement||ad||2015-11-08 20:16:53.611061@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:17:11.987633||measurement||loadtime||0:00:18.852579||0||1
+2015-11-08 20:17:13.601312||measurement||ad||2015-11-08 20:17:10.074669@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:17:13.601601||measurement||loadtime||0:00:18.538052||3||1
+2015-11-08 20:17:16.393265||measurement||ad||2015-11-08 20:17:16.287935@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:17:16.470244||measurement||ad||2015-11-08 20:17:16.287935@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:17:16.569640||measurement||ad||2015-11-08 20:17:16.287935@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 20:17:16.569929||measurement||loadtime||0:00:05.538088||2||0
+2015-11-08 20:17:27.444332||measurement||ad||2015-11-08 20:17:27.274803@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:17:27.635586||measurement||ad||2015-11-08 20:17:27.274803@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:17:27.742857||measurement||ad||2015-11-08 20:17:27.274803@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:17:27.743072||measurement||loadtime||0:00:06.171686||2||0
+2015-11-08 20:17:30.341963||measurement||ad||2015-11-08 20:17:26.330354@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||0||1
+2015-11-08 20:17:31.635634||measurement||ad||2015-11-08 20:17:29.047052@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||1
+2015-11-08 20:17:32.127928||measurement||ad||2015-11-08 20:17:26.330354@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:17:36.482171||measurement||ad||2015-11-08 20:17:26.330354@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:17:36.482431||measurement||loadtime||0:00:19.494348||0||1
+2015-11-08 20:17:36.692029||measurement||ad||2015-11-08 20:17:29.047052@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:17:38.664961||measurement||ad||2015-11-08 20:17:29.047052@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||1
+2015-11-08 20:17:38.665277||measurement||loadtime||0:00:20.062244||3||1
+2015-11-08 20:17:50.918833||measurement||ad||2015-11-08 20:17:49.584975@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:17:52.079688||measurement||ad||2015-11-08 20:17:49.584975@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||1
+2015-11-08 20:17:52.463972||measurement||ad||2015-11-08 20:17:49.584975@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:17:52.464240||measurement||loadtime||0:00:10.980823||0||1
+2015-11-08 20:17:53.194991||measurement||ad||2015-11-08 20:17:51.444502@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:17:53.544443||measurement||ad||2015-11-08 20:17:51.444502@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:17:55.034099||measurement||ad||2015-11-08 20:17:51.444502@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||3||1
+2015-11-08 20:17:55.034348||measurement||loadtime||0:00:11.367680||3||1
+2015-11-08 20:17:55.428263||error||collecting ads||Error||1||0
+2015-11-08 20:18:05.514201||measurement||ad||2015-11-08 20:18:05.387373@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:18:05.656015||measurement||ad||2015-11-08 20:18:05.387373@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:18:05.814450||measurement||ad||2015-11-08 20:18:05.387373@|Age 55+ Cruise Discounts@|vacationstogo.com@|Extra savings on cruises for travelers age 55+. Huge selection!||2||0
+2015-11-08 20:18:05.814766||measurement||loadtime||0:00:33.070270||2||0
+2015-11-08 20:18:05.853687||measurement||ad||2015-11-08 20:18:05.621529@|Free Food@|www.getitfree.us@|Absolutely Free Brand Name Samples. No CC Needed. 100% Free. Start Now!||1||0
+2015-11-08 20:18:06.060927||measurement||ad||2015-11-08 20:18:05.621529@|ITT Tech - Official Site@|www.itt-tech.edu@|Associate, Bachelor Degree Programs Browse Programs Now  Learn More.||1||0
+2015-11-08 20:18:06.212624||measurement||ad||2015-11-08 20:18:05.621529@|sUAS News Drone Stories@|www.suasnews.com@|Multirotor,military, FAA approved Worldwide Unmanned aircraft News||1||0
+2015-11-08 20:18:06.212902||measurement||loadtime||0:00:05.783519||1||0
+2015-11-08 20:18:11.667770||measurement||ad||2015-11-08 20:18:10.072741@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:18:16.076477||measurement||ad||2015-11-08 20:18:15.940077@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:18:16.173358||measurement||ad||2015-11-08 20:18:15.940077@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:18:16.309600||measurement||ad||2015-11-08 20:18:15.940077@|Organize Corporate Events@|www.yoursingapore.com/mice@|Plan Meetings  Conferences With Our Diversity Of Culture  Sights.||1||0
+2015-11-08 20:18:16.309984||measurement||loadtime||0:00:05.096037||1||0
+2015-11-08 20:18:16.747242||measurement||ad||2015-11-08 20:18:16.577344@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:18:16.833841||measurement||ad||2015-11-08 20:18:16.577344@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-08 20:18:16.882250||measurement||ad||2015-11-08 20:18:12.189654@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:18:16.949377||measurement||ad||2015-11-08 20:18:16.577344@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:18:16.949681||measurement||loadtime||0:00:06.134279||2||0
+2015-11-08 20:18:16.993559||measurement||ad||2015-11-08 20:18:12.189654@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:18:17.065048||measurement||ad||2015-11-08 20:18:12.189654@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:18:17.065337||measurement||loadtime||0:00:17.029552||3||1
+2015-11-08 20:18:23.140005||measurement||ad||2015-11-08 20:18:10.072741@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 20:18:26.884065||measurement||ad||2015-11-08 20:18:26.670097@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:18:27.069604||measurement||ad||2015-11-08 20:18:26.670097@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:18:27.222730||measurement||ad||2015-11-08 20:18:26.670097@|HUD Homes low as $10,000@|www.hudforeclosed.com@|$1 Trial to Search Foreclosures Now Find Homes You can Afford!||2||0
+2015-11-08 20:18:27.223002||measurement||loadtime||0:00:05.272951||2||0
+2015-11-08 20:18:27.711104||measurement||ad||2015-11-08 20:18:27.587775@|CNC Machine Services@|Repairs. Contact Us For More Info!@|We Do Most Installation, Service  ||1||0
+2015-11-08 20:18:27.711429||measurement||loadtime||0:00:06.400145||1||0
+2015-11-08 20:18:28.593448||measurement||ad||2015-11-08 20:18:10.072741@|Cleaner for Mac OS X@|idoctorapp.com@|IDoctor- First-Aid Kit for your Mac Keep your Mac Clean. Try Now!||0||1
+2015-11-08 20:18:28.593722||measurement||loadtime||0:00:31.127872||0||1
+2015-11-08 20:18:36.685425||measurement||ad||2015-11-08 20:18:33.497332@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:18:37.248413||measurement||ad||2015-11-08 20:18:37.072105@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:18:37.375694||measurement||ad||2015-11-08 20:18:37.072105@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||2||0
+2015-11-08 20:18:37.494177||measurement||ad||2015-11-08 20:18:37.072105@|5 Foods Hurt The Liver@|perfectorigins.com/5BadFoods@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||2||0
+2015-11-08 20:18:37.494454||measurement||loadtime||0:00:05.270073||2||0
+2015-11-08 20:18:37.692913||measurement||ad||2015-11-08 20:18:37.365758@|CNC Machine Services@|Repairs. Contact Us For More Info!@|We Do Most Installation, Service  ||1||0
+2015-11-08 20:18:37.693202||measurement||loadtime||0:00:04.981378||1||0
+2015-11-08 20:18:37.693359||event||progress-marker||measurement-end||1||0
+2015-11-08 20:18:38.488427||measurement||ad||2015-11-08 20:18:33.497332@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:18:38.604678||measurement||ad||2015-11-08 20:18:33.497332@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:18:38.604983||measurement||loadtime||0:00:16.539240||3||1
+2015-11-08 20:18:46.434301||measurement||ad||2015-11-08 20:18:42.450289@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:18:46.745157||measurement||ad||2015-11-08 20:18:42.450289@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 20:18:46.829832||measurement||ad||2015-11-08 20:18:46.689613@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:18:46.831558||measurement||ad||2015-11-08 20:18:42.450289@|Cleaner for Mac OS X@|idoctorapp.com@|IDoctor- First-Aid Kit for your Mac Keep your Mac Clean. Try Now!||0||1
+2015-11-08 20:18:46.831813||measurement||loadtime||0:00:13.237691||0||1
+2015-11-08 20:18:46.904536||measurement||ad||2015-11-08 20:18:46.689613@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:18:46.976146||measurement||ad||2015-11-08 20:18:46.689613@|Age 55+ Cruise Discounts@|vacationstogo.com@|Extra savings on cruises for travelers age 55+. Huge selection!||2||0
+2015-11-08 20:18:46.976372||measurement||loadtime||0:00:04.480032||2||0
+2015-11-08 20:18:46.976559||event||progress-marker||measurement-end||2||0
+2015-11-08 20:18:49.055791||measurement||ad||2015-11-08 20:18:48.582945@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:18:50.661290||measurement||ad||2015-11-08 20:18:48.582945@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:18:51.047406||measurement||ad||2015-11-08 20:18:48.582945@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:18:51.047670||measurement||loadtime||0:00:07.441297||3||1
+2015-11-08 20:19:01.994198||measurement||ad||2015-11-08 20:18:59.486454@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||0||1
+2015-11-08 20:19:02.404519||measurement||ad||2015-11-08 20:18:59.486454@|LG G4 Sale@|dealhunter.us/LG-G4@|2015 Bestselling LG G4 At Best Prices Ever!||0||1
+2015-11-08 20:19:04.300185||measurement||ad||2015-11-08 20:19:03.780445@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:19:06.255919||measurement||ad||2015-11-08 20:18:59.486454@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||1
+2015-11-08 20:19:06.256202||measurement||loadtime||0:00:14.423707||0||1
+2015-11-08 20:19:06.384040||measurement||ad||2015-11-08 20:19:03.780445@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||3||1
+2015-11-08 20:19:06.451275||measurement||ad||2015-11-08 20:19:03.780445@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:19:06.451561||measurement||loadtime||0:00:10.402504||3||1
+2015-11-08 20:19:06.451699||event||progress-marker||measurement-end||3||1
+2015-11-08 20:19:22.082745||measurement||ad||2015-11-08 20:19:20.000344@|16 Biggest Dogs in World@|pressroomvip.com/16-Biggest-Dogs@|We’ve Never seen anything like 'em! #6 Made Our Jaw Drop.||0||1
+2015-11-08 20:19:23.443033||measurement||ad||2015-11-08 20:19:20.000344@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-08 20:19:24.099190||measurement||ad||2015-11-08 20:19:20.000344@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||0||1
+2015-11-08 20:19:24.099534||measurement||loadtime||0:00:12.842736||0||1
+2015-11-08 20:19:24.099652||event||progress-marker||measurement-end||0||1
+2015-11-08 20:19:24.427456||meta||block_id end||12
+2015-11-08 20:19:24.429409||meta||block_id start||13
+2015-11-08 20:19:24.429440||meta||assignment||1@|3@|0@|2
+2015-11-08 20:19:27.060107||event||progress-marker||training-start||1||0
+2015-11-08 20:19:27.207027||event||progress-marker||training-start||3||0
+2015-11-08 20:19:28.838031||event||progress-marker||training-start||0||1
+2015-11-08 20:19:28.859035||event||progress-marker||training-start||2||1
+2015-11-08 20:19:35.377749||treatment||visit website||http://irs.gov||3||0
+2015-11-08 20:19:35.879316||treatment||visit website||http://irs.gov||1||0
+2015-11-08 20:19:37.291171||treatment||visit website||http://irs.gov||2||1
+2015-11-08 20:19:37.291890||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:19:43.122489||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 20:19:44.189260||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 20:19:45.772585||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 20:19:45.841745||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:19:54.852600||treatment||visit website||http://pwc.com||3||0
+2015-11-08 20:19:56.207948||treatment||visit website||http://pwc.com||1||0
+2015-11-08 20:19:57.393635||treatment||visit website||http://pwc.com||2||1
+2015-11-08 20:19:57.441458||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:20:01.776623||treatment||visit website||http://ey.com||3||0
+2015-11-08 20:20:03.564469||treatment||visit website||http://ey.com||1||0
+2015-11-08 20:20:04.754336||treatment||visit website||http://ey.com||2||1
+2015-11-08 20:20:04.818026||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:20:10.160065||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 20:20:10.160359||event||progress-marker||training-end||3||0
+2015-11-08 20:20:12.665244||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 20:20:12.665478||event||progress-marker||training-end||2||1
+2015-11-08 20:20:13.678336||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:20:13.678673||event||progress-marker||training-end||0||1
+2015-11-08 20:20:15.975675||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 20:20:15.975943||event||progress-marker||training-end||1||0
+2015-11-08 20:20:17.685846||event||progress-marker||measurement-start||2||1
+2015-11-08 20:20:18.700792||event||progress-marker||measurement-start||0||1
+2015-11-08 20:20:20.195389||event||progress-marker||measurement-start||3||0
+2015-11-08 20:20:20.999299||event||progress-marker||measurement-start||1||0
+2015-11-08 20:20:31.069769||measurement||ad||2015-11-08 20:20:30.594261@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||0||1
+2015-11-08 20:20:31.191601||measurement||ad||2015-11-08 20:20:30.606357@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||1
+2015-11-08 20:20:31.282248||measurement||ad||2015-11-08 20:20:30.594261@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:20:31.381671||measurement||ad||2015-11-08 20:20:30.606357@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||2||1
+2015-11-08 20:20:31.538903||measurement||ad||2015-11-08 20:20:30.594261@|Traffic Noise@|www.healio.com/chd-prevention@|Daytime traffic noise exposure may raise mortality risk.||0||1
+2015-11-08 20:20:31.539293||measurement||loadtime||0:00:07.837543||0||1
+2015-11-08 20:20:31.554857||measurement||ad||2015-11-08 20:20:30.606357@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:20:31.555196||measurement||loadtime||0:00:08.867811||2||1
+2015-11-08 20:20:36.000469||measurement||ad||2015-11-08 20:20:35.742331@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:20:36.091650||measurement||ad||2015-11-08 20:20:35.742331@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:20:36.224514||measurement||ad||2015-11-08 20:20:35.742331@|HUD Homes low as $10,000@|www.hudforeclosed.com@|$1 Trial to Search Foreclosures Now Find Homes You can Afford!||3||0
+2015-11-08 20:20:36.224838||measurement||loadtime||0:00:11.028539||3||0
+2015-11-08 20:20:38.044941||measurement||ad||2015-11-08 20:20:37.325883@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:20:38.302595||measurement||ad||2015-11-08 20:20:37.325883@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 20:20:38.502078||measurement||ad||2015-11-08 20:20:37.325883@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||1||0
+2015-11-08 20:20:38.502338||measurement||loadtime||0:00:12.501779||1||0
+2015-11-08 20:20:46.125072||measurement||ad||2015-11-08 20:20:45.637801@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:20:46.739134||measurement||ad||2015-11-08 20:20:45.637801@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 20:20:46.885748||measurement||ad||2015-11-08 20:20:45.637801@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 20:20:46.886001||measurement||loadtime||0:00:10.330215||2||1
+2015-11-08 20:20:48.401385||measurement||ad||2015-11-08 20:20:47.802271@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:20:48.603839||measurement||ad||2015-11-08 20:20:47.802271@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:20:48.760840||measurement||ad||2015-11-08 20:20:47.802271@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:20:48.761228||measurement||loadtime||0:00:12.220874||0||1
+2015-11-08 20:20:54.003789||measurement||ad||2015-11-08 20:20:53.608927@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:20:54.772284||measurement||ad||2015-11-08 20:20:53.608927@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:20:55.463821||measurement||ad||2015-11-08 20:20:53.608927@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Your Destination. Get Directions with FreeMaps App||1||0
+2015-11-08 20:20:55.464096||measurement||loadtime||0:00:11.960706||1||0
+2015-11-08 20:20:56.838650||measurement||ad||2015-11-08 20:20:56.527122@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:20:58.036237||measurement||ad||2015-11-08 20:20:56.527122@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:20:58.803834||measurement||ad||2015-11-08 20:20:56.527122@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||3||0
+2015-11-08 20:20:58.804109||measurement||loadtime||0:00:17.578059||3||0
+2015-11-08 20:21:03.735157||measurement||ad||2015-11-08 20:21:02.770464@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:21:04.022573||measurement||ad||2015-11-08 20:21:02.770464@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||1
+2015-11-08 20:21:04.213664||measurement||ad||2015-11-08 20:21:02.770464@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:21:04.214432||measurement||loadtime||0:00:10.452072||0||1
+2015-11-08 20:21:06.092221||measurement||ad||2015-11-08 20:21:04.367317@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:21:06.286568||measurement||ad||2015-11-08 20:21:04.367317@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||1
+2015-11-08 20:21:06.693758||measurement||ad||2015-11-08 20:21:04.367317@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:21:06.694015||measurement||loadtime||0:00:14.807232||2||1
+2015-11-08 20:21:12.348203||measurement||ad||2015-11-08 20:21:11.564583@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:21:12.595938||measurement||ad||2015-11-08 20:21:11.564583@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:21:12.927095||measurement||ad||2015-11-08 20:21:11.564583@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:21:12.927375||measurement||loadtime||0:00:12.461327||1||0
+2015-11-08 20:21:16.828235||measurement||ad||2015-11-08 20:21:15.713920@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:21:17.715999||measurement||ad||2015-11-08 20:21:15.713920@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||0
+2015-11-08 20:21:18.275446||measurement||ad||2015-11-08 20:21:17.698437@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:21:18.419475||measurement||ad||2015-11-08 20:21:17.698437@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||1
+2015-11-08 20:21:18.546155||measurement||ad||2015-11-08 20:21:17.698437@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:21:18.546456||measurement||loadtime||0:00:09.331275||0||1
+2015-11-08 20:21:18.831132||measurement||ad||2015-11-08 20:21:15.713920@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:21:18.831413||measurement||loadtime||0:00:15.026545||3||0
+2015-11-08 20:21:19.740279||measurement||ad||2015-11-08 20:21:19.412960@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:21:19.857397||measurement||ad||2015-11-08 20:21:19.412960@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 20:21:19.998749||measurement||ad||2015-11-08 20:21:19.412960@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 20:21:19.998980||measurement||loadtime||0:00:08.304379||2||1
+2015-11-08 20:21:38.045576||measurement||ad||2015-11-08 20:21:36.510393@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:21:38.576961||measurement||ad||2015-11-08 20:21:36.510393@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:21:38.945597||measurement||ad||2015-11-08 20:21:36.510393@|Boingo® Unlimited Wi-Fi@|boingo.com/Unlimited-Wi-Fi@|10X Faster Than 3G/4G. 1st Mo $4.98 No Contracts. Sign Up From Mobile.||2||1
+2015-11-08 20:21:38.945880||measurement||loadtime||0:00:13.945680||2||1
+2015-11-08 20:21:41.764418||measurement||ad||2015-11-08 20:21:39.829157@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:21:42.415445||measurement||ad||2015-11-08 20:21:39.829157@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:21:42.983196||measurement||ad||2015-11-08 20:21:39.829157@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:21:42.985057||measurement||loadtime||0:00:25.055503||1||0
+2015-11-08 20:21:50.982563||measurement||ad||2015-11-08 20:21:49.674968@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:21:51.048990||measurement||ad||2015-11-08 20:21:49.674968@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 20:21:51.126430||measurement||ad||2015-11-08 20:21:49.674968@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 20:21:51.126691||measurement||loadtime||0:00:07.180094||2||1
+2015-11-08 20:21:58.825902||measurement||ad||2015-11-08 20:21:58.326302@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||1||0
+2015-11-08 20:21:58.826275||measurement||loadtime||0:00:10.840187||1||0
+2015-11-08 20:22:01.658891||measurement||ad||2015-11-08 20:21:56.556293@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:22:01.713278||measurement||ad||2015-11-08 20:21:56.556293@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:22:01.763606||measurement||ad||2015-11-08 20:21:56.556293@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||2||1
+2015-11-08 20:22:01.763921||measurement||loadtime||0:00:05.636603||2||1
+2015-11-08 20:22:11.442848||measurement||ad||2015-11-08 20:22:10.975271@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:22:11.570499||measurement||ad||2015-11-08 20:22:10.975271@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:22:11.771797||measurement||ad||2015-11-08 20:22:10.975271@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-08 20:22:11.772042||measurement||loadtime||0:00:05.006725||2||1
+2015-11-08 20:22:12.371444||measurement||ad||2015-11-08 20:22:11.968412@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||1||0
+2015-11-08 20:22:12.371760||measurement||loadtime||0:00:08.544895||1||0
+2015-11-08 20:22:24.029214||error||collecting ads||Error||3||0
+2015-11-08 20:22:24.827853||measurement||ad||2015-11-08 20:22:24.426985@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||1||0
+2015-11-08 20:22:24.829527||measurement||loadtime||0:00:07.456284||1||0
+2015-11-08 20:22:35.459752||measurement||ad||2015-11-08 20:22:35.032266@|Swistek Machine Services@|Contact Us For Info  Pricing!@|Machines, Services  Repairs. ||1||0
+2015-11-08 20:22:35.460051||measurement||loadtime||0:00:05.629744||1||0
+2015-11-08 20:22:39.925568||measurement||ad||2015-11-08 20:22:39.624942@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:22:40.260606||measurement||ad||2015-11-08 20:22:39.624942@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||3||0
+2015-11-08 20:22:40.529621||measurement||ad||2015-11-08 20:22:39.624942@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||3||0
+2015-11-08 20:22:40.529931||measurement||loadtime||0:00:11.500237||3||0
+2015-11-08 20:22:52.552953||measurement||ad||2015-11-08 20:22:52.259675@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:22:52.761846||measurement||ad||2015-11-08 20:22:52.259675@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||0
+2015-11-08 20:22:52.933502||measurement||ad||2015-11-08 20:22:52.259675@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||0
+2015-11-08 20:22:52.933749||measurement||loadtime||0:00:07.402026||3||0
+2015-11-08 20:22:58.978199||measurement||ad||2015-11-08 20:21:39.875290@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:22:59.077843||measurement||ad||2015-11-08 20:21:39.875290@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:22:59.175957||measurement||ad||2015-11-08 20:21:39.875290@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:22:59.176235||measurement||loadtime||0:01:35.629431||0||1
+2015-11-08 20:23:03.298779||measurement||ad||2015-11-08 20:23:02.958483@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:23:03.530582||measurement||ad||2015-11-08 20:23:02.958483@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-08 20:23:03.661725||measurement||ad||2015-11-08 20:23:02.958483@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||3||0
+2015-11-08 20:23:03.661936||measurement||loadtime||0:00:05.727816||3||0
+2015-11-08 20:23:12.902539||measurement||ad||2015-11-08 20:23:12.494389@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:23:13.246022||measurement||ad||2015-11-08 20:23:12.494389@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||1
+2015-11-08 20:23:13.660864||measurement||ad||2015-11-08 20:23:12.494389@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||0||1
+2015-11-08 20:23:13.661156||measurement||loadtime||0:00:09.484436||0||1
+2015-11-08 20:23:16.796639||error||collecting ads||Error||2||1
+2015-11-08 20:23:18.803319||measurement||ad||2015-11-08 20:23:17.886416@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:23:19.410763||measurement||ad||2015-11-08 20:23:17.886416@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||3||0
+2015-11-08 20:23:20.399076||measurement||ad||2015-11-08 20:23:17.886416@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||3||0
+2015-11-08 20:23:20.399560||measurement||loadtime||0:00:11.736551||3||0
+2015-11-08 20:23:26.794326||measurement||ad||2015-11-08 20:23:25.928333@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:23:26.871516||measurement||ad||2015-11-08 20:23:25.928333@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||1
+2015-11-08 20:23:26.906427||measurement||ad||2015-11-08 20:23:26.786933@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||1
+2015-11-08 20:23:26.969833||measurement||ad||2015-11-08 20:23:26.786933@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:23:26.977994||measurement||ad||2015-11-08 20:23:25.928333@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:23:26.978252||measurement||loadtime||0:00:08.316405||0||1
+2015-11-08 20:23:27.027581||measurement||ad||2015-11-08 20:23:26.786933@|Boingo® Unlimited Wi-Fi@|boingo.com/Unlimited-Wi-Fi@|10X Faster Than 3G/4G. 1st Mo $4.98 No Contracts. Sign Up From Mobile.||2||1
+2015-11-08 20:23:27.027906||measurement||loadtime||0:00:05.230117||2||1
+2015-11-08 20:23:27.028092||event||progress-marker||measurement-end||2||1
+2015-11-08 20:23:38.328414||measurement||ad||2015-11-08 20:23:37.938218@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:23:38.425844||measurement||ad||2015-11-08 20:23:37.938218@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:23:38.503939||measurement||ad||2015-11-08 20:23:37.938218@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:23:38.504141||measurement||loadtime||0:00:06.524339||0||1
+2015-11-08 20:23:40.573038||error||collecting ads||Error||1||0
+2015-11-08 20:23:47.505973||measurement||ad||2015-11-08 20:23:47.288241@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:23:47.555544||measurement||ad||2015-11-08 20:23:47.288241@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||0||1
+2015-11-08 20:23:47.644879||measurement||ad||2015-11-08 20:23:47.288241@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||0||1
+2015-11-08 20:23:47.645147||measurement||loadtime||0:00:04.139585||0||1
+2015-11-08 20:23:56.186346||measurement||ad||2015-11-08 20:23:55.652457@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:23:56.361996||measurement||ad||2015-11-08 20:23:55.652457@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:23:56.512769||measurement||ad||2015-11-08 20:23:55.652457@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:23:56.513053||measurement||loadtime||0:00:10.938422||1||0
+2015-11-08 20:23:56.513271||event||progress-marker||measurement-end||1||0
+2015-11-08 20:24:16.938423||measurement||ad||2015-11-08 20:24:16.771024@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:24:16.978544||measurement||ad||2015-11-08 20:24:16.771024@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:24:17.013864||measurement||ad||2015-11-08 20:24:16.771024@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||0||1
+2015-11-08 20:24:17.014178||measurement||loadtime||0:00:24.368473||0||1
+2015-11-08 20:24:17.014328||event||progress-marker||measurement-end||0||1
+2015-11-08 20:24:25.469903||error||collecting ads||Error||3||0
+2015-11-08 20:24:35.532724||measurement||ad||2015-11-08 20:24:35.428835@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||0
+2015-11-08 20:24:35.652078||measurement||ad||2015-11-08 20:24:35.428835@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||3||0
+2015-11-08 20:24:35.749641||measurement||ad||2015-11-08 20:24:35.428835@|10Kw Wind Turbines Sale@|dealhunter.us@|BestSelling 10Kw Wind Turbines At Best Prices Ever!||3||0
+2015-11-08 20:24:35.749937||measurement||loadtime||0:00:05.278575||3||0
+2015-11-08 20:24:35.750158||event||progress-marker||measurement-end||3||0
+2015-11-08 20:24:36.237528||meta||block_id end||13
+2015-11-08 20:24:36.238477||meta||block_id start||14
+2015-11-08 20:24:36.238510||meta||assignment||2@|3@|1@|0
+2015-11-08 20:24:38.905313||event||progress-marker||training-start||3||0
+2015-11-08 20:24:38.928668||event||progress-marker||training-start||2||0
+2015-11-08 20:24:40.658666||event||progress-marker||training-start||0||1
+2015-11-08 20:24:40.851615||event||progress-marker||training-start||1||1
+2015-11-08 20:24:47.512344||treatment||visit website||http://irs.gov||3||0
+2015-11-08 20:24:47.811625||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:24:48.566817||treatment||visit website||http://irs.gov||1||1
+2015-11-08 20:24:48.592053||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:24:56.384766||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 20:24:57.787383||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:24:57.808958||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:24:57.914320||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 20:25:07.858611||treatment||visit website||http://pwc.com||3||0
+2015-11-08 20:25:08.906622||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:25:09.852285||treatment||visit website||http://pwc.com||1||1
+2015-11-08 20:25:10.210967||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:25:15.122108||treatment||visit website||http://ey.com||3||0
+2015-11-08 20:25:16.468523||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:25:17.918386||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:25:17.938757||treatment||visit website||http://ey.com||1||1
+2015-11-08 20:25:22.688107||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 20:25:22.688882||event||progress-marker||training-end||3||0
+2015-11-08 20:25:24.390096||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:25:24.390361||event||progress-marker||training-end||2||0
+2015-11-08 20:25:25.785378||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 20:25:25.785728||event||progress-marker||training-end||1||1
+2015-11-08 20:25:25.957082||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:25:25.957631||event||progress-marker||training-end||0||1
+2015-11-08 20:25:27.714457||event||progress-marker||measurement-start||3||0
+2015-11-08 20:25:29.414512||event||progress-marker||measurement-start||2||0
+2015-11-08 20:25:30.810625||event||progress-marker||measurement-start||1||1
+2015-11-08 20:25:30.985601||event||progress-marker||measurement-start||0||1
+2015-11-08 20:25:45.555271||measurement||ad||2015-11-08 20:25:44.751603@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||0
+2015-11-08 20:25:45.968407||measurement||ad||2015-11-08 20:25:44.751603@|Site Closure@|www.terra-petra.com@|National Environmental Engineering firm to assist on site closures||3||0
+2015-11-08 20:25:46.218894||measurement||ad||2015-11-08 20:25:44.751603@|AgBioResearch@|agbioresearch.msu.edu@|Read the latest news on innovative agricultural research.||3||0
+2015-11-08 20:25:46.219199||measurement||loadtime||0:00:13.503744||3||0
+2015-11-08 20:25:48.665043||measurement||ad||2015-11-08 20:25:47.698042@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:25:49.084577||measurement||ad||2015-11-08 20:25:47.698042@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||0||1
+2015-11-08 20:25:49.439069||measurement||ad||2015-11-08 20:25:47.698042@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:25:49.439340||measurement||loadtime||0:00:13.452544||0||1
+2015-11-08 20:25:49.697085||measurement||ad||2015-11-08 20:25:48.943293@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||1||1
+2015-11-08 20:25:49.798872||measurement||ad||2015-11-08 20:25:48.943293@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:25:49.948069||measurement||ad||2015-11-08 20:25:48.943293@|Chelsea NY Hotel Deals@|www.choicehotels.com/Chelsea@|Book Now for Our Best Internet Rates in New York Guaranteed!||1||1
+2015-11-08 20:25:49.948412||measurement||loadtime||0:00:14.137318||1||1
+2015-11-08 20:25:55.667924||measurement||ad||2015-11-08 20:25:55.233680@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:25:55.870868||measurement||ad||2015-11-08 20:25:55.233680@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:25:56.007906||measurement||ad||2015-11-08 20:25:55.233680@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:25:56.008251||measurement||loadtime||0:00:21.593087||2||0
+2015-11-08 20:26:04.414879||measurement||ad||2015-11-08 20:26:04.012602@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:26:04.517141||measurement||ad||2015-11-08 20:26:04.012602@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:26:04.622163||measurement||ad||2015-11-08 20:26:04.012602@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:26:04.622440||measurement||loadtime||0:00:10.182645||0||1
+2015-11-08 20:26:05.258893||measurement||ad||2015-11-08 20:26:04.925143@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||1||1
+2015-11-08 20:26:05.361962||measurement||ad||2015-11-08 20:26:04.925143@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-08 20:26:05.462481||measurement||ad||2015-11-08 20:26:04.925143@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:26:05.462750||measurement||loadtime||0:00:10.512927||1||1
+2015-11-08 20:26:07.204512||measurement||ad||2015-11-08 20:26:06.828969@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||0
+2015-11-08 20:26:07.498818||measurement||ad||2015-11-08 20:26:06.828969@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||0
+2015-11-08 20:26:07.780620||measurement||ad||2015-11-08 20:26:06.828969@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||3||0
+2015-11-08 20:26:07.780887||measurement||loadtime||0:00:16.560265||3||0
+2015-11-08 20:26:09.847359||measurement||ad||2015-11-08 20:26:09.667369@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:26:10.182653||measurement||ad||2015-11-08 20:26:09.667369@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:26:10.418409||measurement||ad||2015-11-08 20:26:09.667369@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:26:10.418641||measurement||loadtime||0:00:09.408967||2||0
+2015-11-08 20:26:17.366290||measurement||ad||2015-11-08 20:26:16.802408@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:26:17.579027||measurement||ad||2015-11-08 20:26:16.802408@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||1||1
+2015-11-08 20:26:17.722521||measurement||ad||2015-11-08 20:26:16.802408@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:26:17.723558||measurement||loadtime||0:00:07.259900||1||1
+2015-11-08 20:26:25.816934||measurement||ad||2015-11-08 20:26:24.975206@|Law and Economics Blog@|specieaeternitatis.blogspot.com@|"Pretty much the most interesting blog on the Internet." Econ. Prof.||3||0
+2015-11-08 20:26:26.277792||measurement||ad||2015-11-08 20:26:24.975206@|Paintless Dent Repair@|www.metzgerauto.com@|Free headlight restoration Paintless Dent Repair||3||0
+2015-11-08 20:26:26.567711||measurement||ad||2015-11-08 20:26:24.975206@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||3||0
+2015-11-08 20:26:26.567985||measurement||loadtime||0:00:13.785956||3||0
+2015-11-08 20:26:29.184725||measurement||ad||2015-11-08 20:26:28.696536@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||1||1
+2015-11-08 20:26:29.315593||measurement||ad||2015-11-08 20:26:28.696536@|Chelsea NY Hotel Deals@|www.choicehotels.com/Chelsea@|Book Now for Our Best Internet Rates in New York Guaranteed!||1||1
+2015-11-08 20:26:29.407803||measurement||ad||2015-11-08 20:26:28.696536@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:26:29.408095||measurement||loadtime||0:00:06.683860||1||1
+2015-11-08 20:26:37.990776||measurement||ad||2015-11-08 20:26:37.712354@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||0
+2015-11-08 20:26:38.173669||measurement||ad||2015-11-08 20:26:37.712354@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||3||0
+2015-11-08 20:26:38.360480||measurement||ad||2015-11-08 20:26:37.712354@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||0
+2015-11-08 20:26:38.360837||measurement||loadtime||0:00:06.791352||3||0
+2015-11-08 20:26:39.250759||measurement||ad||2015-11-08 20:26:19.502618@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:26:39.334192||measurement||ad||2015-11-08 20:26:19.502618@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:26:39.394604||measurement||ad||2015-11-08 20:26:19.502618@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:26:39.394827||measurement||loadtime||0:00:29.771889||0||1
+2015-11-08 20:26:40.550763||measurement||ad||2015-11-08 20:26:40.218105@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:26:40.622215||measurement||ad||2015-11-08 20:26:40.218105@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:26:40.687308||measurement||ad||2015-11-08 20:26:40.218105@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:26:40.687481||measurement||loadtime||0:00:06.278025||1||1
+2015-11-08 20:26:50.020811||measurement||ad||2015-11-08 20:26:44.494792@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:26:50.234020||measurement||ad||2015-11-08 20:26:44.494792@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:26:50.740234||measurement||ad||2015-11-08 20:26:44.494792@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:26:50.740500||measurement||loadtime||0:00:06.344431||0||1
+2015-11-08 20:26:52.485489||measurement||ad||2015-11-08 20:26:51.535601@|Carnegie Institution@|www.carnegiescience.edu@|for Science. Over 100 years of discoveries||3||0
+2015-11-08 20:26:52.541619||measurement||ad||2015-11-08 20:26:51.977912@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:26:52.614943||measurement||ad||2015-11-08 20:26:51.977912@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||1||1
+2015-11-08 20:26:52.702279||measurement||ad||2015-11-08 20:26:51.977912@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:26:52.703363||measurement||loadtime||0:00:07.013754||1||1
+2015-11-08 20:26:52.890516||measurement||ad||2015-11-08 20:26:51.535601@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:26:53.190489||measurement||ad||2015-11-08 20:26:51.535601@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||0
+2015-11-08 20:26:53.191591||measurement||loadtime||0:00:09.829172||3||0
+2015-11-08 20:27:01.524161||measurement||ad||2015-11-08 20:27:01.304301@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:27:01.747198||measurement||ad||2015-11-08 20:27:01.304301@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:27:01.844034||measurement||ad||2015-11-08 20:27:01.304301@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-08 20:27:01.844313||measurement||loadtime||0:00:06.102252||0||1
+2015-11-08 20:27:03.708647||measurement||ad||2015-11-08 20:27:03.444081@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||1||1
+2015-11-08 20:27:03.933026||measurement||ad||2015-11-08 20:27:03.444081@|Chelsea NY Hotel Deals@|www.choicehotels.com/Chelsea@|Book Now for Our Best Internet Rates in New York Guaranteed!||1||1
+2015-11-08 20:27:04.118561||measurement||ad||2015-11-08 20:27:03.444081@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-08 20:27:04.118859||measurement||loadtime||0:00:06.412957||1||1
+2015-11-08 20:27:09.941428||measurement||ad||2015-11-08 20:27:08.626648@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||0
+2015-11-08 20:27:11.291772||measurement||ad||2015-11-08 20:27:08.626648@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||3||0
+2015-11-08 20:27:11.783575||measurement||ad||2015-11-08 20:27:08.626648@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||3||0
+2015-11-08 20:27:11.783910||measurement||loadtime||0:00:13.590856||3||0
+2015-11-08 20:27:14.212666||measurement||ad||2015-11-08 20:27:13.750220@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:27:14.273593||measurement||ad||2015-11-08 20:27:13.750220@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:27:14.343170||measurement||ad||2015-11-08 20:27:13.750220@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:27:14.343444||measurement||loadtime||0:00:07.497673||0||1
+2015-11-08 20:27:14.843062||measurement||ad||2015-11-08 20:27:14.590988@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:27:14.899824||measurement||ad||2015-11-08 20:27:14.590988@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||1||1
+2015-11-08 20:27:14.965280||measurement||ad||2015-11-08 20:27:14.590988@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:27:14.965584||measurement||loadtime||0:00:05.846125||1||1
+2015-11-08 20:27:15.632456||error||collecting ads||Error||2||0
+2015-11-08 20:27:25.125767||measurement||ad||2015-11-08 20:27:24.700182@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:27:25.417495||measurement||ad||2015-11-08 20:27:24.700182@|Samsung Galaxy Note 5@|pricemall.us/Galaxy-Note-5@|Incredible Deals On Galaxy Note 5 Compare All Offers across Sellers||1||1
+2015-11-08 20:27:25.498573||measurement||ad||2015-11-08 20:27:24.700182@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:27:25.498810||measurement||loadtime||0:00:05.532820||1||1
+2015-11-08 20:27:27.429762||measurement||ad||2015-11-08 20:27:27.030202@|Custom Luxury Curtains@|Affordable Custom Window Treatment@|Up to 90% off Retail Price! ||3||0
+2015-11-08 20:27:27.430229||measurement||loadtime||0:00:10.645631||3||0
+2015-11-08 20:27:29.522126||measurement||ad||2015-11-08 20:27:29.197086@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:27:29.593663||measurement||ad||2015-11-08 20:27:29.197086@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:27:29.643457||measurement||ad||2015-11-08 20:27:29.197086@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:27:29.643741||measurement||loadtime||0:00:10.298847||0||1
+2015-11-08 20:27:35.078428||measurement||ad||2015-11-08 20:27:34.039953@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:27:36.162324||measurement||ad||2015-11-08 20:27:35.730789@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:27:36.240282||measurement||ad||2015-11-08 20:27:35.730789@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||1||1
+2015-11-08 20:27:36.302524||measurement||ad||2015-11-08 20:27:35.730789@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:27:36.302835||measurement||loadtime||0:00:05.802655||1||1
+2015-11-08 20:27:36.303106||event||progress-marker||measurement-end||1||1
+2015-11-08 20:27:36.837114||measurement||ad||2015-11-08 20:27:34.039953@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:27:37.421691||measurement||ad||2015-11-08 20:27:34.039953@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:27:37.422408||measurement||loadtime||0:00:16.789158||2||0
+2015-11-08 20:28:08.640178||measurement||ad||2015-11-08 20:28:08.333545@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:28:08.978304||measurement||ad||2015-11-08 20:28:08.333545@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:28:09.191210||measurement||ad||2015-11-08 20:28:08.333545@|Portable Oxygen Sale@|comparestores.net/Portable-Oxygen@|Up To 55% Off Portable Oxygen Check Today's Low Prices  Save.||2||0
+2015-11-08 20:28:09.191537||measurement||loadtime||0:00:26.767411||2||0
+2015-11-08 20:28:21.475350||measurement||ad||2015-11-08 20:28:21.315140@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:28:21.611497||measurement||ad||2015-11-08 20:28:21.315140@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:28:21.714956||measurement||ad||2015-11-08 20:28:21.315140@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:28:21.715357||measurement||loadtime||0:00:07.522556||2||0
+2015-11-08 20:28:31.261676||measurement||ad||2015-11-08 20:28:31.113758@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:28:31.391468||measurement||ad||2015-11-08 20:28:31.113758@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:28:31.525670||measurement||ad||2015-11-08 20:28:31.113758@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:28:31.525938||measurement||loadtime||0:00:04.810086||2||0
+2015-11-08 20:28:32.671368||error||collecting ads||Error||3||0
+2015-11-08 20:28:41.858928||measurement||ad||2015-11-08 20:28:41.673098@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:28:42.001426||measurement||ad||2015-11-08 20:28:41.889672@|Cost Estimating Software@|www.mtisystems.com@|Machining  Fabrication 1600+ Worldwide Users - Free Demo||3||0
+2015-11-08 20:28:42.013642||measurement||ad||2015-11-08 20:28:41.673098@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:28:42.102572||measurement||ad||2015-11-08 20:28:41.889672@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||3||0
+2015-11-08 20:28:42.102787||measurement||loadtime||0:00:04.430816||3||0
+2015-11-08 20:28:42.159310||measurement||ad||2015-11-08 20:28:41.673098@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:28:42.159659||measurement||loadtime||0:00:05.633079||2||0
+2015-11-08 20:28:51.902809||measurement||ad||2015-11-08 20:28:51.788642@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:28:52.015395||measurement||ad||2015-11-08 20:28:51.788642@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:28:52.129962||measurement||ad||2015-11-08 20:28:51.788642@|Portable Oxygen Sale@|comparestores.net/Portable-Oxygen@|Up To 55% Off Portable Oxygen Check Today's Low Prices  Save.||2||0
+2015-11-08 20:28:52.130207||measurement||loadtime||0:00:04.969570||2||0
+2015-11-08 20:28:52.664436||measurement||ad||2015-11-08 20:28:52.519194@|Carnegie Institution@|www.carnegiescience.edu@|for Science. Over 100 years of discoveries||3||0
+2015-11-08 20:28:52.836157||measurement||ad||2015-11-08 20:28:52.519194@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:28:53.085061||measurement||ad||2015-11-08 20:28:52.519194@|AgBioResearch@|agbioresearch.msu.edu@|Read the latest news on innovative agricultural research.||3||0
+2015-11-08 20:28:53.085371||measurement||loadtime||0:00:05.981940||3||0
+2015-11-08 20:28:53.085544||event||progress-marker||measurement-end||3||0
+2015-11-08 20:29:01.244320||measurement||ad||2015-11-08 20:29:01.107964@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:29:01.339674||measurement||ad||2015-11-08 20:29:01.107964@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 20:29:01.456398||measurement||ad||2015-11-08 20:29:01.107964@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:29:01.456665||measurement||loadtime||0:00:04.325013||2||0
+2015-11-08 20:29:01.456959||event||progress-marker||measurement-end||2||0
+2015-11-08 20:29:10.233693||measurement||ad||2015-11-08 20:27:39.305779@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:29:10.268077||measurement||ad||2015-11-08 20:27:39.305779@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:29:10.300920||measurement||ad||2015-11-08 20:27:39.305779@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:29:10.301121||measurement||loadtime||0:01:35.656092||0||1
+2015-11-08 20:29:20.111405||measurement||ad||2015-11-08 20:29:19.928903@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:29:20.161315||measurement||ad||2015-11-08 20:29:19.928903@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:29:20.198219||measurement||ad||2015-11-08 20:29:19.928903@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:29:20.198453||measurement||loadtime||0:00:04.896460||0||1
+2015-11-08 20:29:29.044233||measurement||ad||2015-11-08 20:29:28.941421@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:29:29.089674||measurement||ad||2015-11-08 20:29:28.941421@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:29:29.272553||measurement||ad||2015-11-08 20:29:28.941421@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:29:29.272825||measurement||loadtime||0:00:04.073682||0||1
+2015-11-08 20:29:29.273027||event||progress-marker||measurement-end||0||1
+2015-11-08 20:29:29.591525||meta||block_id end||14
+2015-11-08 20:29:29.592515||meta||block_id start||15
+2015-11-08 20:29:29.592531||meta||assignment||2@|3@|0@|1
+2015-11-08 20:29:32.247026||event||progress-marker||training-start||3||0
+2015-11-08 20:29:32.416981||event||progress-marker||training-start||2||0
+2015-11-08 20:29:33.995606||event||progress-marker||training-start||0||1
+2015-11-08 20:29:34.170973||event||progress-marker||training-start||1||1
+2015-11-08 20:29:40.841281||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:29:41.007523||treatment||visit website||http://irs.gov||3||0
+2015-11-08 20:29:42.054512||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:29:42.099114||treatment||visit website||http://irs.gov||1||1
+2015-11-08 20:29:49.103755||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:29:49.436396||treatment||visit website||http://deloitte.com||3||0
+2015-11-08 20:29:50.677792||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:29:50.930409||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 20:30:00.217204||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:30:01.016691||treatment||visit website||http://pwc.com||3||0
+2015-11-08 20:30:02.548838||treatment||visit website||http://pwc.com||1||1
+2015-11-08 20:30:02.551875||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:30:07.517783||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:30:08.285407||treatment||visit website||http://ey.com||3||0
+2015-11-08 20:30:10.139784||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:30:10.154636||treatment||visit website||http://ey.com||1||1
+2015-11-08 20:30:15.397635||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:30:15.397958||event||progress-marker||training-end||2||0
+2015-11-08 20:30:16.252446||treatment||visit website||http://kpmg.com||3||0
+2015-11-08 20:30:16.252653||event||progress-marker||training-end||3||0
+2015-11-08 20:30:17.810072||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:30:17.810371||event||progress-marker||training-end||0||1
+2015-11-08 20:30:17.846208||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 20:30:17.846465||event||progress-marker||training-end||1||1
+2015-11-08 20:30:20.421897||event||progress-marker||measurement-start||2||0
+2015-11-08 20:30:21.273753||event||progress-marker||measurement-start||3||0
+2015-11-08 20:30:22.833099||event||progress-marker||measurement-start||0||1
+2015-11-08 20:30:22.872367||event||progress-marker||measurement-start||1||1
+2015-11-08 20:30:36.741109||measurement||ad||2015-11-08 20:30:35.855358@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:30:37.389583||measurement||ad||2015-11-08 20:30:35.855358@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:30:37.592078||measurement||ad||2015-11-08 20:30:35.855358@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:30:37.592360||measurement||loadtime||0:00:09.758606||0||1
+2015-11-08 20:30:37.790110||measurement||ad||2015-11-08 20:30:37.229468@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||1||1
+2015-11-08 20:30:37.929069||measurement||ad||2015-11-08 20:30:37.229468@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||1||1
+2015-11-08 20:30:38.115325||measurement||ad||2015-11-08 20:30:37.229468@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:30:38.115696||measurement||loadtime||0:00:10.241858||1||1
+2015-11-08 20:30:40.267340||measurement||ad||2015-11-08 20:30:40.059897@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||0
+2015-11-08 20:30:40.442368||measurement||ad||2015-11-08 20:30:40.059897@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||0
+2015-11-08 20:30:40.581339||measurement||ad||2015-11-08 20:30:40.059897@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:30:40.581657||measurement||loadtime||0:00:14.306367||3||0
+2015-11-08 20:30:50.117547||measurement||ad||2015-11-08 20:30:49.885500@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:30:50.418549||measurement||ad||2015-11-08 20:30:49.885500@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 20:30:50.557686||measurement||ad||2015-11-08 20:30:49.885500@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:30:50.558044||measurement||loadtime||0:00:25.135227||2||0
+2015-11-08 20:30:52.767916||measurement||ad||2015-11-08 20:30:51.873754@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:30:53.012536||measurement||ad||2015-11-08 20:30:51.873754@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:30:53.315711||measurement||ad||2015-11-08 20:30:51.873754@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:30:53.315943||measurement||loadtime||0:00:10.723099||0||1
+2015-11-08 20:30:53.679453||measurement||ad||2015-11-08 20:30:52.245760@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:30:53.916987||measurement||ad||2015-11-08 20:30:52.245760@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:30:54.158690||measurement||ad||2015-11-08 20:30:52.245760@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:30:54.158968||measurement||loadtime||0:00:11.042793||1||1
+2015-11-08 20:30:57.230374||measurement||ad||2015-11-08 20:30:56.539346@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||0
+2015-11-08 20:30:57.727039||measurement||ad||2015-11-08 20:30:56.539346@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||0
+2015-11-08 20:30:57.934877||measurement||ad||2015-11-08 20:30:56.539346@|Best Dry Dog Food@|www.whole-dog-journal.com@|Unbiased Dry Dog Food Reviews All in Whole Dog Journal Magazine||3||0
+2015-11-08 20:30:57.935147||measurement||loadtime||0:00:12.352539||3||0
+2015-11-08 20:31:11.652278||measurement||ad||2015-11-08 20:31:10.826767@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:31:12.141908||measurement||ad||2015-11-08 20:31:10.826767@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:31:12.300283||measurement||ad||2015-11-08 20:31:10.826767@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:31:12.300615||measurement||loadtime||0:00:13.983252||0||1
+2015-11-08 20:31:14.758587||measurement||ad||2015-11-08 20:31:11.919124@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:31:15.444655||measurement||ad||2015-11-08 20:31:11.919124@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:31:15.845244||measurement||ad||2015-11-08 20:31:11.919124@|Airport Car Rentals@|lowerprices.us/Airport-Car-Rentals@|Looking For Airport Car Rentals? Compare Today's Top Offers  Save!||1||1
+2015-11-08 20:31:15.845513||measurement||loadtime||0:00:16.686026||1||1
+2015-11-08 20:31:19.014258||measurement||ad||2015-11-08 20:31:18.740635@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:31:19.394035||measurement||ad||2015-11-08 20:31:18.740635@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 20:31:19.917367||measurement||ad||2015-11-08 20:31:18.740635@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:31:19.917683||measurement||loadtime||0:00:24.358412||2||0
+2015-11-08 20:31:23.089045||measurement||ad||2015-11-08 20:31:21.779748@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:31:24.328823||measurement||ad||2015-11-08 20:31:21.779748@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||0
+2015-11-08 20:31:26.048815||measurement||ad||2015-11-08 20:31:21.779748@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||0
+2015-11-08 20:31:26.049075||measurement||loadtime||0:00:23.111896||3||0
+2015-11-08 20:31:28.922663||measurement||ad||2015-11-08 20:31:28.423424@|8% Annual Annuity Return@|reduced risks to retirees all here.@|Get guaranteed lifetime income and ||1||1
+2015-11-08 20:31:28.922965||measurement||loadtime||0:00:08.076056||1||1
+2015-11-08 20:31:41.457770||measurement||ad||2015-11-08 20:31:41.273840@|16 Biggest Dogs Ever@|pressroomvip.com/16-Biggest-Dogs@|See the Biggest Dogs of All Time! You'll Never Believe #6.||1||1
+2015-11-08 20:31:41.524804||measurement||ad||2015-11-08 20:31:41.273840@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:31:41.624738||measurement||ad||2015-11-08 20:31:41.273840@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||1
+2015-11-08 20:31:41.625009||measurement||loadtime||0:00:07.701429||1||1
+2015-11-08 20:31:43.851127||measurement||ad||2015-11-08 20:31:43.478639@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:31:43.924952||measurement||ad||2015-11-08 20:31:43.478639@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:31:43.975917||measurement||ad||2015-11-08 20:31:43.478639@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:31:43.976181||measurement||loadtime||0:00:26.674599||0||1
+2015-11-08 20:31:49.593230||measurement||ad||2015-11-08 20:31:47.741414@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:31:53.441733||measurement||ad||2015-11-08 20:31:47.741414@|Forensic Science Training@|forensics.comparetopschools.com@|Request Free Info From Schools With Forensic Science Degree Programs.||2||0
+2015-11-08 20:31:54.791027||measurement||ad||2015-11-08 20:31:47.741414@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||2||0
+2015-11-08 20:31:54.791302||measurement||loadtime||0:00:29.872770||2||0
+2015-11-08 20:31:56.767080||measurement||ad||2015-11-08 20:31:56.493926@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:31:57.062726||measurement||ad||2015-11-08 20:31:56.493926@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:31:57.328137||measurement||ad||2015-11-08 20:31:56.493926@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:31:57.328547||measurement||loadtime||0:00:08.351107||0||1
+2015-11-08 20:31:59.693103||measurement||ad||2015-11-08 20:31:59.246570@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:32:00.185379||measurement||ad||2015-11-08 20:31:59.246570@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||0
+2015-11-08 20:32:00.739894||measurement||ad||2015-11-08 20:31:59.246570@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||0
+2015-11-08 20:32:00.740170||measurement||loadtime||0:00:29.690383||3||0
+2015-11-08 20:32:07.656026||measurement||ad||2015-11-08 20:32:07.442778@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:32:07.721722||measurement||ad||2015-11-08 20:32:07.442778@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:32:07.783728||measurement||ad||2015-11-08 20:32:07.442778@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:32:07.784002||measurement||loadtime||0:00:05.454963||0||1
+2015-11-08 20:32:10.787076||measurement||ad||2015-11-08 20:32:10.387521@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:32:11.185708||measurement||ad||2015-11-08 20:32:10.387521@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 20:32:11.698348||measurement||ad||2015-11-08 20:32:10.387521@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:32:11.698703||measurement||loadtime||0:00:11.906559||2||0
+2015-11-08 20:32:19.231067||measurement||ad||2015-11-08 20:32:18.749432@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:32:19.306555||measurement||ad||2015-11-08 20:32:18.749432@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:32:19.407810||measurement||ad||2015-11-08 20:32:18.749432@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:32:19.408040||measurement||loadtime||0:00:06.622775||0||1
+2015-11-08 20:32:28.688958||measurement||ad||2015-11-08 20:32:27.738468@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:32:29.593720||measurement||ad||2015-11-08 20:32:27.738468@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 20:32:30.380896||measurement||ad||2015-11-08 20:32:29.796012@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:32:30.482838||measurement||ad||2015-11-08 20:32:29.796012@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:32:30.534861||measurement||ad||2015-11-08 20:32:27.738468@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:32:30.535622||measurement||loadtime||0:00:13.836188||2||0
+2015-11-08 20:32:30.557013||measurement||ad||2015-11-08 20:32:29.796012@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:32:30.557232||measurement||loadtime||0:00:06.147681||0||1
+2015-11-08 20:32:42.172921||measurement||ad||2015-11-08 20:32:41.977783@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:32:42.232651||measurement||ad||2015-11-08 20:32:41.977783@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:32:42.302453||measurement||ad||2015-11-08 20:32:41.977783@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:32:42.302706||measurement||loadtime||0:00:06.744060||0||1
+2015-11-08 20:32:50.691811||measurement||ad||2015-11-08 20:32:50.038949@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||0
+2015-11-08 20:32:50.896598||measurement||ad||2015-11-08 20:32:50.038949@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||0
+2015-11-08 20:32:51.340259||measurement||ad||2015-11-08 20:32:50.038949@|Best Dry Dog Food@|www.whole-dog-journal.com@|Unbiased Dry Dog Food Reviews All in Whole Dog Journal Magazine||3||0
+2015-11-08 20:32:51.340582||measurement||loadtime||0:00:45.598856||3||0
+2015-11-08 20:32:53.349679||measurement||ad||2015-11-08 20:32:52.828466@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||1
+2015-11-08 20:32:53.429181||measurement||ad||2015-11-08 20:32:52.828466@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:32:53.501418||measurement||ad||2015-11-08 20:32:52.828466@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:32:53.501631||measurement||loadtime||0:00:06.198423||0||1
+2015-11-08 20:32:53.501817||event||progress-marker||measurement-end||0||1
+2015-11-08 20:33:02.636297||measurement||ad||2015-11-08 20:33:02.251099@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:33:02.894876||measurement||ad||2015-11-08 20:33:02.251099@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||0
+2015-11-08 20:33:03.148068||measurement||ad||2015-11-08 20:33:02.251099@|Get 5 Star Reviews@|onlinemeetingnow.com@|Magnetically Attract New Customers To Your Restaurant. We Show You How||3||0
+2015-11-08 20:33:03.148291||measurement||loadtime||0:00:06.806135||3||0
+2015-11-08 20:33:14.703048||measurement||ad||2015-11-08 20:31:54.675781@|8% Annual Annuity Return@|reduced risks to retirees all here.@|Get guaranteed lifetime income and ||1||1
+2015-11-08 20:33:14.703415||measurement||loadtime||0:01:28.077746||1||1
+2015-11-08 20:33:14.793117||measurement||ad||2015-11-08 20:33:14.540811@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:33:15.028205||measurement||ad||2015-11-08 20:33:14.540811@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||0
+2015-11-08 20:33:15.186898||measurement||ad||2015-11-08 20:33:14.540811@|Get 5 Star Reviews@|onlinemeetingnow.com@|Magnetically Attract New Customers To Your Restaurant. We Show You How||3||0
+2015-11-08 20:33:15.187155||measurement||loadtime||0:00:07.036736||3||0
+2015-11-08 20:33:25.784268||measurement||ad||2015-11-08 20:33:25.600563@|2015 Car Lease Specials@|www.newcar-leases.com@|Lease a Car at the Lowest Payment. Check Car Dealers for Lease Deals!||3||0
+2015-11-08 20:33:25.969552||measurement||ad||2015-11-08 20:33:25.600563@|Used Cars@|www.carnearyou.com@|Search by price, year, location. The best way to find your next car.||3||0
+2015-11-08 20:33:26.017746||measurement||ad||2015-11-08 20:33:25.891592@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:33:26.074246||measurement||ad||2015-11-08 20:33:25.891592@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:33:26.120190||measurement||ad||2015-11-08 20:33:25.600563@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||0
+2015-11-08 20:33:26.120439||measurement||loadtime||0:00:05.932187||3||0
+2015-11-08 20:33:26.122416||measurement||ad||2015-11-08 20:33:25.891592@|Airport Car Rentals@|lowerprices.us/Airport-Car-Rentals@|Looking For Airport Car Rentals? Compare Today's Top Offers  Save!||1||1
+2015-11-08 20:33:26.122645||measurement||loadtime||0:00:06.418557||1||1
+2015-11-08 20:33:35.721511||error||collecting ads||Error||2||0
+2015-11-08 20:33:38.680631||measurement||ad||2015-11-08 20:33:38.355816@|16 Biggest Dogs Ever@|pressroomvip.com/16-Biggest-Dogs@|See the Biggest Dogs of All Time! You'll Never Believe #6.||1||1
+2015-11-08 20:33:38.751840||measurement||ad||2015-11-08 20:33:38.355816@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:33:38.828021||measurement||ad||2015-11-08 20:33:38.355816@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||1
+2015-11-08 20:33:38.828337||measurement||loadtime||0:00:07.705349||1||1
+2015-11-08 20:33:39.387596||measurement||ad||2015-11-08 20:33:39.171905@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||0
+2015-11-08 20:33:39.535686||measurement||ad||2015-11-08 20:33:39.171905@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||0
+2015-11-08 20:33:39.696569||measurement||ad||2015-11-08 20:33:39.171905@|Best Dry Dog Food@|www.whole-dog-journal.com@|Unbiased Dry Dog Food Reviews All in Whole Dog Journal Magazine||3||0
+2015-11-08 20:33:39.696842||measurement||loadtime||0:00:08.575026||3||0
+2015-11-08 20:33:47.167326||measurement||ad||2015-11-08 20:33:46.994669@|Forensic Science Training@|forensics.comparetopschools.com@|Request Free Info From Schools With Forensic Science Degree Programs.||2||0
+2015-11-08 20:33:47.277612||measurement||ad||2015-11-08 20:33:46.994669@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:33:47.516576||measurement||ad||2015-11-08 20:33:46.994669@|Do You Have an Idea?@|www.idea4invention.com@|Find Companies that Can Turn Your Idea Into A Real Product. Start Now||2||0
+2015-11-08 20:33:47.516867||measurement||loadtime||0:00:06.793813||2||0
+2015-11-08 20:33:51.492895||measurement||ad||2015-11-08 20:33:51.321960@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||0
+2015-11-08 20:33:51.591706||measurement||ad||2015-11-08 20:33:51.321960@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||0
+2015-11-08 20:33:51.714955||measurement||ad||2015-11-08 20:33:51.321960@|Get 5 Star Reviews@|onlinemeetingnow.com@|Magnetically Attract New Customers To Your Restaurant. We Show You How||3||0
+2015-11-08 20:33:51.715239||measurement||loadtime||0:00:07.015782||3||0
+2015-11-08 20:33:51.715896||event||progress-marker||measurement-end||3||0
+2015-11-08 20:33:52.950176||measurement||ad||2015-11-08 20:33:52.622854@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:33:53.012138||measurement||ad||2015-11-08 20:33:52.622854@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:33:53.057402||measurement||ad||2015-11-08 20:33:52.622854@|Airport Car Rentals@|lowerprices.us/Airport-Car-Rentals@|Looking For Airport Car Rentals? Compare Today's Top Offers  Save!||1||1
+2015-11-08 20:33:53.057692||measurement||loadtime||0:00:09.227887||1||1
+2015-11-08 20:33:56.397527||measurement||ad||2015-11-08 20:33:56.295018@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:33:56.474757||measurement||ad||2015-11-08 20:33:56.295018@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:33:56.584024||measurement||ad||2015-11-08 20:33:56.295018@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:33:56.584341||measurement||loadtime||0:00:04.066977||2||0
+2015-11-08 20:34:03.826317||measurement||ad||2015-11-08 20:34:03.648438@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:34:03.877276||measurement||ad||2015-11-08 20:34:03.648438@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||1
+2015-11-08 20:34:03.926417||measurement||ad||2015-11-08 20:34:03.648438@|Airport Car Rentals@|lowerprices.us/Airport-Car-Rentals@|Looking For Airport Car Rentals? Compare Today's Top Offers  Save!||1||1
+2015-11-08 20:34:03.926689||measurement||loadtime||0:00:05.867388||1||1
+2015-11-08 20:34:03.926824||event||progress-marker||measurement-end||1||1
+2015-11-08 20:34:06.791352||measurement||ad||2015-11-08 20:34:06.676744@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:34:06.890741||measurement||ad||2015-11-08 20:34:06.676744@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||2||0
+2015-11-08 20:34:06.999254||measurement||ad||2015-11-08 20:34:06.676744@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:34:06.999525||measurement||loadtime||0:00:05.414352||2||0
+2015-11-08 20:34:15.276769||measurement||ad||2015-11-08 20:34:15.094344@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:34:15.438154||measurement||ad||2015-11-08 20:34:15.094344@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 20:34:15.548234||measurement||ad||2015-11-08 20:34:15.094344@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:34:15.548703||measurement||loadtime||0:00:03.547319||2||0
+2015-11-08 20:34:15.549428||event||progress-marker||measurement-end||2||0
+2015-11-08 20:34:16.037183||meta||block_id end||15
+2015-11-08 20:34:16.039913||meta||block_id start||16
+2015-11-08 20:34:16.039977||meta||assignment||1@|0@|2@|3
+2015-11-08 20:34:18.747248||event||progress-marker||training-start||1||0
+2015-11-08 20:34:18.769142||event||progress-marker||training-start||0||0
+2015-11-08 20:34:20.506944||event||progress-marker||training-start||2||1
+2015-11-08 20:34:20.524507||event||progress-marker||training-start||3||1
+2015-11-08 20:34:27.395420||treatment||visit website||http://irs.gov||0||0
+2015-11-08 20:34:27.716695||treatment||visit website||http://irs.gov||1||0
+2015-11-08 20:34:28.412234||treatment||visit website||http://irs.gov||2||1
+2015-11-08 20:34:28.524880||treatment||visit website||http://irs.gov||3||1
+2015-11-08 20:34:36.379149||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 20:34:36.407441||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 20:34:37.375209||treatment||visit website||http://deloitte.com||2||1
+2015-11-08 20:34:37.493950||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 20:34:48.572599||treatment||visit website||http://pwc.com||0||0
+2015-11-08 20:34:48.593183||treatment||visit website||http://pwc.com||1||0
+2015-11-08 20:34:49.688215||treatment||visit website||http://pwc.com||3||1
+2015-11-08 20:34:49.741141||treatment||visit website||http://pwc.com||2||1
+2015-11-08 20:34:56.426870||treatment||visit website||http://ey.com||0||0
+2015-11-08 20:34:56.700168||treatment||visit website||http://ey.com||1||0
+2015-11-08 20:34:57.782310||treatment||visit website||http://ey.com||3||1
+2015-11-08 20:34:57.893991||treatment||visit website||http://ey.com||2||1
+2015-11-08 20:35:05.270098||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 20:35:05.270320||event||progress-marker||training-end||0||0
+2015-11-08 20:35:05.772259||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 20:35:05.772522||event||progress-marker||training-end||1||0
+2015-11-08 20:35:05.891161||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 20:35:05.891413||event||progress-marker||training-end||3||1
+2015-11-08 20:35:06.031452||treatment||visit website||http://kpmg.com||2||1
+2015-11-08 20:35:06.031704||event||progress-marker||training-end||2||1
+2015-11-08 20:35:10.297572||event||progress-marker||measurement-start||0||0
+2015-11-08 20:35:10.797808||event||progress-marker||measurement-start||1||0
+2015-11-08 20:35:10.917301||event||progress-marker||measurement-start||3||1
+2015-11-08 20:35:11.056535||event||progress-marker||measurement-start||2||1
+2015-11-08 20:35:24.937307||measurement||ad||2015-11-08 20:35:24.522577@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:35:25.211040||measurement||ad||2015-11-08 20:35:24.522577@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:35:25.332119||measurement||ad||2015-11-08 20:35:24.529039@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:35:25.343411||measurement||ad||2015-11-08 20:35:24.522577@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||2||1
+2015-11-08 20:35:25.343657||measurement||loadtime||0:00:09.286405||2||1
+2015-11-08 20:35:25.458386||measurement||ad||2015-11-08 20:35:24.529039@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:35:25.542595||measurement||ad||2015-11-08 20:35:24.529039@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:35:25.542867||measurement||loadtime||0:00:09.624983||3||1
+2015-11-08 20:35:30.669958||measurement||ad||2015-11-08 20:35:30.366889@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:35:30.955982||measurement||ad||2015-11-08 20:35:30.518124@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:35:31.019065||measurement||ad||2015-11-08 20:35:30.366889@|Lumosity Brain Games@|www.lumosity.com@|Challenge memory and attention with scientific brain games.||1||0
+2015-11-08 20:35:31.246590||measurement||ad||2015-11-08 20:35:30.518124@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:35:31.453151||measurement||ad||2015-11-08 20:35:30.366889@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:35:31.453457||measurement||loadtime||0:00:15.653936||1||0
+2015-11-08 20:35:31.535802||measurement||ad||2015-11-08 20:35:30.518124@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:35:31.536155||measurement||loadtime||0:00:16.237037||0||0
+2015-11-08 20:35:39.579464||measurement||ad||2015-11-08 20:35:39.147910@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:35:39.682903||measurement||ad||2015-11-08 20:35:39.147910@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:35:39.821993||measurement||ad||2015-11-08 20:35:39.147910@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 20:35:39.822281||measurement||loadtime||0:00:09.477392||2||1
+2015-11-08 20:35:41.169848||measurement||ad||2015-11-08 20:35:40.722722@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||3||1
+2015-11-08 20:35:41.651194||measurement||ad||2015-11-08 20:35:40.722722@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:35:41.895070||measurement||ad||2015-11-08 20:35:40.722722@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:35:41.895335||measurement||loadtime||0:00:11.351870||3||1
+2015-11-08 20:35:49.451569||measurement||ad||2015-11-08 20:35:49.192309@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:35:50.031159||measurement||ad||2015-11-08 20:35:49.192309@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:35:50.550979||measurement||ad||2015-11-08 20:35:49.192309@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 20:35:50.551405||measurement||loadtime||0:00:14.097606||1||0
+2015-11-08 20:35:51.919462||measurement||ad||2015-11-08 20:35:51.479084@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:35:52.624472||measurement||ad||2015-11-08 20:35:51.479084@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:35:53.155897||measurement||ad||2015-11-08 20:35:51.479084@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:35:53.156299||measurement||loadtime||0:00:16.619518||0||0
+2015-11-08 20:35:53.381384||measurement||ad||2015-11-08 20:35:52.879513@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:35:53.487562||measurement||ad||2015-11-08 20:35:52.879513@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:35:53.716362||measurement||ad||2015-11-08 20:35:52.879513@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||1
+2015-11-08 20:35:53.716613||measurement||loadtime||0:00:08.893127||2||1
+2015-11-08 20:35:55.033626||measurement||ad||2015-11-08 20:35:54.782055@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:35:55.124077||measurement||ad||2015-11-08 20:35:54.782055@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:35:55.208524||measurement||ad||2015-11-08 20:35:54.782055@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:35:55.208895||measurement||loadtime||0:00:08.312452||3||1
+2015-11-08 20:36:02.029257||measurement||ad||2015-11-08 20:36:00.555404@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:36:02.645954||measurement||ad||2015-11-08 20:36:00.555404@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:36:03.588820||measurement||ad||2015-11-08 20:36:00.555404@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:36:03.589611||measurement||loadtime||0:00:08.036760||1||0
+2015-11-08 20:36:09.086602||measurement||ad||2015-11-08 20:36:08.610180@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:36:09.188588||measurement||ad||2015-11-08 20:36:08.306379@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:36:09.240486||measurement||ad||2015-11-08 20:36:08.610180@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:36:09.399637||measurement||ad||2015-11-08 20:36:08.306379@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 20:36:09.568661||measurement||ad||2015-11-08 20:36:08.306379@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 20:36:09.568951||measurement||loadtime||0:00:10.850551||2||1
+2015-11-08 20:36:09.721059||measurement||ad||2015-11-08 20:36:08.610180@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:36:09.721355||measurement||loadtime||0:00:09.511229||3||1
+2015-11-08 20:36:11.849612||measurement||ad||2015-11-08 20:36:11.593953@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:36:12.039883||measurement||ad||2015-11-08 20:36:11.593953@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||0
+2015-11-08 20:36:12.200022||measurement||ad||2015-11-08 20:36:11.593953@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||0
+2015-11-08 20:36:12.200326||measurement||loadtime||0:00:14.042874||0||0
+2015-11-08 20:36:18.790596||measurement||ad||2015-11-08 20:36:18.238565@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:36:20.035345||measurement||ad||2015-11-08 20:36:18.238565@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 20:36:20.604238||measurement||ad||2015-11-08 20:36:18.238565@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:36:20.604540||measurement||loadtime||0:00:12.014499||1||0
+2015-11-08 20:36:21.870201||measurement||ad||2015-11-08 20:36:21.309466@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:36:21.956163||measurement||ad||2015-11-08 20:36:21.309466@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||1
+2015-11-08 20:36:22.047216||measurement||ad||2015-11-08 20:36:21.309466@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:36:22.048250||measurement||loadtime||0:00:07.477564||2||1
+2015-11-08 20:36:23.672059||measurement||ad||2015-11-08 20:36:23.385693@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:36:23.763655||measurement||ad||2015-11-08 20:36:23.385693@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||3||1
+2015-11-08 20:36:23.827888||measurement||ad||2015-11-08 20:36:23.385693@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:36:23.828169||measurement||loadtime||0:00:09.106383||3||1
+2015-11-08 20:36:29.549452||measurement||ad||2015-11-08 20:36:28.698044@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:36:30.446440||measurement||ad||2015-11-08 20:36:28.698044@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||0
+2015-11-08 20:36:31.141346||measurement||ad||2015-11-08 20:36:28.698044@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 20:36:31.141652||measurement||loadtime||0:00:13.940789||0||0
+2015-11-08 20:36:32.333626||measurement||ad||2015-11-08 20:36:32.173455@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:36:32.426380||measurement||ad||2015-11-08 20:36:32.173455@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:36:32.533367||measurement||ad||2015-11-08 20:36:32.173455@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||1
+2015-11-08 20:36:32.533653||measurement||loadtime||0:00:05.484168||2||1
+2015-11-08 20:36:36.194962||measurement||ad||2015-11-08 20:36:35.778532@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:36:36.275386||measurement||ad||2015-11-08 20:36:35.778532@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:36:36.323052||measurement||ad||2015-11-08 20:36:35.778532@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:36:36.323277||measurement||loadtime||0:00:07.494503||3||1
+2015-11-08 20:36:39.993756||measurement||ad||2015-11-08 20:36:39.243442@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:36:40.546931||measurement||ad||2015-11-08 20:36:39.243442@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:36:40.942685||measurement||ad||2015-11-08 20:36:39.243442@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:36:40.943017||measurement||loadtime||0:00:15.338019||1||0
+2015-11-08 20:36:44.816123||measurement||ad||2015-11-08 20:36:44.643237@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:36:44.966902||measurement||ad||2015-11-08 20:36:44.643237@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:36:45.228135||measurement||ad||2015-11-08 20:36:44.643237@|Graphene Is The Future@|outsiderclub.com/Graphene@|Learn How It Will Change The World It's All In This Free Investor Rpt.||2||1
+2015-11-08 20:36:45.228439||measurement||loadtime||0:00:07.693892||2||1
+2015-11-08 20:36:45.699008||measurement||ad||2015-11-08 20:36:44.855177@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:36:46.055874||measurement||ad||2015-11-08 20:36:44.855177@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:36:46.548524||measurement||ad||2015-11-08 20:36:44.855177@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 20:36:46.548908||measurement||loadtime||0:00:10.406631||0||0
+2015-11-08 20:36:47.936856||measurement||ad||2015-11-08 20:36:47.811294@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:36:48.059010||measurement||ad||2015-11-08 20:36:47.811294@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:36:48.139398||measurement||ad||2015-11-08 20:36:47.811294@|Donald Trump Said What?@|pressroomvip.com/21-Donald-Trump@|21 Insane Donald Trump Quotes. You'll Never Believe He Said #7!||3||1
+2015-11-08 20:36:48.140882||measurement||loadtime||0:00:06.815778||3||1
+2015-11-08 20:36:55.394015||measurement||ad||2015-11-08 20:36:55.201673@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:36:55.513514||measurement||ad||2015-11-08 20:36:55.201673@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 20:36:55.597308||measurement||ad||2015-11-08 20:36:55.201673@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 20:36:55.597575||measurement||loadtime||0:00:05.367604||2||1
+2015-11-08 20:37:00.876381||measurement||ad||2015-11-08 20:36:59.631937@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:37:01.004129||measurement||ad||2015-11-08 20:36:59.631937@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:37:01.169624||measurement||ad||2015-11-08 20:36:59.631937@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:37:01.169884||measurement||loadtime||0:00:08.027068||3||1
+2015-11-08 20:37:03.995266||measurement||ad||2015-11-08 20:37:03.406253@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:37:04.994773||measurement||ad||2015-11-08 20:37:03.406253@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:37:05.447193||measurement||ad||2015-11-08 20:37:03.406253@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:37:05.447466||measurement||loadtime||0:00:19.503968||1||0
+2015-11-08 20:37:15.155263||measurement||ad||2015-11-08 20:37:14.982941@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:37:15.259111||measurement||ad||2015-11-08 20:37:15.128171@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||1
+2015-11-08 20:37:15.312660||measurement||ad||2015-11-08 20:37:14.982941@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:37:15.343681||measurement||ad||2015-11-08 20:37:15.128171@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||1
+2015-11-08 20:37:15.397004||measurement||ad||2015-11-08 20:37:15.128171@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||1
+2015-11-08 20:37:15.397266||measurement||loadtime||0:00:14.799293||2||1
+2015-11-08 20:37:15.413912||measurement||ad||2015-11-08 20:37:14.982941@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:37:15.414179||measurement||loadtime||0:00:09.243439||3||1
+2015-11-08 20:37:23.556402||measurement||ad||2015-11-08 20:37:22.945731@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:37:24.145349||measurement||ad||2015-11-08 20:37:22.945731@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:37:24.744819||measurement||ad||2015-11-08 20:37:22.945731@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:37:24.745102||measurement||loadtime||0:00:14.296992||1||0
+2015-11-08 20:37:27.375221||measurement||ad||2015-11-08 20:37:27.250208@|Home Depot® Appliances@|www.homedepot.com@|Get Black Friday Prices thru 12/2. Up to 40% Off Major Appliances!||2||1
+2015-11-08 20:37:27.496187||measurement||ad||2015-11-08 20:37:27.250208@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||1
+2015-11-08 20:37:27.594068||measurement||ad||2015-11-08 20:37:27.250208@|The Graphene Miracle@|moneymorningresearch.com/@|Just 1 atom thick, Graphene is will change the world. Learn more||2||1
+2015-11-08 20:37:27.594338||measurement||loadtime||0:00:07.195775||2||1
+2015-11-08 20:37:27.594500||event||progress-marker||measurement-end||2||1
+2015-11-08 20:37:29.028120||measurement||ad||2015-11-08 20:37:28.835726@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:37:29.264167||measurement||ad||2015-11-08 20:37:28.835726@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:37:29.467264||measurement||ad||2015-11-08 20:37:28.835726@|Costa Rica All-inclusive@|www.vacationscostarica.com@|We plan Your perfect Costa Rica Vacation package. Save time, stress||3||1
+2015-11-08 20:37:29.467496||measurement||loadtime||0:00:09.052594||3||1
+2015-11-08 20:37:29.467642||event||progress-marker||measurement-end||3||1
+2015-11-08 20:37:38.907408||measurement||ad||2015-11-08 20:37:38.557057@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:37:39.208415||measurement||ad||2015-11-08 20:37:38.557057@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:37:39.505803||measurement||ad||2015-11-08 20:37:38.557057@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:37:39.506171||measurement||loadtime||0:00:09.760410||1||0
+2015-11-08 20:37:50.994540||measurement||ad||2015-11-08 20:37:50.605664@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:37:51.254777||measurement||ad||2015-11-08 20:37:50.605664@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:37:51.505411||measurement||ad||2015-11-08 20:37:50.605664@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:37:51.505616||measurement||loadtime||0:00:06.997836||1||0
+2015-11-08 20:37:51.697883||error||collecting ads||Error||0||0
+2015-11-08 20:38:02.257001||measurement||ad||2015-11-08 20:38:02.049012@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:38:02.553186||measurement||ad||2015-11-08 20:38:02.049012@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||1||0
+2015-11-08 20:38:02.702967||measurement||ad||2015-11-08 20:38:02.049012@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:38:02.703198||measurement||loadtime||0:00:06.195478||1||0
+2015-11-08 20:38:02.703807||event||progress-marker||measurement-end||1||0
+2015-11-08 20:38:05.042181||measurement||ad||2015-11-08 20:38:04.853299@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:38:05.185742||measurement||ad||2015-11-08 20:38:04.853299@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:38:05.305213||measurement||ad||2015-11-08 20:38:04.853299@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||0
+2015-11-08 20:38:05.305421||measurement||loadtime||0:00:08.606751||0||0
+2015-11-08 20:38:14.989568||measurement||ad||2015-11-08 20:38:14.843344@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 20:38:15.133346||measurement||ad||2015-11-08 20:38:14.843344@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||0||0
+2015-11-08 20:38:15.280319||measurement||ad||2015-11-08 20:38:14.843344@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||0
+2015-11-08 20:38:15.280628||measurement||loadtime||0:00:04.973199||0||0
+2015-11-08 20:38:23.058079||measurement||ad||2015-11-08 20:38:22.927514@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:38:23.179625||measurement||ad||2015-11-08 20:38:22.927514@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||0
+2015-11-08 20:38:23.280988||measurement||ad||2015-11-08 20:38:22.927514@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||0||0
+2015-11-08 20:38:23.281220||measurement||loadtime||0:00:02.998575||0||0
+2015-11-08 20:38:33.084614||measurement||ad||2015-11-08 20:38:32.957102@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||0
+2015-11-08 20:38:33.198888||measurement||ad||2015-11-08 20:38:32.957102@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 20:38:33.306848||measurement||ad||2015-11-08 20:38:32.957102@|IPhone 6s 64 GB Sale@|lowerprices.us/IPhone-6s-64-GB@|Great Offers On IPhone 6s 64 GB Find Amazing Bargains and Save!||0||0
+2015-11-08 20:38:33.307165||measurement||loadtime||0:00:05.025018||0||0
+2015-11-08 20:38:33.307765||event||progress-marker||measurement-end||0||0
+2015-11-08 20:38:33.830934||meta||block_id end||16
+2015-11-08 20:38:33.832619||meta||block_id start||17
+2015-11-08 20:38:33.832642||meta||assignment||2@|0@|1@|3
+2015-11-08 20:38:36.557952||event||progress-marker||training-start||2||0
+2015-11-08 20:38:36.617970||event||progress-marker||training-start||0||0
+2015-11-08 20:38:38.264740||event||progress-marker||training-start||1||1
+2015-11-08 20:38:38.341738||event||progress-marker||training-start||3||1
+2015-11-08 20:38:44.602231||treatment||visit website||http://irs.gov||0||0
+2015-11-08 20:38:44.627272||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:38:46.481474||treatment||visit website||http://irs.gov||3||1
+2015-11-08 20:38:46.519852||treatment||visit website||http://irs.gov||1||1
+2015-11-08 20:38:52.627981||treatment||visit website||http://deloitte.com||0||0
+2015-11-08 20:38:52.911801||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:38:54.762771||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 20:38:55.810704||treatment||visit website||http://deloitte.com||1||1
+2015-11-08 20:39:03.436762||treatment||visit website||http://pwc.com||0||0
+2015-11-08 20:39:04.865459||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:39:06.103181||treatment||visit website||http://pwc.com||3||1
+2015-11-08 20:39:06.163615||treatment||visit website||http://pwc.com||1||1
+2015-11-08 20:39:09.854536||treatment||visit website||http://ey.com||0||0
+2015-11-08 20:39:12.154607||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:39:12.758883||treatment||visit website||http://ey.com||3||1
+2015-11-08 20:39:13.355985||treatment||visit website||http://ey.com||1||1
+2015-11-08 20:39:19.847263||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:39:19.847608||event||progress-marker||training-end||2||0
+2015-11-08 20:39:20.776699||treatment||visit website||http://kpmg.com||0||0
+2015-11-08 20:39:20.777293||event||progress-marker||training-end||0||0
+2015-11-08 20:39:21.504756||treatment||visit website||http://kpmg.com||1||1
+2015-11-08 20:39:21.505053||event||progress-marker||training-end||1||1
+2015-11-08 20:39:21.676846||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 20:39:21.677089||event||progress-marker||training-end||3||1
+2015-11-08 20:39:24.888902||event||progress-marker||measurement-start||2||0
+2015-11-08 20:39:25.807548||event||progress-marker||measurement-start||0||0
+2015-11-08 20:39:26.532964||event||progress-marker||measurement-start||1||1
+2015-11-08 20:39:26.705876||event||progress-marker||measurement-start||3||1
+2015-11-08 20:39:41.840830||measurement||ad||2015-11-08 20:39:40.905475@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:39:42.058577||measurement||ad||2015-11-08 20:39:40.905475@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:39:42.251553||measurement||ad||2015-11-08 20:39:40.905475@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:39:42.251812||measurement||loadtime||0:00:10.544596||3||1
+2015-11-08 20:39:42.863722||measurement||ad||2015-11-08 20:39:41.994106@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:39:42.937251||measurement||ad||2015-11-08 20:39:41.994106@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||1
+2015-11-08 20:39:43.025727||measurement||ad||2015-11-08 20:39:41.994106@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||1
+2015-11-08 20:39:43.026029||measurement||loadtime||0:00:11.492067||1||1
+2015-11-08 20:39:44.981865||measurement||ad||2015-11-08 20:39:44.409426@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:39:45.337266||measurement||ad||2015-11-08 20:39:44.409426@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:39:45.549721||measurement||ad||2015-11-08 20:39:44.409426@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||2||0
+2015-11-08 20:39:45.550025||measurement||loadtime||0:00:15.659485||2||0
+2015-11-08 20:39:48.677841||measurement||ad||2015-11-08 20:39:48.201197@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:39:49.002572||measurement||ad||2015-11-08 20:39:48.201197@|Costa Rica All-inclusive@|www.vacationscostarica.com@|We plan Your perfect Costa Rica Vacation package. Save time, stress||0||0
+2015-11-08 20:39:49.406550||measurement||ad||2015-11-08 20:39:48.201197@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||0||0
+2015-11-08 20:39:49.407233||measurement||loadtime||0:00:18.599059||0||0
+2015-11-08 20:39:54.538580||measurement||ad||2015-11-08 20:39:54.216979@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:39:54.664642||measurement||ad||2015-11-08 20:39:54.216979@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:39:54.919048||measurement||ad||2015-11-08 20:39:54.216979@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||3||1
+2015-11-08 20:39:54.919335||measurement||loadtime||0:00:07.666585||3||1
+2015-11-08 20:39:56.014704||measurement||ad||2015-11-08 20:39:55.800001@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:39:56.093066||measurement||ad||2015-11-08 20:39:55.800001@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:39:56.182189||measurement||ad||2015-11-08 20:39:55.800001@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:39:56.182469||measurement||loadtime||0:00:08.155885||1||1
+2015-11-08 20:39:59.862446||measurement||ad||2015-11-08 20:39:59.686629@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:40:00.332258||measurement||ad||2015-11-08 20:39:59.686629@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:40:00.786434||measurement||ad||2015-11-08 20:39:59.686629@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||2||0
+2015-11-08 20:40:00.786678||measurement||loadtime||0:00:10.235291||2||0
+2015-11-08 20:40:03.153067||measurement||ad||2015-11-08 20:40:02.687762@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:40:03.934326||measurement||ad||2015-11-08 20:40:02.687762@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||0
+2015-11-08 20:40:04.192724||measurement||ad||2015-11-08 20:40:02.687762@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 20:40:04.193002||measurement||loadtime||0:00:09.784831||0||0
+2015-11-08 20:40:09.318947||measurement||ad||2015-11-08 20:40:08.960347@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:40:09.570813||measurement||ad||2015-11-08 20:40:08.960347@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:40:09.806193||measurement||ad||2015-11-08 20:40:08.960347@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:40:09.806465||measurement||loadtime||0:00:09.886468||3||1
+2015-11-08 20:40:13.902913||measurement||ad||2015-11-08 20:40:13.477249@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:40:14.026937||measurement||ad||2015-11-08 20:40:13.477249@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:40:14.167804||measurement||ad||2015-11-08 20:40:13.477249@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:40:14.168122||measurement||loadtime||0:00:12.985091||1||1
+2015-11-08 20:40:17.838415||measurement||ad||2015-11-08 20:40:17.534837@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||0
+2015-11-08 20:40:18.093792||measurement||ad||2015-11-08 20:40:17.534837@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 20:40:18.394215||measurement||ad||2015-11-08 20:40:17.534837@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||0
+2015-11-08 20:40:18.394489||measurement||loadtime||0:00:09.200124||0||0
+2015-11-08 20:40:25.439441||measurement||ad||2015-11-08 20:40:24.661989@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:40:25.616136||measurement||ad||2015-11-08 20:40:24.661989@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:40:25.722670||measurement||ad||2015-11-08 20:40:24.661989@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:40:25.722982||measurement||loadtime||0:00:10.915520||3||1
+2015-11-08 20:40:29.476916||measurement||ad||2015-11-08 20:40:28.765737@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:40:29.716927||measurement||ad||2015-11-08 20:40:28.765737@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:40:29.903772||measurement||ad||2015-11-08 20:40:28.765737@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:40:29.905325||measurement||loadtime||0:00:10.736286||1||1
+2015-11-08 20:40:37.609506||measurement||ad||2015-11-08 20:40:37.252393@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:40:37.862653||measurement||ad||2015-11-08 20:40:37.252393@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:40:38.105169||measurement||ad||2015-11-08 20:40:37.252393@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:40:38.105447||measurement||loadtime||0:00:32.317258||2||0
+2015-11-08 20:40:38.787525||measurement||ad||2015-11-08 20:40:38.697427@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:40:38.863328||measurement||ad||2015-11-08 20:40:38.697427@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:40:38.948810||measurement||ad||2015-11-08 20:40:38.697427@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||3||1
+2015-11-08 20:40:38.949519||measurement||loadtime||0:00:08.225560||3||1
+2015-11-08 20:40:40.972659||measurement||ad||2015-11-08 20:40:35.619974@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||1
+2015-11-08 20:40:41.047460||measurement||ad||2015-11-08 20:40:35.619974@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||1
+2015-11-08 20:40:41.149488||measurement||ad||2015-11-08 20:40:35.619974@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||1
+2015-11-08 20:40:41.149943||measurement||loadtime||0:00:06.243592||1||1
+2015-11-08 20:40:49.191422||measurement||ad||2015-11-08 20:40:49.031321@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:40:49.370288||measurement||ad||2015-11-08 20:40:49.031321@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:40:49.464073||measurement||ad||2015-11-08 20:40:49.031321@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:40:49.464405||measurement||loadtime||0:00:05.513312||3||1
+2015-11-08 20:40:51.058789||measurement||ad||2015-11-08 20:40:50.256126@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 20:40:51.506738||measurement||ad||2015-11-08 20:40:50.256126@|He/She Cheating On You?@|phone.instantcheckmate.com@|1) Enter His/Her Phone Number. 2) Find Everything They're Hiding||0||0
+2015-11-08 20:40:52.404913||measurement||ad||2015-11-08 20:40:50.256126@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||0
+2015-11-08 20:40:52.405207||measurement||loadtime||0:00:29.009631||0||0
+2015-11-08 20:40:52.507462||measurement||ad||2015-11-08 20:40:51.996462@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:40:52.574967||measurement||ad||2015-11-08 20:40:51.996462@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:40:52.642845||measurement||ad||2015-11-08 20:40:51.996462@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:40:52.643063||measurement||loadtime||0:00:06.492069||1||1
+2015-11-08 20:40:59.759151||measurement||ad||2015-11-08 20:40:59.550537@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:40:59.847920||measurement||ad||2015-11-08 20:40:59.550537@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:40:59.926798||measurement||ad||2015-11-08 20:40:59.550537@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:40:59.927054||measurement||loadtime||0:00:05.462052||3||1
+2015-11-08 20:41:02.865682||measurement||ad||2015-11-08 20:41:02.541104@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:41:03.039783||measurement||ad||2015-11-08 20:41:02.541104@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:41:03.100703||measurement||ad||2015-11-08 20:41:02.541104@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:41:03.100937||measurement||loadtime||0:00:05.457476||1||1
+2015-11-08 20:41:06.866865||measurement||ad||2015-11-08 20:41:06.305902@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||0
+2015-11-08 20:41:07.161845||measurement||ad||2015-11-08 20:41:06.305902@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||0||0
+2015-11-08 20:41:07.513597||measurement||ad||2015-11-08 20:41:06.305902@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||0||0
+2015-11-08 20:41:07.513912||measurement||loadtime||0:00:10.108234||0||0
+2015-11-08 20:41:10.988643||measurement||ad||2015-11-08 20:41:10.421726@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:41:11.102296||measurement||ad||2015-11-08 20:41:10.421726@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:41:11.176065||measurement||ad||2015-11-08 20:41:10.421726@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:41:11.176314||measurement||loadtime||0:00:06.247969||3||1
+2015-11-08 20:41:14.045627||measurement||ad||2015-11-08 20:41:13.594470@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:41:14.146135||measurement||ad||2015-11-08 20:41:13.594470@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:41:14.203332||measurement||ad||2015-11-08 20:41:13.594470@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:41:14.203504||measurement||loadtime||0:00:06.101278||1||1
+2015-11-08 20:41:26.802585||measurement||ad||2015-11-08 20:41:16.322385@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:41:27.433793||measurement||ad||2015-11-08 20:41:16.322385@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:41:27.617335||measurement||ad||2015-11-08 20:41:16.322385@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:41:27.617522||measurement||loadtime||0:00:11.439974||3||1
+2015-11-08 20:41:37.530536||measurement||ad||2015-11-08 20:41:37.110659@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:41:37.615602||measurement||ad||2015-11-08 20:41:37.110659@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:41:37.679138||measurement||ad||2015-11-08 20:41:37.110659@|6 Stocks to Hold Forever@|wealthyretirement.com/Forever-Stock@|Looking to retire? These "forever" stocks will provide regular income.||3||1
+2015-11-08 20:41:37.679372||measurement||loadtime||0:00:05.060381||3||1
+2015-11-08 20:41:37.679534||event||progress-marker||measurement-end||3||1
+2015-11-08 20:41:43.215710||error||collecting ads||Error||2||0
+2015-11-08 20:41:54.763622||measurement||ad||2015-11-08 20:41:54.508430@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:41:55.050516||measurement||ad||2015-11-08 20:41:54.508430@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:41:55.251160||measurement||ad||2015-11-08 20:41:54.508430@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:41:55.251420||measurement||loadtime||0:00:07.034376||2||0
+2015-11-08 20:42:05.407883||measurement||ad||2015-11-08 20:42:05.201793@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:42:05.554546||measurement||ad||2015-11-08 20:42:05.201793@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:42:05.708668||measurement||ad||2015-11-08 20:42:05.201793@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||2||0
+2015-11-08 20:42:05.708978||measurement||loadtime||0:00:05.456491||2||0
+2015-11-08 20:42:12.694817||error||collecting ads||Error||0||0
+2015-11-08 20:42:14.849157||measurement||ad||2015-11-08 20:42:14.723485@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:42:14.925120||measurement||ad||2015-11-08 20:42:14.723485@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:42:15.011271||measurement||ad||2015-11-08 20:42:14.723485@|Check DSL Availability@|www.highspeedinternetdeals.com@|Find DSL Availability and Compare Plans for DSL, Cable and Satellite||2||0
+2015-11-08 20:42:15.011504||measurement||loadtime||0:00:04.301572||2||0
+2015-11-08 20:42:25.564010||measurement||ad||2015-11-08 20:42:25.395096@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:42:25.736454||measurement||ad||2015-11-08 20:42:25.395096@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:42:25.909354||measurement||ad||2015-11-08 20:42:25.395096@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:42:25.909585||measurement||loadtime||0:00:05.897375||2||0
+2015-11-08 20:42:30.792504||measurement||ad||2015-11-08 20:42:30.637551@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||0
+2015-11-08 20:42:30.934840||measurement||ad||2015-11-08 20:42:30.637551@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||0||0
+2015-11-08 20:42:30.935949||measurement||loadtime||0:00:13.240460||0||0
+2015-11-08 20:42:42.855884||measurement||ad||2015-11-08 20:42:42.729499@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||0
+2015-11-08 20:42:42.958981||measurement||ad||2015-11-08 20:42:42.729499@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||0
+2015-11-08 20:42:43.092358||measurement||ad||2015-11-08 20:42:42.729499@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||0
+2015-11-08 20:42:43.092629||measurement||loadtime||0:00:07.155689||0||0
+2015-11-08 20:42:52.580290||measurement||ad||2015-11-08 20:42:52.429351@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||0
+2015-11-08 20:42:52.739193||measurement||ad||2015-11-08 20:42:52.429351@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||0||0
+2015-11-08 20:42:52.740118||measurement||loadtime||0:00:04.646994||0||0
+2015-11-08 20:42:55.265917||measurement||ad||2015-11-08 20:42:55.056449@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:42:55.387964||measurement||ad||2015-11-08 20:42:55.056449@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:42:55.499731||measurement||ad||2015-11-08 20:42:55.056449@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:42:55.500066||measurement||loadtime||0:00:24.589312||2||0
+2015-11-08 20:42:55.525751||measurement||ad||2015-11-08 20:41:24.495216@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:42:55.577522||measurement||ad||2015-11-08 20:41:24.495216@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:42:55.625578||measurement||ad||2015-11-08 20:41:24.495216@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:42:55.625792||measurement||loadtime||0:01:36.420788||1||1
+2015-11-08 20:43:02.246995||measurement||ad||2015-11-08 20:43:01.744294@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||0
+2015-11-08 20:43:02.639621||measurement||ad||2015-11-08 20:43:01.744294@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||0||0
+2015-11-08 20:43:02.639994||measurement||loadtime||0:00:04.898322||0||0
+2015-11-08 20:43:02.640163||event||progress-marker||measurement-end||0||0
+2015-11-08 20:43:07.437086||measurement||ad||2015-11-08 20:43:06.955081@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:43:07.648221||measurement||ad||2015-11-08 20:43:06.955081@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||2||0
+2015-11-08 20:43:08.015481||measurement||ad||2015-11-08 20:43:06.955081@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:43:08.015748||measurement||loadtime||0:00:07.514722||2||0
+2015-11-08 20:43:08.016446||event||progress-marker||measurement-end||2||0
+2015-11-08 20:43:26.797400||measurement||ad||2015-11-08 20:43:26.410319@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||1
+2015-11-08 20:43:26.834878||measurement||ad||2015-11-08 20:43:26.410319@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||1
+2015-11-08 20:43:26.872131||measurement||ad||2015-11-08 20:43:26.410319@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||1
+2015-11-08 20:43:26.872423||measurement||loadtime||0:00:26.246308||1||1
+2015-11-08 20:43:26.872666||event||progress-marker||measurement-end||1||1
+2015-11-08 20:43:27.210418||meta||block_id end||17
+2015-11-08 20:43:27.211983||meta||block_id start||18
+2015-11-08 20:43:27.212018||meta||assignment||2@|1@|0@|3
+2015-11-08 20:43:30.232945||event||progress-marker||training-start||2||0
+2015-11-08 20:43:30.323124||event||progress-marker||training-start||1||0
+2015-11-08 20:43:32.206963||event||progress-marker||training-start||3||1
+2015-11-08 20:43:32.232380||event||progress-marker||training-start||0||1
+2015-11-08 20:43:39.943300||treatment||visit website||http://irs.gov||1||0
+2015-11-08 20:43:40.024453||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:43:41.286211||treatment||visit website||http://irs.gov||3||1
+2015-11-08 20:43:41.510491||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:43:49.464273||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:43:49.607232||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 20:43:51.999553||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:43:52.006909||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 20:44:03.371715||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:44:04.103159||treatment||visit website||http://pwc.com||1||0
+2015-11-08 20:44:05.471585||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:44:05.636672||treatment||visit website||http://pwc.com||3||1
+2015-11-08 20:44:10.896896||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:44:12.238616||treatment||visit website||http://ey.com||1||0
+2015-11-08 20:44:13.757830||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:44:14.452901||treatment||visit website||http://ey.com||3||1
+2015-11-08 20:44:18.537365||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:44:18.537992||event||progress-marker||training-end||2||0
+2015-11-08 20:44:20.045477||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 20:44:20.045743||event||progress-marker||training-end||1||0
+2015-11-08 20:44:21.930031||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:44:21.930339||event||progress-marker||training-end||0||1
+2015-11-08 20:44:23.046882||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 20:44:23.047177||event||progress-marker||training-end||3||1
+2015-11-08 20:44:23.576774||event||progress-marker||measurement-start||2||0
+2015-11-08 20:44:25.076620||event||progress-marker||measurement-start||1||0
+2015-11-08 20:44:26.959909||event||progress-marker||measurement-start||0||1
+2015-11-08 20:44:28.076046||event||progress-marker||measurement-start||3||1
+2015-11-08 20:44:41.259901||measurement||ad||2015-11-08 20:44:40.757064@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:44:41.550346||measurement||ad||2015-11-08 20:44:40.757064@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:44:41.816424||measurement||ad||2015-11-08 20:44:40.757064@|Brain Training Games@|www.lumosity.com@|Train memory and attention with scientific brain games.||2||0
+2015-11-08 20:44:41.816724||measurement||loadtime||0:00:13.238297||2||0
+2015-11-08 20:44:41.876799||measurement||ad||2015-11-08 20:44:41.650142@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:44:42.088258||measurement||ad||2015-11-08 20:44:41.650142@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:44:42.339914||measurement||ad||2015-11-08 20:44:41.650142@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:44:42.340194||measurement||loadtime||0:00:12.262836||1||0
+2015-11-08 20:44:44.911556||measurement||ad||2015-11-08 20:44:44.321351@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:44:45.073852||measurement||ad||2015-11-08 20:44:44.321351@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 20:44:45.188252||measurement||ad||2015-11-08 20:44:44.321351@|Top 7 Portable Oxygen@|comparestores.net/Portable-Oxygen@|2015 Bestselling Portable Oxygen Compare Latest Deals  Save Big||0||1
+2015-11-08 20:44:45.188616||measurement||loadtime||0:00:13.228207||0||1
+2015-11-08 20:44:46.762023||measurement||ad||2015-11-08 20:44:45.549912@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:44:47.096672||measurement||ad||2015-11-08 20:44:45.549912@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||1
+2015-11-08 20:44:47.225125||measurement||ad||2015-11-08 20:44:45.549912@|5 Foods you must not eat@|trimdownclub.com@|If you never eat these 5 foods, you can lose your belly hips and thighs||3||1
+2015-11-08 20:44:47.225413||measurement||loadtime||0:00:14.147830||3||1
+2015-11-08 20:44:57.040838||measurement||ad||2015-11-08 20:44:56.727686@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:44:57.752018||measurement||ad||2015-11-08 20:44:56.727686@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:44:58.077835||measurement||ad||2015-11-08 20:44:56.727686@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:44:58.078194||measurement||loadtime||0:00:11.259860||2||0
+2015-11-08 20:44:58.377801||measurement||ad||2015-11-08 20:44:57.847924@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:44:58.666563||measurement||ad||2015-11-08 20:44:57.847924@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:44:59.059289||measurement||ad||2015-11-08 20:44:57.847924@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||0
+2015-11-08 20:44:59.059569||measurement||loadtime||0:00:11.718367||1||0
+2015-11-08 20:45:00.965527||measurement||ad||2015-11-08 20:45:00.414518@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:45:01.268476||measurement||ad||2015-11-08 20:45:00.414518@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 20:45:01.547935||measurement||ad||2015-11-08 20:45:00.414518@|Top 7 Portable Oxygen@|comparestores.net/Portable-Oxygen@|2015 Bestselling Portable Oxygen Compare Latest Deals  Save Big||0||1
+2015-11-08 20:45:01.548212||measurement||loadtime||0:00:11.359150||0||1
+2015-11-08 20:45:03.466999||measurement||ad||2015-11-08 20:45:02.486489@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||1
+2015-11-08 20:45:03.636788||measurement||ad||2015-11-08 20:45:02.486489@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||3||1
+2015-11-08 20:45:03.637075||measurement||loadtime||0:00:11.411249||3||1
+2015-11-08 20:45:17.837341||measurement||ad||2015-11-08 20:45:17.347642@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:45:18.037047||measurement||ad||2015-11-08 20:45:17.347642@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:45:18.153568||measurement||ad||2015-11-08 20:45:17.347642@|Retire in the U.K@|www.internationalliving.com@|Free Report for people considering Retiring in the United Kindgom||0||1
+2015-11-08 20:45:18.153843||measurement||loadtime||0:00:11.604409||0||1
+2015-11-08 20:45:23.106681||measurement||ad||2015-11-08 20:45:20.712628@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:45:23.517428||measurement||ad||2015-11-08 20:45:23.046133@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||1
+2015-11-08 20:45:23.634436||measurement||ad||2015-11-08 20:45:23.046133@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||3||1
+2015-11-08 20:45:23.634707||measurement||loadtime||0:00:14.996684||3||1
+2015-11-08 20:45:24.321786||measurement||ad||2015-11-08 20:45:21.955840@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:45:24.568517||measurement||ad||2015-11-08 20:45:20.712628@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:45:25.113006||measurement||ad||2015-11-08 20:45:21.955840@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:45:25.559896||measurement||ad||2015-11-08 20:45:20.712628@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:45:25.560208||measurement||loadtime||0:00:21.500016||1||0
+2015-11-08 20:45:25.717664||measurement||ad||2015-11-08 20:45:21.955840@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:45:25.718074||measurement||loadtime||0:00:22.638338||2||0
+2015-11-08 20:45:31.134218||measurement||ad||2015-11-08 20:45:30.755329@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:45:31.431325||measurement||ad||2015-11-08 20:45:30.755329@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:45:31.774669||measurement||ad||2015-11-08 20:45:30.755329@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:45:31.774908||measurement||loadtime||0:00:08.620545||0||1
+2015-11-08 20:45:35.742512||measurement||ad||2015-11-08 20:45:35.648164@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||1
+2015-11-08 20:45:35.808992||measurement||ad||2015-11-08 20:45:35.648164@|Driving Directions  Maps@|www.download-freemaps.com@|Enter Address Or Location. Get Directions with FreeMaps App||3||1
+2015-11-08 20:45:35.809255||measurement||loadtime||0:00:07.173936||3||1
+2015-11-08 20:45:42.324199||measurement||ad||2015-11-08 20:45:42.213130@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:45:42.410326||measurement||ad||2015-11-08 20:45:42.213130@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 20:45:42.483875||measurement||ad||2015-11-08 20:45:42.213130@|Top 7 Portable Oxygen@|comparestores.net/Portable-Oxygen@|2015 Bestselling Portable Oxygen Compare Latest Deals  Save Big||0||1
+2015-11-08 20:45:42.484140||measurement||loadtime||0:00:05.707704||0||1
+2015-11-08 20:45:46.863637||measurement||ad||2015-11-08 20:45:46.630270@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||3||1
+2015-11-08 20:45:46.978695||measurement||ad||2015-11-08 20:45:46.630270@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||1
+2015-11-08 20:45:47.050773||measurement||ad||2015-11-08 20:45:46.630270@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 20:45:47.051087||measurement||loadtime||0:00:06.240258||3||1
+2015-11-08 20:45:47.157149||measurement||ad||2015-11-08 20:45:46.560844@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:45:47.458537||measurement||ad||2015-11-08 20:45:46.560844@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||2||0
+2015-11-08 20:45:47.907785||measurement||ad||2015-11-08 20:45:46.560844@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:45:47.908099||measurement||loadtime||0:00:17.189419||2||0
+2015-11-08 20:45:48.156809||measurement||ad||2015-11-08 20:45:47.712014@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:45:48.458907||measurement||ad||2015-11-08 20:45:47.712014@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:45:48.717847||measurement||ad||2015-11-08 20:45:47.712014@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||0
+2015-11-08 20:45:48.718045||measurement||loadtime||0:00:18.156552||1||0
+2015-11-08 20:45:53.522724||measurement||ad||2015-11-08 20:45:53.152003@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:45:53.627519||measurement||ad||2015-11-08 20:45:53.152003@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||0||1
+2015-11-08 20:45:53.722404||measurement||ad||2015-11-08 20:45:53.152003@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 20:45:53.722674||measurement||loadtime||0:00:06.237242||0||1
+2015-11-08 20:46:02.587611||measurement||ad||2015-11-08 20:46:02.129881@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:46:02.734890||measurement||ad||2015-11-08 20:46:02.129881@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:46:02.893601||measurement||ad||2015-11-08 20:46:02.636178@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:46:02.985143||measurement||ad||2015-11-08 20:46:02.129881@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||0
+2015-11-08 20:46:02.985405||measurement||loadtime||0:00:09.266576||1||0
+2015-11-08 20:46:03.089248||measurement||ad||2015-11-08 20:46:02.636178@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:46:03.496754||measurement||ad||2015-11-08 20:46:02.636178@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:46:03.497028||measurement||loadtime||0:00:10.588045||2||0
+2015-11-08 20:46:03.605210||measurement||ad||2015-11-08 20:46:01.451534@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:46:04.005662||measurement||ad||2015-11-08 20:46:01.451534@|Top 7 Lg Washer Dryers@|comparestores.net/Lg-Washer-Dryers@|Compare Latest Offers  Save Big. Bestselling Lg Washer Dryers!||3||1
+2015-11-08 20:46:04.479691||measurement||ad||2015-11-08 20:46:01.451534@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||1
+2015-11-08 20:46:04.480045||measurement||loadtime||0:00:12.428095||3||1
+2015-11-08 20:46:08.081077||measurement||ad||2015-11-08 20:46:07.537442@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:46:08.246793||measurement||ad||2015-11-08 20:46:07.537442@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:46:08.386052||measurement||ad||2015-11-08 20:46:07.537442@|Annuity+Social Security=@|seniorannuityalert.com/TV_CNBC_PBS@|Potentially Double Your Income? Open to See New Strategy Now!||0||1
+2015-11-08 20:46:08.386293||measurement||loadtime||0:00:09.662472||0||1
+2015-11-08 20:46:16.768664||measurement||ad||2015-11-08 20:46:16.397935@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:46:17.714162||measurement||ad||2015-11-08 20:46:16.397935@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:46:18.422596||measurement||ad||2015-11-08 20:46:16.397935@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:46:18.422917||measurement||loadtime||0:00:10.437133||1||0
+2015-11-08 20:46:18.880007||measurement||ad||2015-11-08 20:46:18.648866@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||3||1
+2015-11-08 20:46:18.953434||measurement||ad||2015-11-08 20:46:18.648866@|Chelsea NY Hotel Deals@|www.choicehotels.com/Chelsea@|Book Now for Our Best Internet Rates in New York Guaranteed!||3||1
+2015-11-08 20:46:19.020399||measurement||ad||2015-11-08 20:46:18.648866@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||3||1
+2015-11-08 20:46:19.020688||measurement||loadtime||0:00:09.539773||3||1
+2015-11-08 20:47:08.574905||error||collecting ads||Error||2||0
+2015-11-08 20:47:18.950913||measurement||ad||2015-11-08 20:47:18.719192@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:47:19.113277||measurement||ad||2015-11-08 20:47:18.719192@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||2||0
+2015-11-08 20:47:19.197885||measurement||ad||2015-11-08 20:47:18.719192@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:47:19.198119||measurement||loadtime||0:00:05.622170||2||0
+2015-11-08 20:47:23.529890||error||collecting ads||Error||1||0
+2015-11-08 20:47:29.307823||measurement||ad||2015-11-08 20:47:29.151339@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:47:29.447129||measurement||ad||2015-11-08 20:47:29.151339@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:47:29.613404||measurement||ad||2015-11-08 20:47:29.151339@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:47:29.613995||measurement||loadtime||0:00:05.414735||2||0
+2015-11-08 20:47:33.820806||measurement||ad||2015-11-08 20:47:33.616573@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:47:33.940226||measurement||ad||2015-11-08 20:47:33.616573@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:47:34.053089||measurement||ad||2015-11-08 20:47:33.616573@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||1||0
+2015-11-08 20:47:34.053695||measurement||loadtime||0:00:05.523184||1||0
+2015-11-08 20:47:38.111702||measurement||ad||2015-11-08 20:46:19.623558@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:47:38.173378||measurement||ad||2015-11-08 20:46:19.623558@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 20:47:38.225797||measurement||ad||2015-11-08 20:46:19.623558@|Top 7 Portable Oxygen@|comparestores.net/Portable-Oxygen@|2015 Bestselling Portable Oxygen Compare Latest Deals  Save Big||0||1
+2015-11-08 20:47:38.226492||measurement||loadtime||0:01:24.839054||0||1
+2015-11-08 20:47:40.834104||measurement||ad||2015-11-08 20:47:40.617752@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:47:40.968440||measurement||ad||2015-11-08 20:47:40.617752@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:47:41.089319||measurement||ad||2015-11-08 20:47:40.617752@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:47:41.089555||measurement||loadtime||0:00:06.474526||2||0
+2015-11-08 20:47:48.349989||measurement||ad||2015-11-08 20:47:47.911263@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:47:48.432016||measurement||ad||2015-11-08 20:47:47.911263@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:47:48.504452||measurement||ad||2015-11-08 20:47:47.911263@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||0||1
+2015-11-08 20:47:48.504756||measurement||loadtime||0:00:05.277890||0||1
+2015-11-08 20:47:49.018334||measurement||ad||2015-11-08 20:46:30.637728@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:47:49.079972||measurement||ad||2015-11-08 20:46:30.637728@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:47:49.123411||measurement||ad||2015-11-08 20:46:30.637728@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 20:47:49.123745||measurement||loadtime||0:01:25.102681||3||1
+2015-11-08 20:47:52.240482||measurement||ad||2015-11-08 20:47:52.110302@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:47:52.360286||measurement||ad||2015-11-08 20:47:52.110302@|15% Annuity Returns@|advisorworld.com/CompareAnnuities@|Did Your CD Earn 15% Last Year? Someone's Annuity Just Did.||2||0
+2015-11-08 20:47:52.583379||measurement||ad||2015-11-08 20:47:52.110302@|3 Worst Foods for Thyroid@|medixselect.com@|The One Thing You Should Be Eating For Your Thyroid Every Morning.||2||0
+2015-11-08 20:47:52.583618||measurement||loadtime||0:00:06.492375||2||0
+2015-11-08 20:47:52.584416||event||progress-marker||measurement-end||2||0
+2015-11-08 20:47:53.671798||measurement||ad||2015-11-08 20:47:53.470258@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:47:53.763620||measurement||ad||2015-11-08 20:47:53.470258@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:47:54.125476||measurement||ad||2015-11-08 20:47:53.470258@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||0
+2015-11-08 20:47:54.125788||measurement||loadtime||0:00:15.070287||1||0
+2015-11-08 20:47:59.814485||measurement||ad||2015-11-08 20:47:59.398734@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:47:59.865514||measurement||ad||2015-11-08 20:47:59.398734@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:47:59.926734||measurement||ad||2015-11-08 20:47:59.398734@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:47:59.927037||measurement||loadtime||0:00:05.802009||3||1
+2015-11-08 20:48:00.125386||measurement||ad||2015-11-08 20:48:00.017159@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||0||1
+2015-11-08 20:48:00.185817||measurement||ad||2015-11-08 20:48:00.017159@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||0||1
+2015-11-08 20:48:00.272563||measurement||ad||2015-11-08 20:48:00.017159@|Retire in the U.K@|www.internationalliving.com@|Free Report for people considering Retiring in the United Kindgom||0||1
+2015-11-08 20:48:00.272814||measurement||loadtime||0:00:06.767101||0||1
+2015-11-08 20:48:00.272967||event||progress-marker||measurement-end||0||1
+2015-11-08 20:48:03.349450||measurement||ad||2015-11-08 20:48:03.196328@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:48:03.489078||measurement||ad||2015-11-08 20:48:03.196328@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:48:03.622994||measurement||ad||2015-11-08 20:48:03.196328@|14 Annuities Passed Test@|seniorannuityalert.com/TV_CNBC_PBS@|We reviewed over 3000 contracts. Find Out Which Ones We Like!||1||0
+2015-11-08 20:48:03.623209||measurement||loadtime||0:00:04.496017||1||0
+2015-11-08 20:48:03.623375||event||progress-marker||measurement-end||1||0
+2015-11-08 20:48:11.659493||measurement||ad||2015-11-08 20:48:11.474895@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:48:11.775537||measurement||ad||2015-11-08 20:48:11.474895@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:48:11.905042||measurement||ad||2015-11-08 20:48:11.474895@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:48:11.905370||measurement||loadtime||0:00:06.976869||3||1
+2015-11-08 20:48:11.905567||event||progress-marker||measurement-end||3||1
+2015-11-08 20:48:12.207916||meta||block_id end||18
+2015-11-08 20:48:12.210367||meta||block_id start||19
+2015-11-08 20:48:12.210430||meta||assignment||1@|2@|3@|0
+2015-11-08 20:48:15.019489||event||progress-marker||training-start||1||0
+2015-11-08 20:48:15.189597||event||progress-marker||training-start||2||0
+2015-11-08 20:48:16.793703||event||progress-marker||training-start||0||1
+2015-11-08 20:48:16.949535||event||progress-marker||training-start||3||1
+2015-11-08 20:48:23.327032||treatment||visit website||http://irs.gov||1||0
+2015-11-08 20:48:23.678289||treatment||visit website||http://irs.gov||2||0
+2015-11-08 20:48:24.597530||treatment||visit website||http://irs.gov||0||1
+2015-11-08 20:48:24.631899||treatment||visit website||http://irs.gov||3||1
+2015-11-08 20:48:31.534047||treatment||visit website||http://deloitte.com||1||0
+2015-11-08 20:48:32.266833||treatment||visit website||http://deloitte.com||2||0
+2015-11-08 20:48:33.250725||treatment||visit website||http://deloitte.com||3||1
+2015-11-08 20:48:33.774328||treatment||visit website||http://deloitte.com||0||1
+2015-11-08 20:48:42.965321||treatment||visit website||http://pwc.com||1||0
+2015-11-08 20:48:44.429801||treatment||visit website||http://pwc.com||2||0
+2015-11-08 20:48:45.338986||treatment||visit website||http://pwc.com||3||1
+2015-11-08 20:48:45.695552||treatment||visit website||http://pwc.com||0||1
+2015-11-08 20:48:50.245416||treatment||visit website||http://ey.com||1||0
+2015-11-08 20:48:52.132289||treatment||visit website||http://ey.com||2||0
+2015-11-08 20:48:52.834493||treatment||visit website||http://ey.com||0||1
+2015-11-08 20:48:53.000842||treatment||visit website||http://ey.com||3||1
+2015-11-08 20:48:57.600453||treatment||visit website||http://kpmg.com||1||0
+2015-11-08 20:48:57.600832||event||progress-marker||training-end||1||0
+2015-11-08 20:49:00.421172||treatment||visit website||http://kpmg.com||2||0
+2015-11-08 20:49:00.421396||event||progress-marker||training-end||2||0
+2015-11-08 20:49:00.929874||treatment||visit website||http://kpmg.com||0||1
+2015-11-08 20:49:00.930128||event||progress-marker||training-end||0||1
+2015-11-08 20:49:00.996603||treatment||visit website||http://kpmg.com||3||1
+2015-11-08 20:49:00.996923||event||progress-marker||training-end||3||1
+2015-11-08 20:49:02.630671||event||progress-marker||measurement-start||1||0
+2015-11-08 20:49:05.454810||event||progress-marker||measurement-start||2||0
+2015-11-08 20:49:05.960385||event||progress-marker||measurement-start||0||1
+2015-11-08 20:49:06.026612||event||progress-marker||measurement-start||3||1
+2015-11-08 20:49:20.865777||measurement||ad||2015-11-08 20:49:19.914926@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||0||1
+2015-11-08 20:49:21.102179||measurement||ad||2015-11-08 20:49:19.914926@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:49:21.196627||measurement||ad||2015-11-08 20:49:19.914926@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:49:21.196896||measurement||loadtime||0:00:10.236103||0||1
+2015-11-08 20:49:21.385865||measurement||ad||2015-11-08 20:49:20.560414@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||3||1
+2015-11-08 20:49:21.461719||measurement||ad||2015-11-08 20:49:20.560414@|16 Biggest Dogs Ever@|pressroomvip.com/16-Biggest-Dogs@|See the Biggest Dogs of All Time! You'll Never Believe #6.||3||1
+2015-11-08 20:49:21.529199||measurement||ad||2015-11-08 20:49:20.560414@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||3||1
+2015-11-08 20:49:21.529480||measurement||loadtime||0:00:10.502373||3||1
+2015-11-08 20:49:24.316970||measurement||ad||2015-11-08 20:49:24.074106@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:49:24.515026||measurement||ad||2015-11-08 20:49:24.074106@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:49:24.723571||measurement||ad||2015-11-08 20:49:24.074106@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:49:24.723882||measurement||loadtime||0:00:17.092589||1||0
+2015-11-08 20:49:26.203732||measurement||ad||2015-11-08 20:49:26.020398@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:49:26.464388||measurement||ad||2015-11-08 20:49:26.020398@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||0
+2015-11-08 20:49:26.957674||measurement||ad||2015-11-08 20:49:26.020398@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:49:26.957997||measurement||loadtime||0:00:16.502406||2||0
+2015-11-08 20:49:33.852001||measurement||ad||2015-11-08 20:49:33.214712@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||0||1
+2015-11-08 20:49:34.009402||measurement||ad||2015-11-08 20:49:33.214712@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||0||1
+2015-11-08 20:49:34.211971||measurement||ad||2015-11-08 20:49:33.214712@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:49:34.212221||measurement||loadtime||0:00:08.014164||0||1
+2015-11-08 20:49:37.565874||measurement||ad||2015-11-08 20:49:37.277883@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:49:37.789397||measurement||ad||2015-11-08 20:49:37.277883@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||3||1
+2015-11-08 20:49:37.880797||measurement||ad||2015-11-08 20:49:37.277883@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||3||1
+2015-11-08 20:49:37.881074||measurement||loadtime||0:00:11.350222||3||1
+2015-11-08 20:49:45.427295||measurement||ad||2015-11-08 20:49:45.066033@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:49:45.736005||measurement||ad||2015-11-08 20:49:45.066033@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 20:49:45.897926||measurement||ad||2015-11-08 20:49:45.066033@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:49:45.898203||measurement||loadtime||0:00:16.173585||1||0
+2015-11-08 20:49:49.430813||measurement||ad||2015-11-08 20:49:48.735704@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:49:49.788195||measurement||ad||2015-11-08 20:49:48.735704@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||0||1
+2015-11-08 20:49:49.923278||measurement||ad||2015-11-08 20:49:48.735704@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:49:49.923590||measurement||loadtime||0:00:10.709902||0||1
+2015-11-08 20:49:53.611070||measurement||ad||2015-11-08 20:49:53.222430@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:49:53.762759||measurement||ad||2015-11-08 20:49:53.222430@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:49:53.909416||measurement||ad||2015-11-08 20:49:53.222430@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:49:53.910232||measurement||loadtime||0:00:11.028244||3||1
+2015-11-08 20:49:55.867634||measurement||ad||2015-11-08 20:49:55.519523@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:49:56.115683||measurement||ad||2015-11-08 20:49:55.519523@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:49:56.320540||measurement||ad||2015-11-08 20:49:55.519523@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:49:56.320906||measurement||loadtime||0:00:24.361943||2||0
+2015-11-08 20:50:04.580775||measurement||ad||2015-11-08 20:50:03.750450@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:50:04.755330||measurement||ad||2015-11-08 20:50:03.750450@|Hospital Jobs (Hiring)@|www.findtherightjob.com/hospital@|Find Job Openings In Your Area. Positions Available - Apply Today!||0||1
+2015-11-08 20:50:04.857338||measurement||ad||2015-11-08 20:50:03.750450@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||0||1
+2015-11-08 20:50:04.858326||measurement||loadtime||0:00:09.933896||0||1
+2015-11-08 20:50:05.610491||measurement||ad||2015-11-08 20:50:05.250357@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:50:05.968005||measurement||ad||2015-11-08 20:50:05.250357@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:50:06.579797||measurement||ad||2015-11-08 20:50:05.250357@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:50:06.580082||measurement||loadtime||0:00:15.679968||1||0
+2015-11-08 20:50:08.171389||measurement||ad||2015-11-08 20:50:07.769740@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||1
+2015-11-08 20:50:08.280762||measurement||ad||2015-11-08 20:50:07.769740@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:50:08.405803||measurement||ad||2015-11-08 20:50:07.769740@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:50:08.406196||measurement||loadtime||0:00:09.494097||3||1
+2015-11-08 20:50:14.403534||measurement||ad||2015-11-08 20:50:13.512872@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:50:14.972169||measurement||ad||2015-11-08 20:50:13.512872@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||2||0
+2015-11-08 20:50:15.377780||measurement||ad||2015-11-08 20:50:13.512872@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:50:15.379001||measurement||loadtime||0:00:14.056337||2||0
+2015-11-08 20:50:19.025744||measurement||ad||2015-11-08 20:50:09.948655@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:50:19.153495||measurement||ad||2015-11-08 20:50:09.948655@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:50:19.250048||measurement||ad||2015-11-08 20:50:09.948655@|Hospital Jobs (Hiring)@|www.findtherightjob.com/hospital@|Find Job Openings In Your Area. Positions Available - Apply Today!||0||1
+2015-11-08 20:50:19.250344||measurement||loadtime||0:00:09.391621||0||1
+2015-11-08 20:50:21.841780||measurement||ad||2015-11-08 20:50:13.855965@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:50:21.989518||measurement||ad||2015-11-08 20:50:13.855965@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||3||1
+2015-11-08 20:50:22.140390||measurement||ad||2015-11-08 20:50:13.855965@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:50:22.140664||measurement||loadtime||0:00:08.734069||3||1
+2015-11-08 20:50:33.768864||measurement||ad||2015-11-08 20:50:33.680352@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:50:33.832622||measurement||ad||2015-11-08 20:50:33.680352@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:50:33.887079||measurement||ad||2015-11-08 20:50:33.680352@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:50:33.887337||measurement||loadtime||0:00:06.746000||3||1
+2015-11-08 20:50:43.720241||measurement||ad||2015-11-08 20:50:43.534461@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:50:43.779965||measurement||ad||2015-11-08 20:50:43.534461@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:50:43.831211||measurement||ad||2015-11-08 20:50:43.534461@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:50:43.831547||measurement||loadtime||0:00:04.942589||3||1
+2015-11-08 20:50:49.911910||measurement||ad||2015-11-08 20:50:29.682304@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:50:49.966660||measurement||ad||2015-11-08 20:50:29.682304@|Common Core Instruction@|learningfarm.com@|Easy to Use; Fun for Kids; Math  ELA; Practice  Instruction||0||1
+2015-11-08 20:50:49.966977||measurement||loadtime||0:00:25.715716||0||1
+2015-11-08 20:50:52.765383||measurement||ad||2015-11-08 20:50:52.630023@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:50:52.853892||measurement||ad||2015-11-08 20:50:52.630023@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:50:52.934960||measurement||ad||2015-11-08 20:50:52.630023@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||3||1
+2015-11-08 20:50:52.935137||measurement||loadtime||0:00:04.102600||3||1
+2015-11-08 20:50:59.548592||measurement||ad||2015-11-08 20:50:59.131550@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:50:59.634525||measurement||ad||2015-11-08 20:50:59.131550@|Airport Jobs (Hiring Now)@|www.findtherightjob.com@|Find Job Openings In Your Area. Positions Available - Apply Today!||0||1
+2015-11-08 20:50:59.702246||measurement||ad||2015-11-08 20:50:59.131550@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||0||1
+2015-11-08 20:50:59.702529||measurement||loadtime||0:00:04.734234||0||1
+2015-11-08 20:51:00.849095||measurement||ad||2015-11-08 20:51:00.637047@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:51:01.415446||measurement||ad||2015-11-08 20:51:00.637047@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||3||1
+2015-11-08 20:51:01.470526||measurement||ad||2015-11-08 20:51:00.637047@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||1
+2015-11-08 20:51:01.470844||measurement||loadtime||0:00:03.534175||3||1
+2015-11-08 20:51:11.722796||measurement||ad||2015-11-08 20:51:11.194448@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||0||1
+2015-11-08 20:51:11.759987||error||collecting ads||Error||1||0
+2015-11-08 20:51:11.918587||measurement||ad||2015-11-08 20:51:11.194448@|$17-$28/Hr Security Jobs@|www.findtherightjob.com@|Find Job Openings In Your Area. Positions Available - Apply Today!||0||1
+2015-11-08 20:51:12.091980||measurement||ad||2015-11-08 20:51:11.194448@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||0||1
+2015-11-08 20:51:12.092253||measurement||loadtime||0:00:07.389180||0||1
+2015-11-08 20:51:12.399233||measurement||ad||2015-11-08 20:51:11.950793@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||3||1
+2015-11-08 20:51:12.509147||measurement||ad||2015-11-08 20:51:11.950793@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||3||1
+2015-11-08 20:51:12.670566||measurement||ad||2015-11-08 20:51:11.950793@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||3||1
+2015-11-08 20:51:12.670861||measurement||loadtime||0:00:06.198878||3||1
+2015-11-08 20:51:12.671018||event||progress-marker||measurement-end||3||1
+2015-11-08 20:51:20.812077||error||collecting ads||Error||2||0
+2015-11-08 20:51:22.467820||measurement||ad||2015-11-08 20:51:22.317919@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 20:51:22.530240||measurement||ad||2015-11-08 20:51:22.317919@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:51:22.587225||measurement||ad||2015-11-08 20:51:22.317919@|Best Dry Dog Food@|www.whole-dog-journal.com@|Unbiased Dry Dog Food Reviews All in Whole Dog Journal Magazine||0||1
+2015-11-08 20:51:22.587590||measurement||loadtime||0:00:05.493863||0||1
+2015-11-08 20:51:25.114280||measurement||ad||2015-11-08 20:51:24.926600@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:51:25.280207||measurement||ad||2015-11-08 20:51:24.926600@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:51:25.461141||measurement||ad||2015-11-08 20:51:24.926600@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:51:25.461643||measurement||loadtime||0:00:08.700552||1||0
+2015-11-08 20:51:34.599403||measurement||ad||2015-11-08 20:51:34.216232@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:51:34.787348||measurement||ad||2015-11-08 20:51:34.216232@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:51:34.882924||measurement||ad||2015-11-08 20:51:34.216232@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:51:34.883203||measurement||loadtime||0:00:09.070473||2||0
+2015-11-08 20:51:35.840417||measurement||ad||2015-11-08 20:51:35.614743@|New Nissans From $9,990@|imotors.com/Nissan@|Dealers are Cutting Prices! Everything Must Go.||0||1
+2015-11-08 20:51:35.934407||measurement||ad||2015-11-08 20:51:35.614743@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-08 20:51:36.027448||measurement||ad||2015-11-08 20:51:35.614743@|Videos on MS@|www.everydayhealth.com/MS@|Learn About the Causes, Symptoms And Treatment Options of MS.||0||1
+2015-11-08 20:51:36.027689||measurement||loadtime||0:00:08.439098||0||1
+2015-11-08 20:51:36.027806||event||progress-marker||measurement-end||0||1
+2015-11-08 20:51:37.564605||measurement||ad||2015-11-08 20:51:37.454607@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:51:37.666647||measurement||ad||2015-11-08 20:51:37.454607@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 20:51:37.817600||measurement||ad||2015-11-08 20:51:37.454607@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:51:37.817823||measurement||loadtime||0:00:07.355286||1||0
+2015-11-08 20:51:42.718618||measurement||ad||2015-11-08 20:51:42.577049@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:51:42.822504||measurement||ad||2015-11-08 20:51:42.577049@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:51:43.030198||measurement||ad||2015-11-08 20:51:42.577049@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||2||0
+2015-11-08 20:51:43.030573||measurement||loadtime||0:00:03.145340||2||0
+2015-11-08 20:51:47.385196||measurement||ad||2015-11-08 20:51:47.283327@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:51:47.469672||measurement||ad||2015-11-08 20:51:47.283327@|Man Cheats Credit Score@|www.thecreditsolutionprogram.com@|1 simple trick  my credit score jumped 217 pts. Banks hate this!||1||0
+2015-11-08 20:51:47.570671||measurement||ad||2015-11-08 20:51:47.283327@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-08 20:51:47.571096||measurement||loadtime||0:00:04.752801||1||0
+2015-11-08 20:51:53.221823||measurement||ad||2015-11-08 20:51:53.074153@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:51:53.324824||measurement||ad||2015-11-08 20:51:53.074153@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||2||0
+2015-11-08 20:51:53.461642||measurement||ad||2015-11-08 20:51:53.074153@|Simple Irish Retirement@|www.internationalliving.com@|Free Report for people considering Living or Retiring in Ireland.||2||0
+2015-11-08 20:51:53.462013||measurement||loadtime||0:00:05.430467||2||0
+2015-11-08 20:51:59.926106||measurement||ad||2015-11-08 20:51:59.495484@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:52:00.123149||measurement||ad||2015-11-08 20:51:59.495484@|Daily Routine for Knees@|www.instaflex.com/advanced@|Doctors reveal the secret to better knees  joints - Do this daily!||1||0
+2015-11-08 20:52:00.314367||measurement||ad||2015-11-08 20:51:59.495484@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:52:00.314635||measurement||loadtime||0:00:07.742638||1||0
+2015-11-08 20:52:04.782827||measurement||ad||2015-11-08 20:52:04.625932@|5 Foods you must not eat@|trimdownclub.com@|Cut down a bit of your belly every day by never eating these 5 foods.||2||0
+2015-11-08 20:52:04.969815||measurement||ad||2015-11-08 20:52:04.625932@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-08 20:52:05.113114||measurement||ad||2015-11-08 20:52:04.625932@|Masters of Laws Degree@|college.ch/LLM-in-One-Year@|British Online Masters of Laws degree in one Year. Get Free Trial!||2||0
+2015-11-08 20:52:05.113379||measurement||loadtime||0:00:06.649643||2||0
+2015-11-08 20:52:11.072564||measurement||ad||2015-11-08 20:52:10.573976@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:52:11.327552||measurement||ad||2015-11-08 20:52:10.573976@|8% Annual Annuity Return@|advisorworld.com/CompareAnnuities@|Get guaranteed lifetime income and reduced risks to retirees all here.||1||0
+2015-11-08 20:52:11.523625||measurement||ad||2015-11-08 20:52:10.573976@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||1||0
+2015-11-08 20:52:11.524037||measurement||loadtime||0:00:06.208000||1||0
+2015-11-08 20:52:16.405766||measurement||ad||2015-11-08 20:52:16.261013@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:52:16.569838||measurement||ad||2015-11-08 20:52:16.261013@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:52:16.736004||measurement||ad||2015-11-08 20:52:16.261013@|How to Fix Slow Computer@|slimcleaner.com/Slow-Computer@|Easily Repair a Slow Computer. Very Simple Instructions||2||0
+2015-11-08 20:52:16.736310||measurement||loadtime||0:00:06.621772||2||0
+2015-11-08 20:52:20.132016||measurement||ad||2015-11-08 20:52:20.046044@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||1||0
+2015-11-08 20:52:20.202741||measurement||ad||2015-11-08 20:52:20.046044@|Stable Retirement Income?@|seniorannuityalert.com/TV_CNBC_PBS@|3000+ Annuities Reviewed. Get Comparative Quote. Call Now!||1||0
+2015-11-08 20:52:20.273219||measurement||ad||2015-11-08 20:52:20.046044@|14.2% 2014 Annuity Return@|onlineannuityrates.com/TopAnnuities@|Best Annuities for 2015 Revealed. Get the Details in our Free Report.||1||0
+2015-11-08 20:52:20.273417||measurement||loadtime||0:00:03.748578||1||0
+2015-11-08 20:52:20.273514||event||progress-marker||measurement-end||1||0
+2015-11-08 20:52:26.539829||measurement||ad||2015-11-08 20:52:26.373058@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||2||0
+2015-11-08 20:52:26.650704||measurement||ad||2015-11-08 20:52:26.373058@|Medicare Part D@|shopsteal.us/Medicare-Part-D@|Compare All Plans and Offers Save Your Money Now !||2||0
+2015-11-08 20:52:26.731086||measurement||ad||2015-11-08 20:52:26.373058@|My Home is Worth, What?@|www.trulia.com@|See your Home's Market Value Free  It Just Takes Seconds||2||0
+2015-11-08 20:52:26.731285||measurement||loadtime||0:00:04.993528||2||0
+2015-11-08 20:52:26.731384||event||progress-marker||measurement-end||2||0
+2015-11-08 20:52:27.248192||meta||block_id end||19

--- a/AdFisher/examples/log.group_ex2.txt
+++ b/AdFisher/examples/log.group_ex2.txt
@@ -1,0 +1,7277 @@
+2015-11-09 02:25:44.775756||meta||agents||6
+2015-11-09 02:25:44.775812||meta||treatnames||control@|experimental
+2015-11-09 02:25:44.776947||meta||block_id start||0
+2015-11-09 02:25:44.776991||meta||assignment||2@|4@|1@|3@|5@|0
+2015-11-09 02:25:49.128702||event||progress-marker||training-start||2||0
+2015-11-09 02:25:49.162475||event||progress-marker||training-start||1||0
+2015-11-09 02:25:49.566785||event||progress-marker||training-start||4||0
+2015-11-09 02:25:54.684435||treatment||google search||Buy BMW||2||0
+2015-11-09 02:25:54.982520||treatment||google search||Buy BMW||4||0
+2015-11-09 02:25:55.047707||event||progress-marker||training-start||5||1
+2015-11-09 02:25:55.175460||event||progress-marker||training-start||0||1
+2015-11-09 02:25:55.190784||event||progress-marker||training-start||3||1
+2015-11-09 02:25:56.067754||treatment||google search||Buy BMW||1||0
+2015-11-09 02:25:56.799452||error||visiting||google searchresults||4||0
+2015-11-09 02:25:56.820285||error||visiting||google searchresults||2||0
+2015-11-09 02:25:57.727054||error||visiting||google searchresults||1||0
+2015-11-09 02:26:00.593189||treatment||google search||Buy BMW||0||1
+2015-11-09 02:26:00.643635||treatment||google search||Buy BMW||5||1
+2015-11-09 02:26:00.781792||treatment||google search||Buy BMW||3||1
+2015-11-09 02:26:11.632065||error||visiting||google searchresults||0||1
+2015-11-09 02:26:11.684568||error||visiting||google searchresults||5||1
+2015-11-09 02:26:11.754158||error||visiting||google searchresults||3||1
+2015-11-09 02:26:16.199895||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||2||0
+2015-11-09 02:26:18.641757||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 02:26:20.959034||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 02:26:27.088192||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||1
+2015-11-09 02:26:29.549201||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 02:26:30.265582||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||2||0
+2015-11-09 02:26:33.076646||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||5||1
+2015-11-09 02:26:35.660665||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 02:26:37.753399||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 02:26:40.809292||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||1
+2015-11-09 02:26:41.091038||error||visiting||google searchresults||2||0
+2015-11-09 02:26:45.807725||error||visiting||google searchresults||4||0
+2015-11-09 02:26:46.256056||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 02:26:46.421535||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||5||1
+2015-11-09 02:26:47.806079||error||visiting||google searchresults||1||0
+2015-11-09 02:26:55.003704||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/build?utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=s7Iy49Vq6_dc|pcrid|64059787972|pkw|1%20series|pmt|b||2||0
+2015-11-09 02:26:59.886557||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CL6PoqXogskCFdUvgQodVzINNw||4||0
+2015-11-09 02:27:00.912604||error||visiting||google searchresults||3||1
+2015-11-09 02:27:01.820183||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CPftmabogskCFZYkgQod96sHBA||1||0
+2015-11-09 02:27:06.344673||error||visiting||google searchresults||0||1
+2015-11-09 02:27:06.475140||error||visiting||google searchresults||5||1
+2015-11-09 02:27:06.881103||treatment||google search||BMW dealer||2||0
+2015-11-09 02:27:07.560963||error||visiting||google searchresults||2||0
+2015-11-09 02:27:11.713818||treatment||google search||BMW dealer||4||0
+2015-11-09 02:27:12.373544||error||visiting||google searchresults||4||0
+2015-11-09 02:27:13.651709||treatment||google search||BMW dealer||1||0
+2015-11-09 02:27:14.282088||error||visiting||google searchresults||1||0
+2015-11-09 02:27:15.278663||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CKGMu6zogskCFVI7gQodrjYBDQ||3||1
+2015-11-09 02:27:20.415185||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CNr6ha_ogskCFdgYgQody_wFDQ||0||1
+2015-11-09 02:27:20.508671||treatment||visit page||http://www.mbusa.com/mercedes/dealers/locator/LCP-508/searchType-byLcp?utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sjbED6sLh_dc|pcrid|64059787972|pkw|1%20series|pmt|b&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b#!layout=/dealers/locator&businessType=DEALERS&radius=500&expandRadius=false&searchType=byLcp&LCP=508||5||1
+2015-11-09 02:27:27.653356||treatment||google search||BMW dealer||3||1
+2015-11-09 02:27:27.977210||treatment||visit page||http://www.carsense.com/?gclid=CK_69bHogskCFZQjgQodp6QJLQ||4||0
+2015-11-09 02:27:32.413293||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIqH7LLogskCFdcYgQodjHIJmg||1||0
+2015-11-09 02:27:32.606789||treatment||google search||BMW dealer||0||1
+2015-11-09 02:27:32.712387||treatment||google search||BMW dealer||5||1
+2015-11-09 02:27:38.667012||error||visiting||google searchresults||3||1
+2015-11-09 02:27:43.293356||error||visiting||google searchresults||0||1
+2015-11-09 02:27:43.546156||treatment||visit page||http://www.carsense.com/?gclid=CKCgwLnogskCFdgPgQodEnsOlw||4||0
+2015-11-09 02:27:43.629691||error||visiting||google searchresults||5||1
+2015-11-09 02:27:44.785858||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPvT1q_ogskCFUgvgQod-r4Cfw||2||0
+2015-11-09 02:27:47.419579||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMuRurvogskCFUUlgQodxcoKZQ||1||0
+2015-11-09 02:27:53.653073||error||visiting||google searchresults||4||0
+2015-11-09 02:27:57.204346||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIrr6cDogskCFZQdgQod_WgHpw||5||1
+2015-11-09 02:27:57.468136||error||visiting||google searchresults||1||0
+2015-11-09 02:27:57.563149||treatment||visit page||http://www.carsense.com/?gclid=COvIuL7ogskCFUM2gQodwkkDeA||3||1
+2015-11-09 02:27:59.717685||treatment||visit page||http://www.carsense.com/?gclid=CKPw18DogskCFVY9gQodhJwOrg||0||1
+2015-11-09 02:28:00.519953||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKT2sMHogskCFdgDgQodN8QD6w||2||0
+2015-11-09 02:28:08.706080||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CM3AysXogskCFdcYgQodjHIJmg||4||0
+2015-11-09 02:28:12.607809||error||visiting||google searchresults||2||0
+2015-11-09 02:28:15.435768||treatment||visit page||http://www.carsense.com/?gclid=CIqswcjogskCFUUdgQodBswGAg||0||1
+2015-11-09 02:28:16.076501||treatment||visit page||http://www.carsense.com/?gclid=CPO0usfogskCFdgVgQodCWoF0w||3||1
+2015-11-09 02:28:16.210729||treatment||visit page||http://www.carsense.com/?gclid=CNKms8fogskCFdgIgQodts4DTw||1||0
+2015-11-09 02:28:16.471940||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMzUo8fogskCFdgGgQodtJYOGQ||5||1
+2015-11-09 02:28:20.520866||treatment||google search||BMW||4||0
+2015-11-09 02:28:21.496424||error||visiting||google searchresults||4||0
+2015-11-09 02:28:28.186093||treatment||google search||BMW||1||0
+2015-11-09 02:28:28.530559||treatment||visit page||http://www.carsense.com/?gclid=CMee1s7ogskCFdgUgQod7XIEQg||2||0
+2015-11-09 02:28:28.961511||error||visiting||google searchresults||1||0
+2015-11-09 02:28:35.512487||error||visiting||google searchresults||0||1
+2015-11-09 02:28:36.130003||error||visiting||google searchresults||3||1
+2015-11-09 02:28:36.567501||error||visiting||google searchresults||5||1
+2015-11-09 02:28:39.798913||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 02:28:40.416338||treatment||google search||BMW||2||0
+2015-11-09 02:28:41.284192||error||visiting||google searchresults||2||0
+2015-11-09 02:28:46.782865||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 02:28:50.193550||treatment||visit page||http://www.usautomart.com/?gclid=CMyh7dnogskCFYkjgQodPiQO3A||3||1
+2015-11-09 02:28:52.555359||treatment||visit page||http://www.usautomart.com/?gclid=CP-7xdnogskCFdgUgQod7XIEQg||0||1
+2015-11-09 02:28:53.884164||treatment||visit page||http://www.carsense.com/?gclid=CMacktrogskCFRc6gQodS7sPmw||5||1
+2015-11-09 02:28:56.304585||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 02:29:00.539010||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 02:29:02.182102||treatment||google search||BMW||3||1
+2015-11-09 02:29:02.600363||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 02:29:04.530158||treatment||google search||BMW||0||1
+2015-11-09 02:29:05.730900||treatment||google search||BMW||5||1
+2015-11-09 02:29:06.389394||error||visiting||google searchresults||4||0
+2015-11-09 02:29:12.666142||error||visiting||google searchresults||1||0
+2015-11-09 02:29:14.131519||error||visiting||google searchresults||3||1
+2015-11-09 02:29:15.774164||error||visiting||google searchresults||0||1
+2015-11-09 02:29:16.728771||error||visiting||google searchresults||5||1
+2015-11-09 02:29:16.787920||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 02:29:21.538225||treatment||visit page||http://www.bmwusa.com/Standard/Content/SalesandPrograms/Offers.aspx||4||0
+2015-11-09 02:29:26.842778||error||visiting||google searchresults||2||0
+2015-11-09 02:29:31.228899||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 02:29:31.540664||event||progress-marker||training-end||4||0
+2015-11-09 02:29:41.233772||event||progress-marker||training-end||1||0
+2015-11-09 02:29:41.511800||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 02:29:41.859449||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 02:29:41.885540||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 02:29:51.512888||event||progress-marker||training-end||2||0
+2015-11-09 02:29:52.715312||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 02:29:55.192445||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 02:29:58.547459||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 02:30:08.711427||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 02:30:15.262751||error||visiting||google searchresults||5||1
+2015-11-09 02:30:18.609709||error||visiting||google searchresults||3||1
+2015-11-09 02:30:28.767054||error||visiting||google searchresults||0||1
+2015-11-09 02:30:32.797530||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 02:30:33.320939||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 02:30:42.798803||event||progress-marker||training-end||3||1
+2015-11-09 02:30:43.323564||event||progress-marker||training-end||5||1
+2015-11-09 02:30:45.411481||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 02:30:55.412434||event||progress-marker||training-end||0||1
+2015-11-09 02:30:56.263000||event||progress-marker||measurement-start||1||0
+2015-11-09 02:30:56.536919||event||progress-marker||measurement-start||2||0
+2015-11-09 02:30:56.569731||event||progress-marker||measurement-start||4||0
+2015-11-09 02:30:57.806853||event||progress-marker||measurement-start||3||1
+2015-11-09 02:30:58.329726||event||progress-marker||measurement-start||5||1
+2015-11-09 02:31:00.416528||event||progress-marker||measurement-start||0||1
+2015-11-09 02:31:43.586594||measurement||ad||2015-11-09 02:31:43.303633@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:31:43.778876||measurement||ad||2015-11-09 02:31:43.303633@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 02:31:43.792516||measurement||loadtime||0:00:40.983630||3||1
+2015-11-09 02:31:45.857529||measurement||ad||2015-11-09 02:31:45.196973@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:31:46.509957||measurement||ad||2015-11-09 02:31:45.196973@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:31:46.542022||measurement||loadtime||0:00:41.124645||0||1
+2015-11-09 02:31:47.539528||measurement||ad||2015-11-09 02:31:46.875250@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 02:31:47.728755||measurement||ad||2015-11-09 02:31:46.875250@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||1
+2015-11-09 02:31:47.765205||measurement||loadtime||0:00:44.434779||5||1
+2015-11-09 02:31:55.664440||measurement||ad||2015-11-09 02:31:36.350348@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:31:57.301908||measurement||ad||2015-11-09 02:31:36.350348@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:31:57.546927||measurement||loadtime||0:00:56.281974||1||0
+2015-11-09 02:32:00.379999||measurement||ad||2015-11-09 02:31:42.006765@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 02:32:00.981157||measurement||ad||2015-11-09 02:31:42.006765@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:32:00.987745||measurement||loadtime||0:00:59.417114||4||0
+2015-11-09 02:32:15.532467||measurement||ad||2015-11-09 02:32:15.036682@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:32:15.854643||measurement||ad||2015-11-09 02:32:15.036682@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 02:32:15.899130||measurement||loadtime||0:00:27.105985||3||1
+2015-11-09 02:32:19.442684||measurement||ad||2015-11-09 02:31:39.777606@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:32:20.707662||measurement||ad||2015-11-09 02:31:39.777606@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 02:32:20.712360||measurement||loadtime||0:01:19.173667||2||0
+2015-11-09 02:32:26.934845||measurement||ad||2015-11-09 02:32:26.142709@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-09 02:32:27.085539||measurement||ad||2015-11-09 02:32:26.142709@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:32:27.116314||measurement||loadtime||0:00:35.573031||0||1
+2015-11-09 02:32:27.399135||measurement||ad||2015-11-09 02:32:26.586784@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||5||1
+2015-11-09 02:32:27.580282||measurement||ad||2015-11-09 02:32:26.586784@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:32:27.594712||measurement||loadtime||0:00:34.828848||5||1
+2015-11-09 02:32:38.916459||measurement||ad||2015-11-09 02:32:31.314626@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||4||0
+2015-11-09 02:32:39.354430||measurement||ad||2015-11-09 02:32:31.314626@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:32:39.359244||measurement||loadtime||0:00:33.370834||4||0
+2015-11-09 02:32:41.245758||measurement||ad||2015-11-09 02:32:30.761582@|Apartments in Bangalore@|puravankara.com/Luxury_Apartments@|Purva Scarlet Off Kanakpura Road. Price Starting @4690 psft.Register!||1||0
+2015-11-09 02:32:41.419858||measurement||ad||2015-11-09 02:32:30.761582@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:32:41.491925||measurement||loadtime||0:00:38.943376||1||0
+2015-11-09 02:32:43.807995||measurement||ad||2015-11-09 02:32:43.345680@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:32:43.971498||measurement||ad||2015-11-09 02:32:43.345680@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:32:43.999612||measurement||loadtime||0:00:23.099683||3||1
+2015-11-09 02:32:58.578268||measurement||ad||2015-11-09 02:32:57.505199@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:32:58.835078||measurement||ad||2015-11-09 02:32:57.505199@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:32:58.944546||measurement||loadtime||0:00:26.827577||0||1
+2015-11-09 02:33:05.118012||measurement||ad||2015-11-09 02:33:04.186842@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||5||1
+2015-11-09 02:33:05.375061||measurement||ad||2015-11-09 02:33:04.186842@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:33:05.422255||measurement||loadtime||0:00:32.826701||5||1
+2015-11-09 02:33:13.706791||measurement||ad||2015-11-09 02:32:55.941238@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:33:14.865222||measurement||ad||2015-11-09 02:32:55.941238@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 02:33:15.006666||measurement||loadtime||0:00:49.293527||2||0
+2015-11-09 02:33:18.551688||measurement||ad||2015-11-09 02:33:18.010133@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:33:18.815544||measurement||ad||2015-11-09 02:33:18.010133@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:33:18.866958||measurement||loadtime||0:00:29.865911||3||1
+2015-11-09 02:33:19.686625||measurement||ad||2015-11-09 02:33:10.287994@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:33:20.279602||measurement||ad||2015-11-09 02:33:10.287994@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:33:20.372765||measurement||loadtime||0:00:33.880015||1||0
+2015-11-09 02:33:21.333889||measurement||ad||2015-11-09 02:33:07.614403@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 02:33:22.513233||measurement||ad||2015-11-09 02:33:07.614403@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:33:22.697687||measurement||loadtime||0:00:38.337576||4||0
+2015-11-09 02:33:34.205985||measurement||ad||2015-11-09 02:33:33.679625@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||0||1
+2015-11-09 02:33:34.414839||measurement||ad||2015-11-09 02:33:33.679625@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:33:34.432329||measurement||loadtime||0:00:30.486337||0||1
+2015-11-09 02:33:41.863644||measurement||ad||2015-11-09 02:33:41.553719@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:33:41.972295||measurement||ad||2015-11-09 02:33:41.553719@|VA Loans- $0 Down@|veteransunited.com@|Dedicated to Military Home Owners. PreQualify Today on Up to $417K!||5||1
+2015-11-09 02:33:41.994907||measurement||loadtime||0:00:31.572151||5||1
+2015-11-09 02:33:50.152303||measurement||ad||2015-11-09 02:33:49.857615@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:33:50.343848||measurement||ad||2015-11-09 02:33:49.857615@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:33:50.359131||measurement||loadtime||0:00:26.490797||3||1
+2015-11-09 02:33:51.152262||measurement||ad||2015-11-09 02:33:45.012450@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:33:51.250375||measurement||ad||2015-11-09 02:33:45.012450@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 02:33:51.255970||measurement||loadtime||0:00:31.247809||2||0
+2015-11-09 02:33:54.435121||measurement||ad||2015-11-09 02:33:48.456769@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:33:54.854197||measurement||ad||2015-11-09 02:33:48.456769@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:33:54.870531||measurement||loadtime||0:00:29.497113||1||0
+2015-11-09 02:34:03.457032||measurement||ad||2015-11-09 02:33:52.565778@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 02:34:03.821394||measurement||ad||2015-11-09 02:33:52.565778@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:34:03.827907||measurement||loadtime||0:00:36.129080||4||0
+2015-11-09 02:34:05.921601||measurement||ad||2015-11-09 02:34:05.568647@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:34:06.031751||measurement||ad||2015-11-09 02:34:05.568647@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:34:06.046933||measurement||loadtime||0:00:26.613157||0||1
+2015-11-09 02:34:12.528864||measurement||ad||2015-11-09 02:34:11.961445@|AncestryDNA™ Official@|ancestry.com/DNA@|Discover your genetic ethnicity  geographic origins with DNA!||5||1
+2015-11-09 02:34:12.738039||measurement||ad||2015-11-09 02:34:11.961445@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:34:13.292457||measurement||loadtime||0:00:26.295809||5||1
+2015-11-09 02:34:19.858188||measurement||ad||2015-11-09 02:34:19.649241@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:34:19.918833||measurement||ad||2015-11-09 02:34:19.649241@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:34:19.931651||measurement||loadtime||0:00:24.571973||3||1
+2015-11-09 02:34:27.420437||measurement||ad||2015-11-09 02:34:20.388247@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:34:27.769912||measurement||ad||2015-11-09 02:34:20.388247@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 02:34:27.775053||measurement||loadtime||0:00:31.517979||2||0
+2015-11-09 02:34:27.892493||measurement||ad||2015-11-09 02:34:21.488966@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||1||0
+2015-11-09 02:34:28.025952||measurement||ad||2015-11-09 02:34:21.488966@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:34:28.030550||measurement||loadtime||0:00:28.159298||1||0
+2015-11-09 02:34:32.609661||measurement||ad||2015-11-09 02:34:32.320020@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:34:32.708003||measurement||ad||2015-11-09 02:34:32.320020@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:34:32.751262||measurement||loadtime||0:00:21.703009||0||1
+2015-11-09 02:34:37.381421||measurement||ad||2015-11-09 02:34:30.683821@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||4||0
+2015-11-09 02:34:37.600782||measurement||ad||2015-11-09 02:34:30.683821@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:34:37.611838||measurement||loadtime||0:00:28.782887||4||0
+2015-11-09 02:34:47.338807||measurement||ad||2015-11-09 02:34:46.436788@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||5||1
+2015-11-09 02:34:47.474489||measurement||ad||2015-11-09 02:34:46.436788@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:34:47.553074||measurement||loadtime||0:00:29.259684||5||1
+2015-11-09 02:34:50.479569||measurement||ad||2015-11-09 02:34:49.046964@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:34:50.553698||measurement||ad||2015-11-09 02:34:49.046964@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:34:50.572293||measurement||loadtime||0:00:25.640116||3||1
+2015-11-09 02:35:04.538436||measurement||ad||2015-11-09 02:35:03.595034@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-09 02:35:04.659775||measurement||ad||2015-11-09 02:35:03.595034@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:35:04.681490||measurement||loadtime||0:00:26.929540||0||1
+2015-11-09 02:35:05.104702||measurement||ad||2015-11-09 02:34:58.189362@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:35:05.361756||measurement||ad||2015-11-09 02:34:58.189362@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:35:05.366886||measurement||loadtime||0:00:32.335438||1||0
+2015-11-09 02:35:14.084106||measurement||ad||2015-11-09 02:34:58.763812@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 02:35:14.641955||measurement||ad||2015-11-09 02:34:58.763812@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:35:14.647754||measurement||loadtime||0:00:41.872002||2||0
+2015-11-09 02:35:15.695289||measurement||ad||2015-11-09 02:35:15.291714@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||5||1
+2015-11-09 02:35:15.764705||measurement||ad||2015-11-09 02:35:15.291714@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:35:15.872485||measurement||loadtime||0:00:23.316522||5||1
+2015-11-09 02:35:16.050920||measurement||ad||2015-11-09 02:35:06.196132@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 02:35:16.750937||measurement||ad||2015-11-09 02:35:06.196132@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:35:16.760604||measurement||loadtime||0:00:34.148205||4||0
+2015-11-09 02:35:21.774814||measurement||ad||2015-11-09 02:35:21.069119@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:35:21.866746||measurement||ad||2015-11-09 02:35:21.069119@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:35:21.879536||measurement||loadtime||0:00:26.305740||3||1
+2015-11-09 02:35:39.742040||measurement||ad||2015-11-09 02:35:39.289779@|Best Wrinkle Creams 2015@|www.iskincarereviews.com@|Full reviews of anti-aging creams. The truth on what really works!||0||1
+2015-11-09 02:35:39.848086||measurement||ad||2015-11-09 02:35:39.289779@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:35:39.874583||measurement||loadtime||0:00:30.191907||0||1
+2015-11-09 02:35:40.528363||measurement||ad||2015-11-09 02:35:34.251242@|Apartments in Bangalore@|puravankara.com/Luxury_Apartments@|Purva Scarlet Off Kanakpura Road. Price Starting @4690 psft.Register!||1||0
+2015-11-09 02:35:40.756544||measurement||ad||2015-11-09 02:35:34.251242@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:35:40.760952||measurement||loadtime||0:00:30.392612||1||0
+2015-11-09 02:35:44.551291||measurement||ad||2015-11-09 02:35:44.274981@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:35:44.631544||measurement||ad||2015-11-09 02:35:44.274981@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||5||1
+2015-11-09 02:35:44.697643||measurement||loadtime||0:00:23.824613||5||1
+2015-11-09 02:35:48.761531||measurement||ad||2015-11-09 02:35:43.867465@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 02:35:48.847771||measurement||ad||2015-11-09 02:35:43.867465@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||4||0
+2015-11-09 02:35:48.851934||measurement||loadtime||0:00:27.090802||4||0
+2015-11-09 02:35:53.287671||measurement||ad||2015-11-09 02:35:52.872650@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:35:53.351085||measurement||ad||2015-11-09 02:35:52.872650@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:35:53.383969||measurement||loadtime||0:00:26.502642||3||1
+2015-11-09 02:35:58.233325||measurement||ad||2015-11-09 02:35:50.067831@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 02:35:59.115081||measurement||ad||2015-11-09 02:35:50.067831@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:35:59.124909||measurement||loadtime||0:00:39.476297||2||0
+2015-11-09 02:36:11.055024||measurement||ad||2015-11-09 02:36:10.821099@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||0||1
+2015-11-09 02:36:11.332490||measurement||ad||2015-11-09 02:36:10.821099@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:36:11.363456||measurement||loadtime||0:00:26.488209||0||1
+2015-11-09 02:36:14.867970||measurement||ad||2015-11-09 02:36:14.552450@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||5||1
+2015-11-09 02:36:15.029075||measurement||ad||2015-11-09 02:36:14.552450@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||5||1
+2015-11-09 02:36:15.045367||measurement||loadtime||0:00:25.345909||5||1
+2015-11-09 02:36:16.404027||measurement||ad||2015-11-09 02:36:09.364164@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:36:16.553351||measurement||ad||2015-11-09 02:36:09.364164@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:36:16.558134||measurement||loadtime||0:00:30.796563||1||0
+2015-11-09 02:36:21.965881||measurement||ad||2015-11-09 02:36:15.458950@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||4||0
+2015-11-09 02:36:22.077297||measurement||ad||2015-11-09 02:36:15.458950@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:36:22.086209||measurement||loadtime||0:00:28.232667||4||0
+2015-11-09 02:36:23.377528||measurement||ad||2015-11-09 02:36:22.797998@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 02:36:23.454473||measurement||ad||2015-11-09 02:36:22.797998@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 02:36:23.474918||measurement||loadtime||0:00:25.090364||3||1
+2015-11-09 02:36:23.475240||event||progress-marker||measurement-end||3||1
+2015-11-09 02:36:41.344291||measurement||ad||2015-11-09 02:36:41.083299@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:36:41.437524||measurement||ad||2015-11-09 02:36:41.083299@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:36:41.448553||measurement||loadtime||0:00:25.084251||0||1
+2015-11-09 02:36:41.448806||event||progress-marker||measurement-end||0||1
+2015-11-09 02:36:43.472538||measurement||ad||2015-11-09 02:36:34.913674@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:36:43.591396||measurement||ad||2015-11-09 02:36:34.913674@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||2||0
+2015-11-09 02:36:43.597851||measurement||loadtime||0:00:39.472323||2||0
+2015-11-09 02:36:46.295478||measurement||ad||2015-11-09 02:36:46.007278@|Auto Insurance Quotes@|autoinsurancequotes.com@|Get 10 Auto Insurance Quotes in Just Minutes - Start Now!||5||1
+2015-11-09 02:36:46.412610||measurement||ad||2015-11-09 02:36:46.007278@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 02:36:46.430494||measurement||loadtime||0:00:26.383609||5||1
+2015-11-09 02:36:46.430744||event||progress-marker||measurement-end||5||1
+2015-11-09 02:36:51.014311||measurement||ad||2015-11-09 02:36:46.529005@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:36:51.283029||measurement||ad||2015-11-09 02:36:46.529005@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:36:51.287610||measurement||loadtime||0:00:29.728550||1||0
+2015-11-09 02:36:51.454433||measurement||ad||2015-11-09 02:36:48.008660@|Apartments in Bangalore@|puravankara.com/Luxury_Apartments@|Purva Scarlet Off Kanakpura Road. Price Starting @4690 psft.Register!||4||0
+2015-11-09 02:36:51.583485||measurement||ad||2015-11-09 02:36:48.008660@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 02:36:51.586345||measurement||loadtime||0:00:24.499006||4||0
+2015-11-09 02:37:10.750124||measurement||ad||2015-11-09 02:37:08.411593@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 02:37:10.806482||measurement||ad||2015-11-09 02:37:08.411593@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:37:10.809815||measurement||loadtime||0:00:22.210915||2||0
+2015-11-09 02:37:13.834119||measurement||ad||2015-11-09 02:37:11.955002@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 02:37:14.001076||measurement||ad||2015-11-09 02:37:11.955002@|Design A Room Online@|www.bhg.com/DesignRoom@|Virtual Room Builder Tool. Better Homes  Gardens®. Start Now!||4||0
+2015-11-09 02:37:14.004321||measurement||loadtime||0:00:17.417518||4||0
+2015-11-09 02:37:14.004661||event||progress-marker||measurement-end||4||0
+2015-11-09 02:37:18.369018||measurement||ad||2015-11-09 02:37:16.013246@|Apartments in Bangalore@|puravankara.com/Luxury_Apartments@|Purva Scarlet Off Kanakpura Road. Price Starting @4690 psft.Register!||1||0
+2015-11-09 02:37:18.425043||measurement||ad||2015-11-09 02:37:16.013246@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:37:18.428038||measurement||loadtime||0:00:22.139534||1||0
+2015-11-09 02:37:18.428291||event||progress-marker||measurement-end||1||0
+2015-11-09 02:37:32.910311||measurement||ad||2015-11-09 02:37:31.171867@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 02:37:32.969163||measurement||ad||2015-11-09 02:37:31.171867@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 02:37:32.972222||measurement||loadtime||0:00:17.161877||2||0
+2015-11-09 02:37:56.201376||measurement||ad||2015-11-09 02:37:54.046114@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||2||0
+2015-11-09 02:37:56.351714||measurement||ad||2015-11-09 02:37:54.046114@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 02:37:56.386397||measurement||loadtime||0:00:18.412611||2||0
+2015-11-09 02:37:56.386701||event||progress-marker||measurement-end||2||0
+2015-11-09 02:37:57.007383||meta||block_id end||0
+2015-11-09 02:37:57.015034||meta||block_id start||1
+2015-11-09 02:37:57.015145||meta||assignment||3@|2@|1@|5@|4@|0
+2015-11-09 02:38:00.716781||event||progress-marker||training-start||1||0
+2015-11-09 02:38:00.892357||event||progress-marker||training-start||2||0
+2015-11-09 02:38:00.913985||event||progress-marker||training-start||3||0
+2015-11-09 02:38:03.323120||event||progress-marker||training-start||4||1
+2015-11-09 02:38:03.394880||event||progress-marker||training-start||5||1
+2015-11-09 02:38:04.335692||event||progress-marker||training-start||0||1
+2015-11-09 02:38:05.896746||treatment||google search||Buy BMW||1||0
+2015-11-09 02:38:05.929556||treatment||google search||Buy BMW||3||0
+2015-11-09 02:38:07.588497||treatment||google search||Buy BMW||2||0
+2015-11-09 02:38:07.963380||error||visiting||google searchresults||1||0
+2015-11-09 02:38:08.130524||error||visiting||google searchresults||3||0
+2015-11-09 02:38:09.010957||error||visiting||google searchresults||2||0
+2015-11-09 02:38:09.816312||treatment||google search||Buy BMW||5||1
+2015-11-09 02:38:09.858235||treatment||google search||Buy BMW||0||1
+2015-11-09 02:38:09.895678||treatment||google search||Buy BMW||4||1
+2015-11-09 02:38:20.758469||error||visiting||google searchresults||0||1
+2015-11-09 02:38:20.812973||error||visiting||google searchresults||4||1
+2015-11-09 02:38:20.819990||error||visiting||google searchresults||5||1
+2015-11-09 02:38:28.299460||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 02:38:30.566319||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 02:38:30.759881||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 02:38:35.397260||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 02:38:35.899951||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||1
+2015-11-09 02:38:38.123496||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 02:38:45.682463||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 02:38:51.163555||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 02:38:51.685051||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 02:38:51.936369||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 02:38:51.973468||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||1
+2015-11-09 02:38:52.946673||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 02:38:55.716906||error||visiting||google searchresults||2||0
+2015-11-09 02:39:01.190966||error||visiting||google searchresults||3||0
+2015-11-09 02:39:01.963255||error||visiting||google searchresults||1||0
+2015-11-09 02:39:10.250899||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COn9pYHrgskCFZAkgQodbqcDvw||2||0
+2015-11-09 02:39:11.794490||error||visiting||google searchresults||5||1
+2015-11-09 02:39:12.024505||error||visiting||google searchresults||4||1
+2015-11-09 02:39:13.000199||error||visiting||google searchresults||0||1
+2015-11-09 02:39:15.581143||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COSn9IPrgskCFdgagQodCK4AMg||3||0
+2015-11-09 02:39:16.461017||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CILqpYTrgskCFdgTgQodJKoCGw||1||0
+2015-11-09 02:39:21.883762||treatment||google search||BMW dealer||2||0
+2015-11-09 02:39:22.754147||error||visiting||google searchresults||2||0
+2015-11-09 02:39:25.020534||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CMGG_ojrgskCFYY9gQodPk0Okw||5||1
+2015-11-09 02:39:26.303388||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJDmyYnrgskCFUkvgQod1qsDVQ||0||1
+2015-11-09 02:39:26.439680||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COeIi4nrgskCFVUlgQodJdoD7Q||4||1
+2015-11-09 02:39:27.406298||treatment||google search||BMW dealer||3||0
+2015-11-09 02:39:27.997795||error||visiting||google searchresults||3||0
+2015-11-09 02:39:28.667147||treatment||google search||BMW dealer||1||0
+2015-11-09 02:39:29.311796||error||visiting||google searchresults||1||0
+2015-11-09 02:39:38.900250||treatment||google search||BMW dealer||5||1
+2015-11-09 02:39:40.339799||treatment||google search||BMW dealer||0||1
+2015-11-09 02:39:41.312888||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMLclY7rgskCFdgUgQod7XIEQg||2||0
+2015-11-09 02:39:41.373462||treatment||google search||BMW dealer||4||1
+2015-11-09 02:39:45.779529||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJvCq5HrgskCFRMjgQodg40D8w||1||0
+2015-11-09 02:39:47.494869||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CL_O3pDrgskCFdgTgQodJKoCGw||3||0
+2015-11-09 02:39:50.533904||error||visiting||google searchresults||5||1
+2015-11-09 02:39:51.742018||error||visiting||google searchresults||0||1
+2015-11-09 02:39:51.989128||error||visiting||google searchresults||4||1
+2015-11-09 02:39:56.455288||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIDZgpfrgskCFZQ6gQodgPIGrA||2||0
+2015-11-09 02:40:03.814585||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLe7k5nrgskCFdgGgQodtJYOGQ||1||0
+2015-11-09 02:40:03.909054||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLqG_JnrgskCFdgIgQodts4DTw||3||0
+2015-11-09 02:40:06.509765||error||visiting||google searchresults||2||0
+2015-11-09 02:40:08.503662||treatment||visit page||http://www.carsense.com/?gclid=CNzkhZzrgskCFVI7gQodrjYBDQ||0||1
+2015-11-09 02:40:09.142669||treatment||visit page||http://www.carsense.com/?gclid=CKaBkZzrgskCFcUkgQod5NkDfg||4||1
+2015-11-09 02:40:10.516904||treatment||visit page||http://www.carsense.com/?gclid=CIf7tpvrgskCFVQkgQodfgMKbg||5||1
+2015-11-09 02:40:13.848795||error||visiting||google searchresults||1||0
+2015-11-09 02:40:13.945163||error||visiting||google searchresults||3||0
+2015-11-09 02:40:22.697734||treatment||visit page||http://www.carsense.com/?gclid=CKbtiaTrgskCFdUvgQodVzINNw||0||1
+2015-11-09 02:40:23.309735||treatment||visit page||http://www.carsense.com/?gclid=CKW7qKTrgskCFdgNgQodcuEFZg||4||1
+2015-11-09 02:40:24.252129||treatment||visit page||http://www.carsense.com/?gclid=CMuzhKPrgskCFdgQgQodo1cHHw||2||0
+2015-11-09 02:40:28.699662||treatment||visit page||http://www.carsense.com/?gclid=CN6o_aTrgskCFdcYgQodjHIJmg||5||1
+2015-11-09 02:40:32.492988||treatment||visit page||http://www.carsense.com/?gclid=CM2tzKbrgskCFVMvgQodTycJrA||1||0
+2015-11-09 02:40:32.621235||treatment||visit page||http://www.carsense.com/?gclid=CLiBzKbrgskCFdgPgQodEnsOlw||3||0
+2015-11-09 02:40:35.829384||treatment||google search||BMW||2||0
+2015-11-09 02:40:36.732626||error||visiting||google searchresults||2||0
+2015-11-09 02:40:42.729407||error||visiting||google searchresults||0||1
+2015-11-09 02:40:43.373021||error||visiting||google searchresults||4||1
+2015-11-09 02:40:44.224710||treatment||google search||BMW||1||0
+2015-11-09 02:40:44.423402||treatment||google search||BMW||3||0
+2015-11-09 02:40:45.053010||error||visiting||google searchresults||1||0
+2015-11-09 02:40:45.353422||error||visiting||google searchresults||3||0
+2015-11-09 02:40:48.790864||error||visiting||google searchresults||5||1
+2015-11-09 02:40:55.206157||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 02:41:00.219252||treatment||visit page||http://www.usautomart.com/?gclid=CNiyp7TrgskCFYE8gQodHBICvw||0||1
+2015-11-09 02:41:02.292804||treatment||visit page||http://www.usautomart.com/?gclid=CNnHz7TrgskCFUEvgQodvQgC1w||4||1
+2015-11-09 02:41:02.683253||treatment||visit page||http://www.usautomart.com/?gclid=CKeNobfrgskCFYI8gQodSNAOFA||5||1
+2015-11-09 02:41:05.570740||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 02:41:07.270341||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 02:41:11.030634||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 02:41:12.205522||treatment||google search||BMW||0||1
+2015-11-09 02:41:14.619271||treatment||google search||BMW||4||1
+2015-11-09 02:41:14.989638||treatment||google search||BMW||5||1
+2015-11-09 02:41:21.056891||error||visiting||google searchresults||2||0
+2015-11-09 02:41:21.379118||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 02:41:23.391047||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 02:41:23.455609||error||visiting||google searchresults||0||1
+2015-11-09 02:41:25.668285||error||visiting||google searchresults||4||1
+2015-11-09 02:41:26.050209||error||visiting||google searchresults||5||1
+2015-11-09 02:41:31.415102||error||visiting||google searchresults||1||0
+2015-11-09 02:41:33.471771||error||visiting||google searchresults||3||0
+2015-11-09 02:41:40.192523||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 02:41:50.193687||event||progress-marker||training-end||2||0
+2015-11-09 02:41:52.443359||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 02:41:52.547668||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 02:41:54.512926||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 02:41:55.200069||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 02:41:55.248688||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 02:42:02.548745||event||progress-marker||training-end||1||0
+2015-11-09 02:42:04.513885||event||progress-marker||training-end||3||0
+2015-11-09 02:42:08.403122||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 02:42:08.756613||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 02:42:11.412506||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 02:42:28.495576||error||visiting||google searchresults||5||1
+2015-11-09 02:42:28.828282||error||visiting||google searchresults||0||1
+2015-11-09 02:42:31.545587||error||visiting||google searchresults||4||1
+2015-11-09 02:42:42.872181||treatment||visit page||http://dealers.car.com/deals/bmw?ukwid=466dc019-5dbf-47ed-8ba3-a7ee76480692&udv=c&gclid=CNaV3-brgskCFZQdgQod_WgHpw||5||1
+2015-11-09 02:42:45.874996||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||1
+2015-11-09 02:42:45.947752||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 02:42:52.873206||event||progress-marker||training-end||5||1
+2015-11-09 02:42:55.876633||event||progress-marker||training-end||4||1
+2015-11-09 02:42:55.948574||event||progress-marker||training-end||0||1
+2015-11-09 02:42:57.590744||event||progress-marker||measurement-start||1||0
+2015-11-09 02:42:57.879098||event||progress-marker||measurement-start||5||1
+2015-11-09 02:42:59.555106||event||progress-marker||measurement-start||3||0
+2015-11-09 02:43:00.250569||event||progress-marker||measurement-start||2||0
+2015-11-09 02:43:00.881463||event||progress-marker||measurement-start||4||1
+2015-11-09 02:43:00.954365||event||progress-marker||measurement-start||0||1
+2015-11-09 02:43:30.858092||measurement||ad||2015-11-09 02:43:29.956985@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:43:31.007762||measurement||ad||2015-11-09 02:43:29.956985@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:43:31.023688||measurement||loadtime||0:00:28.143627||5||1
+2015-11-09 02:43:41.368426||measurement||ad||2015-11-09 02:43:40.755390@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||4||1
+2015-11-09 02:43:41.565197||measurement||ad||2015-11-09 02:43:40.755390@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||4||1
+2015-11-09 02:43:41.581281||measurement||loadtime||0:00:35.698300||4||1
+2015-11-09 02:43:43.387988||measurement||ad||2015-11-09 02:43:42.769307@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:43:43.482257||measurement||ad||2015-11-09 02:43:42.769307@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:43:43.494735||measurement||loadtime||0:00:37.539881||0||1
+2015-11-09 02:43:44.379776||measurement||ad||2015-11-09 02:43:35.467114@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:43:45.700665||measurement||ad||2015-11-09 02:43:35.467114@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:43:45.838827||measurement||loadtime||0:00:40.587574||2||0
+2015-11-09 02:43:53.127871||measurement||ad||2015-11-09 02:43:38.356886@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:43:53.957313||measurement||ad||2015-11-09 02:43:38.356886@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:43:53.964965||measurement||loadtime||0:00:49.409109||3||0
+2015-11-09 02:44:01.758465||measurement||ad||2015-11-09 02:43:38.473011@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:44:02.946488||measurement||ad||2015-11-09 02:43:38.473011@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 02:44:02.951240||measurement||loadtime||0:01:00.358888||1||0
+2015-11-09 02:44:10.173799||measurement||ad||2015-11-09 02:44:06.828942@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:44:10.451309||measurement||ad||2015-11-09 02:44:06.828942@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:44:10.464651||measurement||loadtime||0:00:34.440000||5||1
+2015-11-09 02:44:15.313747||measurement||ad||2015-11-09 02:44:15.072169@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||1
+2015-11-09 02:44:15.515344||measurement||ad||2015-11-09 02:44:15.072169@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||4||1
+2015-11-09 02:44:15.574316||measurement||loadtime||0:00:28.992102||4||1
+2015-11-09 02:44:24.761007||measurement||ad||2015-11-09 02:44:16.952141@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:44:25.577387||measurement||ad||2015-11-09 02:44:16.952141@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:44:25.591303||measurement||loadtime||0:00:34.751849||2||0
+2015-11-09 02:44:27.122477||measurement||ad||2015-11-09 02:44:26.324400@|Senior Citizen Apartments@|lowerprices.us/Senior-Apartments@|Senior Apartments - Up To 35% Off Find Deals, Bargains and Discounts||0||1
+2015-11-09 02:44:28.041378||measurement||ad||2015-11-09 02:44:26.324400@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:44:28.203202||measurement||loadtime||0:00:39.707975||0||1
+2015-11-09 02:44:45.666264||measurement||ad||2015-11-09 02:44:45.114352@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:44:45.854620||measurement||ad||2015-11-09 02:44:45.114352@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:44:45.916188||measurement||loadtime||0:00:30.450919||5||1
+2015-11-09 02:44:47.632523||measurement||ad||2015-11-09 02:44:31.596217@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:44:47.778561||measurement||ad||2015-11-09 02:44:47.431778@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||4||1
+2015-11-09 02:44:48.034010||measurement||ad||2015-11-09 02:44:47.431778@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||4||1
+2015-11-09 02:44:48.166660||measurement||loadtime||0:00:27.590950||4||1
+2015-11-09 02:44:48.305112||measurement||ad||2015-11-09 02:44:31.596217@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||3||0
+2015-11-09 02:44:48.400258||measurement||loadtime||0:00:49.434057||3||0
+2015-11-09 02:44:52.543913||measurement||ad||2015-11-09 02:44:41.864659@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:44:53.147704||measurement||ad||2015-11-09 02:44:41.864659@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 02:44:53.399301||measurement||loadtime||0:00:45.447291||1||0
+2015-11-09 02:45:03.913699||measurement||ad||2015-11-09 02:45:03.339677@|Best Wrinkle Creams 2015@|www.iskincarereviews.com@|Full reviews of anti-aging creams. The truth on what really works!||0||1
+2015-11-09 02:45:04.222344||measurement||ad||2015-11-09 02:45:03.339677@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:45:04.250124||measurement||loadtime||0:00:31.046294||0||1
+2015-11-09 02:45:07.752059||measurement||ad||2015-11-09 02:45:01.265247@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:45:07.963997||measurement||ad||2015-11-09 02:45:01.265247@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:45:07.970630||measurement||loadtime||0:00:37.378677||2||0
+2015-11-09 02:45:26.383310||measurement||ad||2015-11-09 02:45:25.543784@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:45:26.828922||measurement||ad||2015-11-09 02:45:25.543784@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:45:26.842912||measurement||loadtime||0:00:35.925665||5||1
+2015-11-09 02:45:31.582541||measurement||ad||2015-11-09 02:45:30.688859@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||1
+2015-11-09 02:45:31.783673||measurement||ad||2015-11-09 02:45:30.688859@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||1
+2015-11-09 02:45:31.864401||measurement||loadtime||0:00:38.695990||4||1
+2015-11-09 02:45:36.178659||measurement||ad||2015-11-09 02:45:26.579139@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:45:36.815718||measurement||ad||2015-11-09 02:45:26.579139@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:45:36.820467||measurement||loadtime||0:00:38.420062||1||0
+2015-11-09 02:45:39.490232||measurement||ad||2015-11-09 02:45:38.845931@|Apartments in Bangalore@|puravankara.com/Luxury_Apartments@|Purva Scarlet Off Kanakpura Road. Price Starting @4690 psft.Register!||0||1
+2015-11-09 02:45:40.005374||measurement||ad||2015-11-09 02:45:38.845931@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:45:40.390975||measurement||loadtime||0:00:31.139333||0||1
+2015-11-09 02:45:42.051843||measurement||ad||2015-11-09 02:45:33.320752@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:45:42.351437||measurement||ad||2015-11-09 02:45:33.320752@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:45:42.356363||measurement||loadtime||0:00:29.384191||2||0
+2015-11-09 02:45:46.845540||measurement||ad||2015-11-09 02:45:26.361938@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:45:48.241634||measurement||ad||2015-11-09 02:45:26.361938@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:45:48.248074||measurement||loadtime||0:00:54.847089||3||0
+2015-11-09 02:46:05.800779||measurement||ad||2015-11-09 02:46:05.122713@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||4||1
+2015-11-09 02:46:06.059638||measurement||ad||2015-11-09 02:46:05.122713@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||1
+2015-11-09 02:46:06.097349||measurement||loadtime||0:00:29.232439||4||1
+2015-11-09 02:46:07.423819||measurement||ad||2015-11-09 02:46:06.250937@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:46:07.564137||measurement||ad||2015-11-09 02:46:06.250937@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:46:07.625504||measurement||loadtime||0:00:35.781002||5||1
+2015-11-09 02:46:13.743997||measurement||ad||2015-11-09 02:46:12.926739@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||0||1
+2015-11-09 02:46:13.869574||measurement||ad||2015-11-09 02:46:12.926739@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:46:13.888143||measurement||loadtime||0:00:28.496306||0||1
+2015-11-09 02:46:15.770583||measurement||ad||2015-11-09 02:46:10.683441@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:46:15.955540||measurement||ad||2015-11-09 02:46:10.683441@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:46:15.965499||measurement||loadtime||0:00:28.607855||2||0
+2015-11-09 02:46:21.177108||measurement||ad||2015-11-09 02:46:13.169784@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:46:21.404592||measurement||ad||2015-11-09 02:46:13.169784@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:46:21.411230||measurement||loadtime||0:00:39.589390||1||0
+2015-11-09 02:46:28.792740||measurement||ad||2015-11-09 02:46:19.877949@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:46:29.634351||measurement||ad||2015-11-09 02:46:19.877949@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 02:46:29.641092||measurement||loadtime||0:00:36.391844||3||0
+2015-11-09 02:46:40.542235||measurement||ad||2015-11-09 02:46:40.184818@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:46:40.688103||measurement||ad||2015-11-09 02:46:40.184818@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:46:40.722254||measurement||loadtime||0:00:28.096038||5||1
+2015-11-09 02:46:44.320937||measurement||ad||2015-11-09 02:46:43.394433@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||1
+2015-11-09 02:46:44.512741||measurement||ad||2015-11-09 02:46:43.394433@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||1
+2015-11-09 02:46:44.523122||measurement||loadtime||0:00:33.425255||4||1
+2015-11-09 02:46:50.208352||measurement||ad||2015-11-09 02:46:43.331728@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:46:50.352258||measurement||ad||2015-11-09 02:46:43.331728@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:46:50.441357||measurement||loadtime||0:00:29.475139||2||0
+2015-11-09 02:46:52.042022||measurement||ad||2015-11-09 02:46:51.582200@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:46:52.181504||measurement||ad||2015-11-09 02:46:51.582200@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:46:52.194315||measurement||loadtime||0:00:33.305261||0||1
+2015-11-09 02:47:11.084062||measurement||ad||2015-11-09 02:47:00.579392@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:47:11.708334||measurement||ad||2015-11-09 02:47:00.579392@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||0
+2015-11-09 02:47:11.713840||measurement||loadtime||0:00:37.072094||3||0
+2015-11-09 02:47:12.711848||measurement||ad||2015-11-09 02:46:54.966913@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:47:13.087325||measurement||ad||2015-11-09 02:46:54.966913@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 02:47:13.096649||measurement||loadtime||0:00:46.684642||1||0
+2015-11-09 02:47:15.434191||measurement||ad||2015-11-09 02:47:14.614963@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||4||1
+2015-11-09 02:47:15.573478||measurement||ad||2015-11-09 02:47:14.614963@|AloeCure For Acid Reflux@|startaloecure.com/Acid-Reflux@|(1) Little Secret to Stopping Acid Reflux for Good - Read More.||4||1
+2015-11-09 02:47:15.597974||measurement||loadtime||0:00:26.074268||4||1
+2015-11-09 02:47:18.816266||measurement||ad||2015-11-09 02:47:17.399376@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:47:19.473264||measurement||ad||2015-11-09 02:47:17.399376@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:47:19.604524||measurement||loadtime||0:00:33.881502||5||1
+2015-11-09 02:47:21.528895||measurement||ad||2015-11-09 02:47:15.900736@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:47:21.859163||measurement||ad||2015-11-09 02:47:15.900736@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:47:21.872874||measurement||loadtime||0:00:26.429686||2||0
+2015-11-09 02:47:27.585382||measurement||ad||2015-11-09 02:47:25.752095@|New Hoverboards: 80% Off@|dealplanet.com/hoverboards@|Huge Hoverboard Sale. Save 80-90%. Quantities Limited. 1 Per Customer.||0||1
+2015-11-09 02:47:28.322169||measurement||ad||2015-11-09 02:47:25.752095@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:47:28.495560||measurement||loadtime||0:00:31.300464||0||1
+2015-11-09 02:47:54.404138||measurement||ad||2015-11-09 02:47:53.909056@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:47:54.658974||measurement||ad||2015-11-09 02:47:52.966163@|Penn. Divorce Online $149@|pennsylvania.divorcewriter.com@|Divorce Paperwork in Minutes. Fast, Lawyer-Free, 100% Guarantee.||4||1
+2015-11-09 02:47:54.779046||measurement||ad||2015-11-09 02:47:53.909056@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:47:54.829976||measurement||ad||2015-11-09 02:47:52.966163@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||4||1
+2015-11-09 02:47:54.844831||measurement||loadtime||0:00:34.245790||4||1
+2015-11-09 02:47:54.879688||measurement||loadtime||0:00:30.273751||5||1
+2015-11-09 02:47:56.136637||measurement||ad||2015-11-09 02:47:50.963136@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:47:56.364973||measurement||ad||2015-11-09 02:47:50.963136@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:47:56.380373||measurement||loadtime||0:00:29.504874||2||0
+2015-11-09 02:48:01.344455||measurement||ad||2015-11-09 02:48:00.459555@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||0||1
+2015-11-09 02:48:01.647212||measurement||ad||2015-11-09 02:48:00.459555@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:48:01.661562||measurement||loadtime||0:00:28.164610||0||1
+2015-11-09 02:48:03.565492||measurement||ad||2015-11-09 02:47:51.832738@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:48:03.753848||measurement||ad||2015-11-09 02:47:52.448387@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:48:04.073014||measurement||ad||2015-11-09 02:47:51.832738@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:48:04.078681||measurement||loadtime||0:00:47.363962||3||0
+2015-11-09 02:48:04.450955||measurement||ad||2015-11-09 02:47:52.448387@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:48:04.690438||measurement||loadtime||0:00:46.592970||1||0
+2015-11-09 02:48:28.364396||measurement||ad||2015-11-09 02:48:21.732921@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:48:28.636028||measurement||ad||2015-11-09 02:48:21.732921@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:48:28.648338||measurement||loadtime||0:00:27.265889||2||0
+2015-11-09 02:48:33.820665||measurement||ad||2015-11-09 02:48:33.245934@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 02:48:33.996047||measurement||ad||2015-11-09 02:48:33.245934@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||1
+2015-11-09 02:48:34.024452||measurement||loadtime||0:00:34.179010||4||1
+2015-11-09 02:48:42.462809||measurement||ad||2015-11-09 02:48:41.625564@|The Name of Your Angel@|guardian-angel-reading.com/Name@|Find out the name of your Angel and what he can do to help You!||0||1
+2015-11-09 02:48:42.678896||measurement||ad||2015-11-09 02:48:41.625564@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:48:42.722006||measurement||loadtime||0:00:36.058735||0||1
+2015-11-09 02:48:43.798650||measurement||ad||2015-11-09 02:48:37.017778@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:48:44.017925||measurement||ad||2015-11-09 02:48:37.017778@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||3||0
+2015-11-09 02:48:44.023870||measurement||loadtime||0:00:34.944381||3||0
+2015-11-09 02:48:48.676580||measurement||ad||2015-11-09 02:48:41.409044@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:48:48.812070||measurement||ad||2015-11-09 02:48:41.409044@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:48:48.818709||measurement||loadtime||0:00:39.127675||1||0
+2015-11-09 02:48:57.271988||measurement||ad||2015-11-09 02:48:56.419975@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:48:57.506789||measurement||ad||2015-11-09 02:48:56.419975@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:48:57.544682||measurement||loadtime||0:00:57.663725||5||1
+2015-11-09 02:48:58.015862||measurement||ad||2015-11-09 02:48:52.166558@|Textile Industry Research@|sourcingjournalonline.com/@|Sourcing Journal Online Save 20% on an Annual Subscription||2||0
+2015-11-09 02:48:58.211077||measurement||ad||2015-11-09 02:48:52.166558@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 02:48:58.215881||measurement||loadtime||0:00:24.566812||2||0
+2015-11-09 02:48:58.216191||event||progress-marker||measurement-end||2||0
+2015-11-09 02:49:03.372318||measurement||ad||2015-11-09 02:49:02.789236@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||4||1
+2015-11-09 02:49:03.507664||measurement||ad||2015-11-09 02:49:02.789236@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||1
+2015-11-09 02:49:03.528813||measurement||loadtime||0:00:24.503464||4||1
+2015-11-09 02:49:03.529248||event||progress-marker||measurement-end||4||1
+2015-11-09 02:49:16.163087||measurement||ad||2015-11-09 02:49:11.832116@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:49:16.309135||measurement||ad||2015-11-09 02:49:11.832116@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:49:16.314214||measurement||loadtime||0:00:27.288680||3||0
+2015-11-09 02:49:16.355746||measurement||ad||2015-11-09 02:49:16.004009@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||0||1
+2015-11-09 02:49:16.456033||measurement||ad||2015-11-09 02:49:16.004009@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:49:16.469458||measurement||loadtime||0:00:28.746066||0||1
+2015-11-09 02:49:16.469702||event||progress-marker||measurement-end||0||1
+2015-11-09 02:49:23.110120||measurement||ad||2015-11-09 02:49:19.186364@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:49:23.187290||measurement||ad||2015-11-09 02:49:19.186364@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||1||0
+2015-11-09 02:49:23.190407||measurement||loadtime||0:00:29.370889||1||0
+2015-11-09 02:49:24.821145||measurement||ad||2015-11-09 02:49:24.661338@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 02:49:24.888739||measurement||ad||2015-11-09 02:49:24.661338@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 02:49:24.898509||measurement||loadtime||0:00:22.352855||5||1
+2015-11-09 02:49:24.899211||event||progress-marker||measurement-end||5||1
+2015-11-09 02:49:40.424601||measurement||ad||2015-11-09 02:49:37.128238@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:49:40.510649||measurement||ad||2015-11-09 02:49:37.128238@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||0
+2015-11-09 02:49:40.514832||measurement||loadtime||0:00:19.198965||3||0
+2015-11-09 02:49:48.894974||measurement||ad||2015-11-09 02:49:45.748087@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 02:49:48.972158||measurement||ad||2015-11-09 02:49:45.748087@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:49:48.976043||measurement||loadtime||0:00:20.784828||1||0
+2015-11-09 02:50:06.184956||measurement||ad||2015-11-09 02:50:03.523825@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:50:06.269427||measurement||ad||2015-11-09 02:50:03.523825@|AncestryDNA Official Site@|ancestry.com/DNA@|One Simple DNA Test. A World of Discoveries. Find Your Answers Now!||3||0
+2015-11-09 02:50:06.272291||measurement||loadtime||0:00:20.755959||3||0
+2015-11-09 02:50:06.272492||event||progress-marker||measurement-end||3||0
+2015-11-09 02:50:12.727957||measurement||ad||2015-11-09 02:50:10.949867@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 02:50:12.782777||measurement||ad||2015-11-09 02:50:10.949867@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 02:50:12.785726||measurement||loadtime||0:00:18.809220||1||0
+2015-11-09 02:50:12.785932||event||progress-marker||measurement-end||1||0
+2015-11-09 02:50:13.344711||meta||block_id end||1
+2015-11-09 02:50:13.347818||meta||block_id start||2
+2015-11-09 02:50:13.347939||meta||assignment||3@|2@|5@|0@|4@|1
+2015-11-09 02:50:16.902416||event||progress-marker||training-start||5||0
+2015-11-09 02:50:17.159247||event||progress-marker||training-start||3||0
+2015-11-09 02:50:17.188535||event||progress-marker||training-start||2||0
+2015-11-09 02:50:20.087482||event||progress-marker||training-start||0||1
+2015-11-09 02:50:20.186218||event||progress-marker||training-start||4||1
+2015-11-09 02:50:20.941540||event||progress-marker||training-start||1||1
+2015-11-09 02:50:21.988826||treatment||google search||Buy BMW||3||0
+2015-11-09 02:50:22.577292||treatment||google search||Buy BMW||5||0
+2015-11-09 02:50:22.682360||treatment||google search||Buy BMW||2||0
+2015-11-09 02:50:23.706479||error||visiting||google searchresults||3||0
+2015-11-09 02:50:24.447465||error||visiting||google searchresults||5||0
+2015-11-09 02:50:24.521173||error||visiting||google searchresults||2||0
+2015-11-09 02:50:25.779869||treatment||google search||Buy BMW||0||1
+2015-11-09 02:50:25.866763||treatment||google search||Buy BMW||4||1
+2015-11-09 02:50:26.090915||treatment||google search||Buy BMW||1||1
+2015-11-09 02:50:36.757936||error||visiting||google searchresults||4||1
+2015-11-09 02:50:36.850070||error||visiting||google searchresults||0||1
+2015-11-09 02:50:36.994282||error||visiting||google searchresults||1||1
+2015-11-09 02:50:43.598635||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 02:50:45.802010||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 02:50:49.292451||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 02:50:51.231695||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 02:50:51.313121||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 02:50:53.424191||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||1
+2015-11-09 02:50:58.740545||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 02:51:06.238494||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 02:51:07.008436||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 02:51:07.143032||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 02:51:08.787279||error||visiting||google searchresults||2||0
+2015-11-09 02:51:09.320387||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||1
+2015-11-09 02:51:09.686884||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 02:51:17.176827||error||visiting||google searchresults||5||0
+2015-11-09 02:51:19.764460||error||visiting||google searchresults||3||0
+2015-11-09 02:51:23.250660||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJv07N7tgskCFdcYgQodr0oJqg||2||0
+2015-11-09 02:51:26.296227||error||visiting||google searchresults||1||1
+2015-11-09 02:51:27.088279||error||visiting||google searchresults||0||1
+2015-11-09 02:51:29.415556||error||visiting||google searchresults||4||1
+2015-11-09 02:51:31.387787||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLW17eLtgskCFdc9gQodIHYKDg||5||0
+2015-11-09 02:51:34.236466||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLCKi-TtgskCFVA6gQodiFIFoQ||3||0
+2015-11-09 02:51:34.886497||treatment||google search||BMW dealer||2||0
+2015-11-09 02:51:35.521264||error||visiting||google searchresults||2||0
+2015-11-09 02:51:40.336897||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CNrTmuftgskCFdQ2gQodFwwNcw||1||1
+2015-11-09 02:51:40.377152||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJ3LzeftgskCFZM2gQodqtgP5w||0||1
+2015-11-09 02:51:42.993186||treatment||google search||BMW dealer||5||0
+2015-11-09 02:51:43.549698||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CPfN2OjtgskCFU82gQodctkLuw||4||1
+2015-11-09 02:51:43.752410||error||visiting||google searchresults||5||0
+2015-11-09 02:51:45.870016||treatment||google search||BMW dealer||3||0
+2015-11-09 02:51:46.443880||error||visiting||google searchresults||3||0
+2015-11-09 02:51:53.069772||treatment||google search||BMW dealer||0||1
+2015-11-09 02:51:53.126533||treatment||google search||BMW dealer||1||1
+2015-11-09 02:51:54.521175||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CO-iy-vtgskCFVY9gQodhJwOrg||2||0
+2015-11-09 02:51:56.083383||treatment||google search||BMW dealer||4||1
+2015-11-09 02:52:02.680462||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJucwu_tgskCFdgTgQodJKoCGw||5||0
+2015-11-09 02:52:04.167173||error||visiting||google searchresults||0||1
+2015-11-09 02:52:04.206887||error||visiting||google searchresults||1||1
+2015-11-09 02:52:04.779303||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP3i5fDtgskCFVMvgQodTycJrA||3||0
+2015-11-09 02:52:06.937635||error||visiting||google searchresults||4||1
+2015-11-09 02:52:09.582762||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNrd0vTtgskCFcUkgQod5NkDfg||2||0
+2015-11-09 02:52:17.863931||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIKjp_ntgskCFZQ6gQodgPIGrA||1||1
+2015-11-09 02:52:18.868571||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKfPxPjtgskCFY49gQodmmkLMA||5||0
+2015-11-09 02:52:19.616488||error||visiting||google searchresults||2||0
+2015-11-09 02:52:21.927985||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKmmxvntgskCFUo8gQodQ3oJ_A||3||0
+2015-11-09 02:52:22.469131||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||4||1
+2015-11-09 02:52:23.787317||treatment||visit page||http://www.carsense.com/?gclid=CNTVofntgskCFYI8gQodSNAOFA||0||1
+2015-11-09 02:52:28.909547||error||visiting||google searchresults||5||0
+2015-11-09 02:52:31.992333||error||visiting||google searchresults||3||0
+2015-11-09 02:52:35.492810||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJj95f_tgskCFUs8gQodYHoPqw||1||1
+2015-11-09 02:52:36.245680||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||2||0
+2015-11-09 02:52:36.957465||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||4||1
+2015-11-09 02:52:37.531160||treatment||visit page||http://www.carsense.com/?gclid=CIWz0YLugskCFYc7gQod-Q0MzA||0||1
+2015-11-09 02:52:45.710711||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||5||0
+2015-11-09 02:52:47.846828||treatment||google search||BMW||2||0
+2015-11-09 02:52:48.770166||error||visiting||google searchresults||2||0
+2015-11-09 02:52:48.854683||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||3||0
+2015-11-09 02:52:55.535780||error||visiting||google searchresults||1||1
+2015-11-09 02:52:57.016583||error||visiting||google searchresults||4||1
+2015-11-09 02:52:57.338562||treatment||google search||BMW||5||0
+2015-11-09 02:52:57.638477||error||visiting||google searchresults||0||1
+2015-11-09 02:52:58.242803||error||visiting||google searchresults||5||0
+2015-11-09 02:53:00.541564||treatment||google search||BMW||3||0
+2015-11-09 02:53:01.464663||error||visiting||google searchresults||3||0
+2015-11-09 02:53:06.950142||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 02:53:10.461634||treatment||visit page||http://www.mbusa.com/mercedes/special_offers/current?utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sE1oFIE6U_dc|pcrid|64059787972|pkw|1%20series|pmt|b&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||4||1
+2015-11-09 02:53:10.949601||treatment||visit page||http://www.mbusa.com/mercedes/vehicles/class/class-C/bodystyle-CPE?&utm_source=google&utm_medium=cpc&utm_campaign=Cnq%7CSCH%7CLCP%7CCNTL%7C508%7CPittsburgh%7CPA&utm_term=1%20series&utm_content=sRldfteCV_dc|pcrid|64059787972|pkw|1%20series|pmt|b||1||1
+2015-11-09 02:53:13.826731||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CMig6pLugskCFdgQgQodo1cHHw||0||1
+2015-11-09 02:53:17.787529||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 02:53:19.959249||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 02:53:22.188481||treatment||google search||BMW||4||1
+2015-11-09 02:53:23.235145||treatment||google search||BMW||1||1
+2015-11-09 02:53:23.466711||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 02:53:25.651248||treatment||google search||BMW||0||1
+2015-11-09 02:53:33.403014||error||visiting||google searchresults||4||1
+2015-11-09 02:53:33.523984||error||visiting||google searchresults||2||0
+2015-11-09 02:53:33.654078||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 02:53:34.387080||error||visiting||google searchresults||1||1
+2015-11-09 02:53:35.655289||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 02:53:36.756362||error||visiting||google searchresults||0||1
+2015-11-09 02:53:43.697497||error||visiting||google searchresults||5||0
+2015-11-09 02:53:45.718180||error||visiting||google searchresults||3||0
+2015-11-09 02:53:55.091935||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 02:53:59.348118||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 02:54:03.212767||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 02:54:03.373050||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 02:54:06.165002||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 02:54:09.349899||event||progress-marker||training-end||2||0
+2015-11-09 02:54:10.874064||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 02:54:13.374157||event||progress-marker||training-end||5||0
+2015-11-09 02:54:15.985893||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 02:54:16.166364||event||progress-marker||training-end||3||0
+2015-11-09 02:54:19.235483||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 02:54:30.906999||error||visiting||google searchresults||1||1
+2015-11-09 02:54:35.261971||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 02:54:39.278046||error||visiting||google searchresults||0||1
+2015-11-09 02:54:47.728358||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 02:54:55.297578||error||visiting||google searchresults||4||1
+2015-11-09 02:54:56.167754||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 02:54:57.729189||event||progress-marker||training-end||1||1
+2015-11-09 02:55:06.169442||event||progress-marker||training-end||0||1
+2015-11-09 02:55:13.834541||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||1
+2015-11-09 02:55:23.835392||event||progress-marker||training-end||4||1
+2015-11-09 02:55:24.428861||event||progress-marker||measurement-start||2||0
+2015-11-09 02:55:26.192907||event||progress-marker||measurement-start||0||1
+2015-11-09 02:55:26.234802||event||progress-marker||measurement-start||3||0
+2015-11-09 02:55:27.763667||event||progress-marker||measurement-start||1||1
+2015-11-09 02:55:28.454417||event||progress-marker||measurement-start||5||0
+2015-11-09 02:55:28.845079||event||progress-marker||measurement-start||4||1
+2015-11-09 02:56:02.552051||measurement||ad||2015-11-09 02:56:02.029122@|Medicare Plans@|dealhunter.us/Medicare-Plans@|Look up Medicare Plans Save Time and Money Now !||4||1
+2015-11-09 02:56:02.692341||measurement||ad||2015-11-09 02:56:02.029122@|How To Do Deep Meditation@|omharmonics.com/Meditation-Audio@|Revolutionize The Way You Meditate Discover The Meditation Technology||4||1
+2015-11-09 02:56:02.717569||measurement||loadtime||0:00:28.871252||4||1
+2015-11-09 02:56:05.828432||measurement||ad||2015-11-09 02:56:05.570245@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 02:56:05.943074||measurement||ad||2015-11-09 02:56:05.570245@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:56:05.956510||measurement||loadtime||0:00:33.192160||1||1
+2015-11-09 02:56:11.946406||measurement||ad||2015-11-09 02:55:56.502959@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 02:56:13.230358||measurement||ad||2015-11-09 02:55:56.502959@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 02:56:13.235652||measurement||loadtime||0:00:43.805392||2||0
+2015-11-09 02:56:16.402794||measurement||ad||2015-11-09 02:56:02.312956@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 02:56:16.832528||measurement||ad||2015-11-09 02:56:02.312956@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:56:16.932332||measurement||loadtime||0:00:45.696829||3||0
+2015-11-09 02:56:25.527236||measurement||ad||2015-11-09 02:56:25.209146@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 02:56:25.686351||measurement||ad||2015-11-09 02:56:25.209146@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:56:25.703804||measurement||loadtime||0:00:54.509296||0||1
+2015-11-09 02:56:27.638743||measurement||ad||2015-11-09 02:56:12.954370@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 02:56:28.950186||measurement||ad||2015-11-09 02:56:12.954370@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 02:56:28.991428||measurement||loadtime||0:00:55.536264||5||0
+2015-11-09 02:56:36.945709||measurement||ad||2015-11-09 02:56:36.113861@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:56:37.678506||measurement||ad||2015-11-09 02:56:36.113861@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:56:37.700874||measurement||loadtime||0:00:26.743483||1||1
+2015-11-09 02:56:37.748589||measurement||ad||2015-11-09 02:56:37.149136@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||1
+2015-11-09 02:56:37.854124||measurement||ad||2015-11-09 02:56:37.149136@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||1
+2015-11-09 02:56:37.876771||measurement||loadtime||0:00:30.157538||4||1
+2015-11-09 02:56:57.807810||measurement||ad||2015-11-09 02:56:57.035992@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 02:56:58.037977||measurement||ad||2015-11-09 02:56:57.035992@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:56:58.051209||measurement||loadtime||0:00:27.346325||0||1
+2015-11-09 02:57:04.472384||measurement||ad||2015-11-09 02:56:49.701249@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:57:06.058624||measurement||ad||2015-11-09 02:56:49.701249@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||0
+2015-11-09 02:57:06.404671||measurement||loadtime||0:00:44.471348||3||0
+2015-11-09 02:57:08.343055||measurement||ad||2015-11-09 02:56:55.789607@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 02:57:09.079822||measurement||ad||2015-11-09 02:56:55.789607@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 02:57:09.126956||measurement||loadtime||0:00:50.890524||2||0
+2015-11-09 02:57:10.153841||measurement||ad||2015-11-09 02:57:09.779120@|How To Do Deep Meditation@|omharmonics.com/Meditation-Audio@|Revolutionize The Way You Meditate Discover The Meditation Technology||4||1
+2015-11-09 02:57:10.235812||measurement||ad||2015-11-09 02:57:09.779120@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||1
+2015-11-09 02:57:10.247267||measurement||loadtime||0:00:27.369587||4||1
+2015-11-09 02:57:12.016421||measurement||ad||2015-11-09 02:57:00.429865@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 02:57:12.550458||measurement||ad||2015-11-09 02:57:00.429865@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 02:57:12.556222||measurement||loadtime||0:00:38.563632||5||0
+2015-11-09 02:57:14.241473||measurement||ad||2015-11-09 02:57:13.349011@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:57:14.437502||measurement||ad||2015-11-09 02:57:13.349011@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:57:14.455225||measurement||loadtime||0:00:31.753517||1||1
+2015-11-09 02:57:28.728725||measurement||ad||2015-11-09 02:57:27.466982@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 02:57:29.031082||measurement||ad||2015-11-09 02:57:27.466982@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:57:29.228256||measurement||loadtime||0:00:26.175816||0||1
+2015-11-09 02:57:41.924110||measurement||ad||2015-11-09 02:57:41.483040@|Top Weight Loss Programs@|shopperstop.us/Deals@|Find Top Weight Loss Programs Get All The Information You Need||4||1
+2015-11-09 02:57:42.005848||measurement||ad||2015-11-09 02:57:41.483040@|Medicare Plans@|dealhunter.us/Medicare-Plans@|Look up Medicare Plans Save Time and Money Now !||4||1
+2015-11-09 02:57:42.019487||measurement||loadtime||0:00:26.771155||4||1
+2015-11-09 02:57:42.213014||measurement||ad||2015-11-09 02:57:36.426842@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:57:42.421299||measurement||ad||2015-11-09 02:57:36.426842@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:57:42.430721||measurement||loadtime||0:00:31.025408||3||0
+2015-11-09 02:57:49.112702||measurement||ad||2015-11-09 02:57:48.357689@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:57:49.213403||measurement||ad||2015-11-09 02:57:48.357689@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:57:49.224268||measurement||loadtime||0:00:29.768148||1||1
+2015-11-09 02:57:50.851149||measurement||ad||2015-11-09 02:57:43.148210@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 02:57:51.362209||measurement||ad||2015-11-09 02:57:43.148210@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||2||0
+2015-11-09 02:57:51.598231||measurement||loadtime||0:00:37.469794||2||0
+2015-11-09 02:57:53.759533||measurement||ad||2015-11-09 02:57:44.834393@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||0
+2015-11-09 02:57:54.136352||measurement||ad||2015-11-09 02:57:44.834393@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 02:57:54.718880||measurement||loadtime||0:00:37.161468||5||0
+2015-11-09 02:57:55.756988||measurement||ad||2015-11-09 02:57:55.397891@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 02:57:55.849868||measurement||ad||2015-11-09 02:57:55.397891@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:57:55.860000||measurement||loadtime||0:00:21.630857||0||1
+2015-11-09 02:58:10.849696||measurement||ad||2015-11-09 02:58:10.378706@|How To Do Deep Meditation@|omharmonics.com/Meditation-Audio@|Revolutionize The Way You Meditate Discover The Meditation Technology||4||1
+2015-11-09 02:58:11.222653||measurement||ad||2015-11-09 02:58:10.378706@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||4||1
+2015-11-09 02:58:11.232196||measurement||loadtime||0:00:24.211468||4||1
+2015-11-09 02:58:19.076230||measurement||ad||2015-11-09 02:58:10.952450@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:58:19.519821||measurement||ad||2015-11-09 02:58:10.952450@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||0
+2015-11-09 02:58:19.536955||measurement||ad||2015-11-09 02:58:19.042743@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:58:19.601569||measurement||loadtime||0:00:32.170203||3||0
+2015-11-09 02:58:19.711143||measurement||ad||2015-11-09 02:58:19.042743@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:58:19.731764||measurement||loadtime||0:00:25.505770||1||1
+2015-11-09 02:58:27.943068||measurement||ad||2015-11-09 02:58:27.276277@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||0||1
+2015-11-09 02:58:28.007066||measurement||ad||2015-11-09 02:58:27.276277@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:58:28.021644||measurement||loadtime||0:00:27.160883||0||1
+2015-11-09 02:58:30.117100||measurement||ad||2015-11-09 02:58:21.411826@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 02:58:30.366048||measurement||ad||2015-11-09 02:58:22.640192@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 02:58:30.717701||measurement||ad||2015-11-09 02:58:21.411826@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 02:58:30.829227||measurement||ad||2015-11-09 02:58:22.640192@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 02:58:30.840478||measurement||loadtime||0:00:31.121047||5||0
+2015-11-09 02:58:30.933975||measurement||loadtime||0:00:34.334243||2||0
+2015-11-09 02:58:37.902133||measurement||ad||2015-11-09 02:58:37.285811@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||1
+2015-11-09 02:58:38.037897||measurement||ad||2015-11-09 02:58:37.285811@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||1
+2015-11-09 02:58:38.057582||measurement||loadtime||0:00:21.823865||4||1
+2015-11-09 02:58:49.094950||measurement||ad||2015-11-09 02:58:48.346327@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:58:49.291523||measurement||ad||2015-11-09 02:58:48.346327@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:58:49.318779||measurement||loadtime||0:00:24.586433||1||1
+2015-11-09 02:58:54.953336||measurement||ad||2015-11-09 02:58:47.851307@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:58:55.411882||measurement||ad||2015-11-09 02:58:47.851307@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:58:55.416216||measurement||loadtime||0:00:30.813984||3||0
+2015-11-09 02:58:58.380435||measurement||ad||2015-11-09 02:58:58.148026@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 02:58:58.466823||measurement||ad||2015-11-09 02:58:58.148026@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:58:58.480740||measurement||loadtime||0:00:25.456130||0||1
+2015-11-09 02:59:09.076344||measurement||ad||2015-11-09 02:59:02.554596@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 02:59:09.454411||measurement||ad||2015-11-09 02:59:02.554596@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 02:59:09.460800||measurement||loadtime||0:00:33.619389||5||0
+2015-11-09 02:59:09.748988||measurement||ad||2015-11-09 02:59:09.137031@|Medicare Plans@|dealhunter.us/Medicare-Plans@|Look up Medicare Plans Save Time and Money Now !||4||1
+2015-11-09 02:59:09.872984||measurement||ad||2015-11-09 02:59:09.137031@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||1
+2015-11-09 02:59:09.989982||measurement||loadtime||0:00:26.931868||4||1
+2015-11-09 02:59:15.849214||measurement||ad||2015-11-09 02:59:15.287518@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 02:59:15.984162||measurement||ad||2015-11-09 02:59:15.287518@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:59:15.999878||measurement||loadtime||0:00:21.679480||1||1
+2015-11-09 02:59:17.460456||measurement||ad||2015-11-09 02:59:04.642042@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 02:59:17.768796||measurement||ad||2015-11-09 02:59:04.642042@|Design A Room Online@|www.bhg.com/DesignRoom@|Virtual Room Builder Tool. Better Homes  Gardens®. Start Now!||2||0
+2015-11-09 02:59:18.073089||measurement||loadtime||0:00:42.138642||2||0
+2015-11-09 02:59:27.536644||measurement||ad||2015-11-09 02:59:26.583273@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||0||1
+2015-11-09 02:59:27.672491||measurement||ad||2015-11-09 02:59:26.583273@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:59:27.688398||measurement||loadtime||0:00:24.207165||0||1
+2015-11-09 02:59:30.576301||measurement||ad||2015-11-09 02:59:23.522499@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 02:59:30.813196||measurement||ad||2015-11-09 02:59:23.522499@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 02:59:30.818253||measurement||loadtime||0:00:30.401365||3||0
+2015-11-09 02:59:42.594361||measurement||ad||2015-11-09 02:59:41.824180@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 02:59:42.839455||measurement||ad||2015-11-09 02:59:41.824180@|How To Do Deep Meditation@|omharmonics.com/Meditation-Audio@|Revolutionize The Way You Meditate Discover The Meditation Technology||4||1
+2015-11-09 02:59:42.858416||measurement||loadtime||0:00:27.867617||4||1
+2015-11-09 02:59:43.353114||measurement||ad||2015-11-09 02:59:36.874770@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 02:59:43.505624||measurement||ad||2015-11-09 02:59:36.874770@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 02:59:43.509945||measurement||loadtime||0:00:29.048281||5||0
+2015-11-09 02:59:44.333822||measurement||ad||2015-11-09 02:59:43.988834@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 02:59:44.413435||measurement||ad||2015-11-09 02:59:43.988834@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 02:59:44.426431||measurement||loadtime||0:00:23.425612||1||1
+2015-11-09 02:59:54.532645||measurement||ad||2015-11-09 02:59:54.268268@|Apartments in Bangalore@|puravankara.com/Luxury_Apartments@|Purva Scarlet Off Kanakpura Road. Price Starting @4690 psft.Register!||0||1
+2015-11-09 02:59:54.682343||measurement||ad||2015-11-09 02:59:54.268268@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 02:59:54.692033||measurement||loadtime||0:00:22.002880||0||1
+2015-11-09 02:59:59.572141||measurement||ad||2015-11-09 02:59:49.293694@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:00:00.015292||measurement||ad||2015-11-09 02:59:49.293694@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||2||0
+2015-11-09 03:00:00.020898||measurement||loadtime||0:00:36.946999||2||0
+2015-11-09 03:00:03.665147||measurement||ad||2015-11-09 02:59:56.463393@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:00:03.865432||measurement||ad||2015-11-09 02:59:56.463393@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||0
+2015-11-09 03:00:03.874594||measurement||loadtime||0:00:28.055462||3||0
+2015-11-09 03:00:17.323377||measurement||ad||2015-11-09 03:00:14.466331@|Medicare Plans@|dealhunter.us/Medicare-Plans@|Look up Medicare Plans Save Time and Money Now !||4||1
+2015-11-09 03:00:17.643890||measurement||ad||2015-11-09 03:00:14.466331@|Want Rapid Weight Loss?@|thyroid-weight-loss.com@|Power-Boost Your Metabolism With A A Simple Thyroid Fix! Learn More.||4||1
+2015-11-09 03:00:17.703595||measurement||loadtime||0:00:29.843575||4||1
+2015-11-09 03:00:17.757464||measurement||ad||2015-11-09 03:00:11.415003@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:00:17.949068||measurement||ad||2015-11-09 03:00:11.415003@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 03:00:17.953600||measurement||loadtime||0:00:29.442557||5||0
+2015-11-09 03:00:18.466093||measurement||ad||2015-11-09 03:00:17.982168@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 03:00:18.554356||measurement||ad||2015-11-09 03:00:17.982168@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 03:00:18.565200||measurement||loadtime||0:00:29.137317||1||1
+2015-11-09 03:00:27.265118||measurement||ad||2015-11-09 03:00:26.788156@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 03:00:27.319325||measurement||ad||2015-11-09 03:00:26.788156@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:00:27.328375||measurement||loadtime||0:00:27.635110||0||1
+2015-11-09 03:00:40.629114||measurement||ad||2015-11-09 03:00:32.364396@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:00:41.615031||measurement||ad||2015-11-09 03:00:32.364396@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:00:41.803008||measurement||loadtime||0:00:36.781352||2||0
+2015-11-09 03:00:44.647201||measurement||ad||2015-11-09 03:00:35.679010@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:00:45.474853||measurement||ad||2015-11-09 03:00:35.679010@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||0
+2015-11-09 03:00:45.549763||measurement||loadtime||0:00:36.674423||3||0
+2015-11-09 03:00:47.658712||measurement||ad||2015-11-09 03:00:46.710210@|Top Weight Loss Programs@|shopperstop.us/Deals@|Find Top Weight Loss Programs Get All The Information You Need||4||1
+2015-11-09 03:00:47.838463||measurement||ad||2015-11-09 03:00:46.710210@|How To Do Deep Meditation@|omharmonics.com/Meditation-Audio@|Revolutionize The Way You Meditate Discover The Meditation Technology||4||1
+2015-11-09 03:00:47.855669||measurement||loadtime||0:00:25.150810||4||1
+2015-11-09 03:00:47.855913||event||progress-marker||measurement-end||4||1
+2015-11-09 03:00:49.918621||measurement||ad||2015-11-09 03:00:48.038595@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 03:00:50.054728||measurement||ad||2015-11-09 03:00:48.038595@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 03:00:50.213144||measurement||loadtime||0:00:26.646989||1||1
+2015-11-09 03:00:50.213815||event||progress-marker||measurement-end||1||1
+2015-11-09 03:00:55.647160||measurement||ad||2015-11-09 03:00:48.941816@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:00:55.775026||measurement||ad||2015-11-09 03:00:48.941816@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 03:00:55.780699||measurement||loadtime||0:00:32.826377||5||0
+2015-11-09 03:00:57.425226||measurement||ad||2015-11-09 03:00:56.948970@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 03:00:57.494443||measurement||ad||2015-11-09 03:00:56.948970@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:00:57.507840||measurement||loadtime||0:00:25.178746||0||1
+2015-11-09 03:00:57.508147||event||progress-marker||measurement-end||0||1
+2015-11-09 03:01:13.888041||measurement||ad||2015-11-09 03:01:10.109739@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:01:14.035399||measurement||ad||2015-11-09 03:01:10.109739@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 03:01:14.041166||measurement||loadtime||0:00:23.489465||3||0
+2015-11-09 03:01:14.514918||measurement||ad||2015-11-09 03:01:10.140821@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:01:14.634502||measurement||ad||2015-11-09 03:01:10.140821@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 03:01:14.650404||measurement||loadtime||0:00:27.846667||2||0
+2015-11-09 03:01:22.436713||measurement||ad||2015-11-09 03:01:18.723876@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 03:01:22.633419||measurement||ad||2015-11-09 03:01:18.723876@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:01:22.637591||measurement||loadtime||0:00:21.856398||5||0
+2015-11-09 03:01:40.696433||measurement||ad||2015-11-09 03:01:37.117269@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:01:40.810129||measurement||ad||2015-11-09 03:01:37.117269@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||0
+2015-11-09 03:01:40.813299||measurement||loadtime||0:00:21.770708||3||0
+2015-11-09 03:01:40.813842||event||progress-marker||measurement-end||3||0
+2015-11-09 03:01:47.000248||measurement||ad||2015-11-09 03:01:44.048955@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||0
+2015-11-09 03:01:47.231164||measurement||ad||2015-11-09 03:01:44.048955@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:01:47.303368||measurement||loadtime||0:00:19.664858||5||0
+2015-11-09 03:01:47.303695||event||progress-marker||measurement-end||5||0
+2015-11-09 03:01:56.912366||measurement||ad||2015-11-09 03:01:43.980670@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:02:03.552925||measurement||ad||2015-11-09 03:01:43.980670@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||2||0
+2015-11-09 03:02:03.815969||measurement||loadtime||0:00:44.163928||2||0
+2015-11-09 03:02:31.616313||measurement||ad||2015-11-09 03:02:27.942754@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:02:31.669689||measurement||ad||2015-11-09 03:02:27.942754@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:02:31.672764||measurement||loadtime||0:00:22.856249||2||0
+2015-11-09 03:02:31.672961||event||progress-marker||measurement-end||2||0
+2015-11-09 03:02:32.303495||meta||block_id end||2
+2015-11-09 03:02:32.306163||meta||block_id start||3
+2015-11-09 03:02:32.307441||meta||assignment||4@|1@|2@|3@|0@|5
+2015-11-09 03:02:35.980701||event||progress-marker||training-start||1||0
+2015-11-09 03:02:36.096598||event||progress-marker||training-start||4||0
+2015-11-09 03:02:36.207957||event||progress-marker||training-start||2||0
+2015-11-09 03:02:39.092753||event||progress-marker||training-start||0||1
+2015-11-09 03:02:39.191236||event||progress-marker||training-start||5||1
+2015-11-09 03:02:39.820574||event||progress-marker||training-start||3||1
+2015-11-09 03:02:41.909332||treatment||google search||Buy BMW||1||0
+2015-11-09 03:02:42.214187||treatment||google search||Buy BMW||2||0
+2015-11-09 03:02:42.305415||treatment||google search||Buy BMW||4||0
+2015-11-09 03:02:43.895068||error||visiting||google searchresults||4||0
+2015-11-09 03:02:43.988680||error||visiting||google searchresults||1||0
+2015-11-09 03:02:44.069379||error||visiting||google searchresults||2||0
+2015-11-09 03:02:44.980552||treatment||google search||Buy BMW||3||1
+2015-11-09 03:02:45.001522||treatment||google search||Buy BMW||0||1
+2015-11-09 03:02:45.022032||treatment||google search||Buy BMW||5||1
+2015-11-09 03:02:55.837720||error||visiting||google searchresults||3||1
+2015-11-09 03:02:55.842428||error||visiting||google searchresults||5||1
+2015-11-09 03:02:55.951739||error||visiting||google searchresults||0||1
+2015-11-09 03:03:01.474129||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 03:03:01.936900||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 03:03:04.192693||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 03:03:09.974141||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 03:03:13.616771||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 03:03:13.904392||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 03:03:15.168840||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 03:03:16.222552||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 03:03:19.999295||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 03:03:24.811776||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 03:03:25.229617||error||visiting||google searchresults||4||0
+2015-11-09 03:03:26.250023||error||visiting||google searchresults||2||0
+2015-11-09 03:03:28.507315||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 03:03:28.791790||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 03:03:30.034755||error||visiting||google searchresults||1||0
+2015-11-09 03:03:41.958366||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||2||0
+2015-11-09 03:03:43.401988||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 03:03:44.790230||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COuup8DwgskCFdcSgQodbsAAfg||1||0
+2015-11-09 03:03:44.898051||error||visiting||google searchresults||0||1
+2015-11-09 03:03:48.618185||error||visiting||google searchresults||3||1
+2015-11-09 03:03:48.838674||error||visiting||google searchresults||5||1
+2015-11-09 03:03:53.662380||treatment||google search||BMW dealer||2||0
+2015-11-09 03:03:54.303308||error||visiting||google searchresults||2||0
+2015-11-09 03:03:55.360067||treatment||google search||BMW dealer||4||0
+2015-11-09 03:03:56.273465||error||visiting||google searchresults||4||0
+2015-11-09 03:03:56.942988||treatment||google search||BMW dealer||1||0
+2015-11-09 03:03:57.714613||error||visiting||google searchresults||1||0
+2015-11-09 03:03:58.209005||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||0||1
+2015-11-09 03:04:04.098004||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||5||1
+2015-11-09 03:04:04.232181||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||3||1
+2015-11-09 03:04:12.503943||treatment||google search||BMW dealer||0||1
+2015-11-09 03:04:13.679836||treatment||visit page||http://www.carsense.com/?gclid=CLvT8cvwgskCFdgagQodCK4AMg||2||0
+2015-11-09 03:04:17.026909||treatment||google search||BMW dealer||5||1
+2015-11-09 03:04:17.240570||treatment||visit page||http://www.carsense.com/?gclid=CLOwwc3wgskCFZM2gQodqtgP5w||1||0
+2015-11-09 03:04:17.982366||treatment||google search||BMW dealer||3||1
+2015-11-09 03:04:23.554263||error||visiting||google searchresults||0||1
+2015-11-09 03:04:28.176047||error||visiting||google searchresults||5||1
+2015-11-09 03:04:28.780434||error||visiting||google searchresults||3||1
+2015-11-09 03:04:29.264358||treatment||visit page||http://www.carsense.com/?gclid=CP26jdXwgskCFYM6gQod_O4HNw||2||0
+2015-11-09 03:04:33.080752||treatment||visit page||http://www.carsense.com/?gclid=CNnZ5tbwgskCFdgLgQodEQEH0g||1||0
+2015-11-09 03:04:39.324068||error||visiting||google searchresults||2||0
+2015-11-09 03:04:42.519650||treatment||visit page||http://www.carsense.com/?gclid=CM2069nwgskCFdQ2gQodFwwNcw||0||1
+2015-11-09 03:04:43.144673||error||visiting||google searchresults||1||0
+2015-11-09 03:04:44.510907||treatment||visit page||http://www.carsense.com/?gclid=COPLsdzwgskCFdgLgQodEQEH0g||3||1
+2015-11-09 03:04:46.383648||error||visiting||google searchresults||4||0
+2015-11-09 03:04:47.066073||treatment||visit page||http://www.carsense.com/?gclid=CNOHhdzwgskCFVUlgQodJdoD7Q||5||1
+2015-11-09 03:04:55.204557||treatment||visit page||http://www.usautomart.com/?gclid=CPrBrOHwgskCFUo6gQodotYFog||2||0
+2015-11-09 03:04:58.836372||treatment||visit page||http://www.carsense.com/?gclid=CNGc7uPwgskCFdcZgQod5yUGlQ||3||1
+2015-11-09 03:04:59.755297||treatment||visit page||http://www.carsense.com/?gclid=CPO37uLwgskCFdgOgQod3CYEoQ||0||1
+2015-11-09 03:05:00.042852||treatment||visit page||http://www.usautomart.com/?gclid=CO2dlOPwgskCFdcZgQod5yUGlQ||1||0
+2015-11-09 03:05:04.271251||treatment||visit page||http://www.carsense.com/?gclid=CO7xhOXwgskCFVY2gQodCsIKEQ||5||1
+2015-11-09 03:05:06.405219||error||visiting||google searchresults||4||0
+2015-11-09 03:05:06.792472||treatment||google search||BMW||2||0
+2015-11-09 03:05:07.628070||error||visiting||google searchresults||2||0
+2015-11-09 03:05:11.824480||treatment||google search||BMW||1||0
+2015-11-09 03:05:12.835709||error||visiting||google searchresults||1||0
+2015-11-09 03:05:18.891675||error||visiting||google searchresults||3||1
+2015-11-09 03:05:19.790914||error||visiting||google searchresults||0||1
+2015-11-09 03:05:23.011517||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||2||0
+2015-11-09 03:05:24.317898||error||visiting||google searchresults||5||1
+2015-11-09 03:05:26.456912||error||visiting||google searchresults||4||0
+2015-11-09 03:05:28.755219||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||1||0
+2015-11-09 03:05:33.972183||treatment||visit page||http://www.usautomart.com/?gclid=CKnk0_TwgskCFZQjgQodp6QJLQ||0||1
+2015-11-09 03:05:35.759857||treatment||visit page||http://www.usautomart.com/?gclid=CNa2mvTwgskCFU47gQod-GIG7g||3||1
+2015-11-09 03:05:38.165602||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||2||0
+2015-11-09 03:05:38.169776||treatment||visit page||http://www.usautomart.com/?gclid=CIXG6PbwgskCFUEvgQodvQgC1w||5||1
+2015-11-09 03:05:44.328469||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||1||0
+2015-11-09 03:05:45.903207||treatment||google search||BMW||0||1
+2015-11-09 03:05:46.492840||error||visiting||google searchresults||4||0
+2015-11-09 03:05:47.913157||treatment||google search||BMW||3||1
+2015-11-09 03:05:48.228632||error||visiting||google searchresults||2||0
+2015-11-09 03:05:49.906685||treatment||google search||BMW||5||1
+2015-11-09 03:05:54.363393||error||visiting||google searchresults||1||0
+2015-11-09 03:05:58.041268||error||visiting||google searchresults||0||1
+2015-11-09 03:05:59.166675||error||visiting||google searchresults||3||1
+2015-11-09 03:06:00.872732||error||visiting||google searchresults||5||1
+2015-11-09 03:06:05.891667||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 03:06:06.507402||error||visiting||google searchresults||4||0
+2015-11-09 03:06:14.332861||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 03:06:15.892533||event||progress-marker||training-end||2||0
+2015-11-09 03:06:19.951616||treatment||google search||BMW||4||0
+2015-11-09 03:06:20.163362||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 03:06:21.336683||error||visiting||google searchresults||4||0
+2015-11-09 03:06:21.833747||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 03:06:24.007350||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:06:24.334566||event||progress-marker||training-end||1||0
+2015-11-09 03:06:35.714695||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 03:06:37.204720||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 03:06:37.835499||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:06:39.405591||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:06:55.489293||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:06:55.835649||error||visiting||google searchresults||3||1
+2015-11-09 03:06:57.261243||error||visiting||google searchresults||5||1
+2015-11-09 03:06:57.880836||error||visiting||google searchresults||0||1
+2015-11-09 03:07:05.523228||error||visiting||google searchresults||4||0
+2015-11-09 03:07:13.630491||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 03:07:14.316904||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 03:07:15.099976||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 03:07:20.536238||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 03:07:23.632640||event||progress-marker||training-end||3||1
+2015-11-09 03:07:24.317788||event||progress-marker||training-end||5||1
+2015-11-09 03:07:25.101458||event||progress-marker||training-end||0||1
+2015-11-09 03:07:30.536965||event||progress-marker||training-end||4||0
+2015-11-09 03:07:31.002569||event||progress-marker||measurement-start||2||0
+2015-11-09 03:07:33.650930||event||progress-marker||measurement-start||3||1
+2015-11-09 03:07:34.335770||event||progress-marker||measurement-start||5||1
+2015-11-09 03:07:34.428296||event||progress-marker||measurement-start||1||0
+2015-11-09 03:07:35.117703||event||progress-marker||measurement-start||0||1
+2015-11-09 03:07:35.549507||event||progress-marker||measurement-start||4||0
+2015-11-09 03:08:23.584294||measurement||ad||2015-11-09 03:08:00.367185@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:08:24.351060||measurement||ad||2015-11-09 03:08:00.367185@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:08:24.356738||measurement||loadtime||0:00:48.352581||2||0
+2015-11-09 03:08:27.411794||measurement||ad||2015-11-09 03:08:26.295530@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:08:27.531705||measurement||ad||2015-11-09 03:08:13.658938@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:08:27.602273||measurement||ad||2015-11-09 03:08:26.295530@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:08:27.620478||measurement||loadtime||0:00:48.283191||5||1
+2015-11-09 03:08:28.139749||measurement||ad||2015-11-09 03:08:13.658938@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 03:08:28.146996||measurement||loadtime||0:00:48.717758||1||0
+2015-11-09 03:08:28.255580||measurement||ad||2015-11-09 03:08:27.445129@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 03:08:28.639748||measurement||ad||2015-11-09 03:08:27.445129@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:08:28.659727||measurement||loadtime||0:00:50.007275||3||1
+2015-11-09 03:08:28.810668||measurement||ad||2015-11-09 03:08:27.501119@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:08:29.283841||measurement||ad||2015-11-09 03:08:27.501119@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 03:08:29.315445||measurement||loadtime||0:00:49.194620||0||1
+2015-11-09 03:08:43.355101||measurement||ad||2015-11-09 03:08:26.432491@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:08:45.423502||measurement||ad||2015-11-09 03:08:26.432491@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:08:45.523923||measurement||loadtime||0:01:04.973643||4||0
+2015-11-09 03:09:07.010458||measurement||ad||2015-11-09 03:09:06.478692@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:09:07.151455||measurement||ad||2015-11-09 03:09:06.478692@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:09:07.302654||measurement||loadtime||0:00:34.680819||5||1
+2015-11-09 03:09:07.659860||measurement||ad||2015-11-09 03:08:56.558877@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||0
+2015-11-09 03:09:07.981553||measurement||ad||2015-11-09 03:08:56.558877@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 03:09:07.999778||measurement||loadtime||0:00:34.852040||1||0
+2015-11-09 03:09:08.956899||measurement||ad||2015-11-09 03:09:08.323727@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:09:09.113190||measurement||ad||2015-11-09 03:09:08.551285@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 03:09:09.241893||measurement||ad||2015-11-09 03:09:08.323727@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 03:09:09.255411||measurement||ad||2015-11-09 03:09:08.551285@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:09:09.301318||measurement||loadtime||0:00:34.984707||0||1
+2015-11-09 03:09:09.329686||measurement||loadtime||0:00:35.668517||3||1
+2015-11-09 03:09:35.416718||measurement||ad||2015-11-09 03:09:17.920114@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:09:36.854816||measurement||ad||2015-11-09 03:09:17.920114@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:09:36.878628||measurement||loadtime||0:00:46.354071||4||0
+2015-11-09 03:09:39.847107||measurement||ad||2015-11-09 03:09:12.782413@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:09:43.122027||measurement||ad||2015-11-09 03:09:12.782413@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:09:43.216584||measurement||ad||2015-11-09 03:09:42.750053@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:09:43.404279||measurement||ad||2015-11-09 03:09:42.750053@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:09:43.417434||measurement||loadtime||0:00:31.114279||5||1
+2015-11-09 03:09:44.009201||measurement||loadtime||0:01:14.651991||2||0
+2015-11-09 03:09:45.049911||measurement||ad||2015-11-09 03:09:44.136615@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 03:09:45.283993||measurement||ad||2015-11-09 03:09:44.136615@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:09:45.294790||measurement||loadtime||0:00:30.963530||3||1
+2015-11-09 03:09:47.180105||measurement||ad||2015-11-09 03:09:46.866086@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:09:47.272659||measurement||ad||2015-11-09 03:09:46.866086@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 03:09:47.293975||measurement||loadtime||0:00:32.991554||0||1
+2015-11-09 03:09:48.891412||measurement||ad||2015-11-09 03:09:41.226575@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 03:09:49.519976||measurement||ad||2015-11-09 03:09:41.226575@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:09:49.525161||measurement||loadtime||0:00:36.524857||1||0
+2015-11-09 03:10:17.404545||measurement||ad||2015-11-09 03:10:17.226133@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:10:17.488914||measurement||ad||2015-11-09 03:10:17.226133@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:10:17.504687||measurement||loadtime||0:00:29.086637||5||1
+2015-11-09 03:10:20.710050||measurement||ad||2015-11-09 03:10:12.331050@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:10:21.383601||measurement||ad||2015-11-09 03:10:12.331050@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:10:21.469280||measurement||loadtime||0:00:39.590045||4||0
+2015-11-09 03:10:22.346926||measurement||ad||2015-11-09 03:10:21.809960@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 03:10:22.480380||measurement||ad||2015-11-09 03:10:21.809960@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:10:22.519638||measurement||loadtime||0:00:32.223626||3||1
+2015-11-09 03:10:23.534121||measurement||ad||2015-11-09 03:10:18.180533@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:10:23.871036||measurement||ad||2015-11-09 03:10:18.180533@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:10:23.879914||measurement||loadtime||0:00:34.870139||2||0
+2015-11-09 03:10:24.880147||measurement||ad||2015-11-09 03:10:20.231511@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||0
+2015-11-09 03:10:25.029709||measurement||ad||2015-11-09 03:10:20.231511@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:10:25.036222||measurement||loadtime||0:00:30.509378||1||0
+2015-11-09 03:10:25.957813||measurement||ad||2015-11-09 03:10:25.600809@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:10:26.025832||measurement||ad||2015-11-09 03:10:25.600809@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 03:10:26.083389||measurement||loadtime||0:00:33.787740||0||1
+2015-11-09 03:10:50.640150||measurement||ad||2015-11-09 03:10:50.126014@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:10:50.775906||measurement||ad||2015-11-09 03:10:50.126014@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:10:50.812388||measurement||loadtime||0:00:28.298815||5||1
+2015-11-09 03:10:58.053962||measurement||ad||2015-11-09 03:10:51.227840@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:10:58.391993||measurement||ad||2015-11-09 03:10:51.227840@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:10:58.510884||measurement||loadtime||0:00:32.040286||4||0
+2015-11-09 03:11:00.621904||measurement||ad||2015-11-09 03:10:59.957090@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 03:11:00.770977||measurement||ad||2015-11-09 03:10:59.957090@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:11:00.785832||measurement||loadtime||0:00:33.264881||3||1
+2015-11-09 03:11:01.081244||measurement||ad||2015-11-09 03:10:53.523239@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:11:01.460409||measurement||ad||2015-11-09 03:10:53.523239@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 03:11:01.464563||measurement||loadtime||0:00:31.427348||1||0
+2015-11-09 03:11:02.749167||measurement||ad||2015-11-09 03:10:53.844797@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:11:03.004346||measurement||ad||2015-11-09 03:10:53.844797@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:11:03.163171||measurement||loadtime||0:00:34.281907||2||0
+2015-11-09 03:11:04.408540||measurement||ad||2015-11-09 03:11:03.582576@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:11:04.824454||measurement||ad||2015-11-09 03:11:03.582576@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:11:04.861253||measurement||loadtime||0:00:33.777178||0||1
+2015-11-09 03:11:24.809121||measurement||ad||2015-11-09 03:11:21.960270@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:11:25.545562||measurement||ad||2015-11-09 03:11:21.960270@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:11:25.589908||measurement||loadtime||0:00:29.776703||5||1
+2015-11-09 03:11:36.277984||measurement||ad||2015-11-09 03:11:27.714535@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:11:36.727591||measurement||ad||2015-11-09 03:11:27.714535@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:11:36.779684||measurement||loadtime||0:00:33.268343||4||0
+2015-11-09 03:11:37.509987||measurement||ad||2015-11-09 03:11:32.744646@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 03:11:37.605027||measurement||ad||2015-11-09 03:11:37.242416@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||1
+2015-11-09 03:11:37.659167||measurement||ad||2015-11-09 03:11:32.744646@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:11:37.664572||measurement||loadtime||0:00:31.199311||1||0
+2015-11-09 03:11:37.766852||measurement||ad||2015-11-09 03:11:37.242416@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:11:37.786232||measurement||loadtime||0:00:31.999528||3||1
+2015-11-09 03:11:40.101662||measurement||ad||2015-11-09 03:11:39.841889@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:11:40.183556||measurement||ad||2015-11-09 03:11:39.841889@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 03:11:40.195158||measurement||loadtime||0:00:30.333327||0||1
+2015-11-09 03:11:54.336788||measurement||ad||2015-11-09 03:11:52.369973@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:11:54.431409||measurement||ad||2015-11-09 03:11:52.369973@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:11:54.440788||measurement||loadtime||0:00:23.847844||5||1
+2015-11-09 03:12:07.660974||measurement||ad||2015-11-09 03:12:05.933729@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 03:12:07.792884||measurement||ad||2015-11-09 03:12:05.933729@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:12:07.801793||measurement||loadtime||0:00:25.012919||3||1
+2015-11-09 03:12:08.669543||error||collecting ads||Error||2||0
+2015-11-09 03:12:09.458275||measurement||ad||2015-11-09 03:12:03.715141@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:12:09.728669||measurement||ad||2015-11-09 03:12:03.715141@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||0
+2015-11-09 03:12:09.739736||measurement||loadtime||0:00:27.074721||1||0
+2015-11-09 03:12:15.316941||measurement||ad||2015-11-09 03:12:14.443008@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:12:15.613601||measurement||ad||2015-11-09 03:12:14.443008@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 03:12:15.727577||measurement||loadtime||0:00:30.531448||0||1
+2015-11-09 03:12:24.308442||measurement||ad||2015-11-09 03:12:08.648829@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 03:12:26.626947||measurement||ad||2015-11-09 03:12:08.648829@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:12:26.636090||measurement||loadtime||0:00:44.855457||4||0
+2015-11-09 03:12:33.685257||measurement||ad||2015-11-09 03:12:32.956382@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:12:33.944710||measurement||ad||2015-11-09 03:12:32.956382@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:12:33.970311||measurement||loadtime||0:00:34.528844||5||1
+2015-11-09 03:12:40.416552||measurement||ad||2015-11-09 03:12:39.699471@|AncestryDNA™ Official@|ancestry.com/DNA@|Discover your genetic ethnicity  geographic origins with DNA!||3||1
+2015-11-09 03:12:40.781692||measurement||ad||2015-11-09 03:12:39.699471@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:12:40.814142||measurement||loadtime||0:00:28.011692||3||1
+2015-11-09 03:12:45.592798||measurement||ad||2015-11-09 03:12:44.636630@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:12:45.866292||measurement||ad||2015-11-09 03:12:44.636630@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:12:45.878751||measurement||loadtime||0:00:25.150222||0||1
+2015-11-09 03:12:52.012122||measurement||ad||2015-11-09 03:12:42.540620@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 03:12:53.163859||measurement||ad||2015-11-09 03:12:42.540620@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||0
+2015-11-09 03:12:53.174274||measurement||loadtime||0:00:38.433939||1||0
+2015-11-09 03:12:54.784584||measurement||ad||2015-11-09 03:12:40.641949@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:12:55.532804||measurement||ad||2015-11-09 03:12:40.641949@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:12:55.550187||measurement||loadtime||0:00:41.879289||2||0
+2015-11-09 03:13:09.927360||measurement||ad||2015-11-09 03:13:02.516810@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:13:10.173595||measurement||ad||2015-11-09 03:13:02.516810@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:13:10.181534||measurement||loadtime||0:00:38.544869||4||0
+2015-11-09 03:13:13.091458||measurement||ad||2015-11-09 03:13:12.449554@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 03:13:13.236464||measurement||ad||2015-11-09 03:13:12.449554@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:13:13.258317||measurement||loadtime||0:00:27.442831||3||1
+2015-11-09 03:13:15.102922||measurement||ad||2015-11-09 03:13:14.594114@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:13:15.289803||measurement||ad||2015-11-09 03:13:14.594114@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:13:15.305983||measurement||loadtime||0:00:36.334658||5||1
+2015-11-09 03:13:26.554851||measurement||ad||2015-11-09 03:13:25.472770@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:13:26.909100||measurement||ad||2015-11-09 03:13:25.472770@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 03:13:26.930376||measurement||loadtime||0:00:36.050789||0||1
+2015-11-09 03:13:28.850591||measurement||ad||2015-11-09 03:13:22.431720@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 03:13:29.085012||measurement||ad||2015-11-09 03:13:22.431720@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 03:13:29.115620||measurement||loadtime||0:00:30.940620||1||0
+2015-11-09 03:13:44.112774||measurement||ad||2015-11-09 03:13:37.008652@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:13:44.390573||measurement||ad||2015-11-09 03:13:37.008652@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:13:44.395202||measurement||loadtime||0:00:29.212619||4||0
+2015-11-09 03:13:45.880969||measurement||ad||2015-11-09 03:13:45.280598@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:13:46.010919||measurement||ad||2015-11-09 03:13:45.280598@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 03:13:46.022499||measurement||loadtime||0:00:25.715709||5||1
+2015-11-09 03:13:46.026969||event||progress-marker||measurement-end||5||1
+2015-11-09 03:13:48.426161||measurement||ad||2015-11-09 03:13:47.586716@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||1
+2015-11-09 03:13:48.582298||measurement||ad||2015-11-09 03:13:47.586716@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:13:48.617956||measurement||loadtime||0:00:30.358159||3||1
+2015-11-09 03:13:48.618431||event||progress-marker||measurement-end||3||1
+2015-11-09 03:14:00.177185||measurement||ad||2015-11-09 03:13:59.918336@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:14:00.327461||measurement||ad||2015-11-09 03:13:59.918336@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 03:14:00.371660||measurement||loadtime||0:00:28.440709||0||1
+2015-11-09 03:14:00.371896||event||progress-marker||measurement-end||0||1
+2015-11-09 03:14:05.341581||measurement||ad||2015-11-09 03:14:00.757530@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 03:14:05.425415||measurement||ad||2015-11-09 03:14:00.757530@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 03:14:05.429817||measurement||loadtime||0:00:31.313531||1||0
+2015-11-09 03:14:05.430141||event||progress-marker||measurement-end||1||0
+2015-11-09 03:14:17.064570||measurement||ad||2015-11-09 03:13:35.484991@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:14:17.259765||measurement||ad||2015-11-09 03:13:35.484991@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:14:17.263650||measurement||loadtime||0:01:16.712587||2||0
+2015-11-09 03:14:20.201425||measurement||ad||2015-11-09 03:14:14.931529@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:14:22.299669||measurement||ad||2015-11-09 03:14:14.931529@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:14:22.303291||measurement||loadtime||0:00:32.907248||4||0
+2015-11-09 03:14:43.613680||measurement||ad||2015-11-09 03:14:41.073323@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:14:43.680925||measurement||ad||2015-11-09 03:14:41.073323@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:14:43.684475||measurement||loadtime||0:00:21.419272||2||0
+2015-11-09 03:14:46.987410||measurement||ad||2015-11-09 03:14:44.911594@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:14:47.059337||measurement||ad||2015-11-09 03:14:44.911594@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 03:14:47.062495||measurement||loadtime||0:00:19.757754||4||0
+2015-11-09 03:14:47.062790||event||progress-marker||measurement-end||4||0
+2015-11-09 03:15:05.273154||measurement||ad||2015-11-09 03:15:03.190955@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:15:05.331525||measurement||ad||2015-11-09 03:15:03.190955@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:15:05.335204||measurement||loadtime||0:00:16.649145||2||0
+2015-11-09 03:15:27.836997||measurement||ad||2015-11-09 03:15:25.871713@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:15:27.891723||measurement||ad||2015-11-09 03:15:25.871713@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:15:27.894866||measurement||loadtime||0:00:17.559152||2||0
+2015-11-09 03:15:27.895202||event||progress-marker||measurement-end||2||0
+2015-11-09 03:15:28.463261||meta||block_id end||3
+2015-11-09 03:15:28.465659||meta||block_id start||4
+2015-11-09 03:15:28.465802||meta||assignment||3@|2@|4@|5@|0@|1
+2015-11-09 03:15:31.933197||event||progress-marker||training-start||4||0
+2015-11-09 03:15:32.197756||event||progress-marker||training-start||3||0
+2015-11-09 03:15:32.331928||event||progress-marker||training-start||2||0
+2015-11-09 03:15:35.292796||event||progress-marker||training-start||1||1
+2015-11-09 03:15:35.692905||event||progress-marker||training-start||5||1
+2015-11-09 03:15:35.723903||event||progress-marker||training-start||0||1
+2015-11-09 03:15:36.499627||treatment||google search||Buy BMW||4||0
+2015-11-09 03:15:37.651061||treatment||google search||Buy BMW||3||0
+2015-11-09 03:15:38.342449||treatment||google search||Buy BMW||2||0
+2015-11-09 03:15:38.388067||error||visiting||google searchresults||4||0
+2015-11-09 03:15:39.646027||error||visiting||google searchresults||3||0
+2015-11-09 03:15:39.811575||error||visiting||google searchresults||2||0
+2015-11-09 03:15:40.917984||treatment||google search||Buy BMW||1||1
+2015-11-09 03:15:40.962772||treatment||google search||Buy BMW||5||1
+2015-11-09 03:15:41.095250||treatment||google search||Buy BMW||0||1
+2015-11-09 03:15:51.913855||error||visiting||google searchresults||5||1
+2015-11-09 03:15:51.920861||error||visiting||google searchresults||1||1
+2015-11-09 03:15:51.979216||error||visiting||google searchresults||0||1
+2015-11-09 03:15:57.036458||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 03:15:59.777230||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 03:16:03.234023||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 03:16:06.978139||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 03:16:09.811521||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 03:16:09.872226||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 03:16:14.323056||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 03:16:15.649251||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 03:16:20.697935||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 03:16:21.735026||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 03:16:23.619485||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 03:16:23.659774||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 03:16:24.366916||error||visiting||google searchresults||3||0
+2015-11-09 03:16:25.683138||error||visiting||google searchresults||4||0
+2015-11-09 03:16:30.731082||error||visiting||google searchresults||2||0
+2015-11-09 03:16:38.994280||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLXExbHzgskCFUgvgQod-r4Cfw||3||0
+2015-11-09 03:16:40.061727||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CPPglbLzgskCFYY9gQodPk0Okw||4||0
+2015-11-09 03:16:41.841583||error||visiting||google searchresults||0||1
+2015-11-09 03:16:43.665173||error||visiting||google searchresults||1||1
+2015-11-09 03:16:43.699409||error||visiting||google searchresults||5||1
+2015-11-09 03:16:45.093801||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CKmGyrTzgskCFUs8gQodYHoPqw||2||0
+2015-11-09 03:16:50.643302||treatment||google search||BMW dealer||3||0
+2015-11-09 03:16:51.597381||error||visiting||google searchresults||3||0
+2015-11-09 03:16:51.913458||treatment||google search||BMW dealer||4||0
+2015-11-09 03:16:52.619059||error||visiting||google searchresults||4||0
+2015-11-09 03:16:55.086352||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CKes87nzgskCFUo6gQodotYFog||0||1
+2015-11-09 03:16:57.002001||treatment||google search||BMW dealer||2||0
+2015-11-09 03:16:57.527338||error||visiting||google searchresults||2||0
+2015-11-09 03:16:57.881597||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLK74LrzgskCFVUlgQodJdoD7Q||1||1
+2015-11-09 03:16:57.906613||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CITa4rrzgskCFY49gQodmmkLMA||5||1
+2015-11-09 03:17:07.514333||treatment||google search||BMW dealer||0||1
+2015-11-09 03:17:10.112555||treatment||visit page||http://www.carsense.com/?gclid=CNTnwL7zgskCFRMjgQodg40D8w||3||0
+2015-11-09 03:17:12.254956||treatment||google search||BMW dealer||1||1
+2015-11-09 03:17:12.841363||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLemgL_zgskCFU47gQod-GIG7g||4||0
+2015-11-09 03:17:13.170868||treatment||google search||BMW dealer||5||1
+2015-11-09 03:17:17.135033||treatment||visit page||http://www.carsense.com/?gclid=CMTYq8HzgskCFdgYgQody_wFDQ||2||0
+2015-11-09 03:17:19.693131||error||visiting||google searchresults||0||1
+2015-11-09 03:17:23.136476||error||visiting||google searchresults||1||1
+2015-11-09 03:17:24.077252||error||visiting||google searchresults||5||1
+2015-11-09 03:17:25.428279||treatment||visit page||http://www.carsense.com/?gclid=CPrcq8fzgskCFYcbgQodIbkOIw||3||0
+2015-11-09 03:17:28.133575||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJXS0cjzgskCFVIbgQodFFQFtw||4||0
+2015-11-09 03:17:32.713753||treatment||visit page||http://www.carsense.com/?gclid=CI2m2MrzgskCFdcYgQodr0oJqg||2||0
+2015-11-09 03:17:35.486267||error||visiting||google searchresults||3||0
+2015-11-09 03:17:37.306673||treatment||visit page||http://www.carsense.com/?gclid=CMqM9cvzgskCFZM2gQodqtgP5w||0||1
+2015-11-09 03:17:37.542453||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLfeg87zgskCFU82gQodctkLuw||5||1
+2015-11-09 03:17:38.202548||error||visiting||google searchresults||4||0
+2015-11-09 03:17:41.520568||treatment||visit page||http://www.carsense.com/?gclid=CKWrx83zgskCFZAkgQodbqcDvw||1||1
+2015-11-09 03:17:42.772732||error||visiting||google searchresults||2||0
+2015-11-09 03:17:51.505173||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807577?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=COO9t9PzgskCFUU7gQodHnMD0w||3||0
+2015-11-09 03:17:54.849470||treatment||visit page||http://www.carsense.com/?gclid=CIa3qNTzgskCFRc6gQodS7sPmw||0||1
+2015-11-09 03:17:56.384289||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJfSt9TzgskCFRc6gQodS7sPmw||5||1
+2015-11-09 03:17:57.122875||treatment||visit page||http://www.carsense.com/?gclid=CPWG39TzgskCFU47gQod-GIG7g||4||0
+2015-11-09 03:17:57.830354||treatment||visit page||http://www.carsense.com/?gclid=CKH-rNbzgskCFZUlgQodkSENrQ||1||1
+2015-11-09 03:17:58.706099||treatment||visit page||http://www.usautomart.com/?gclid=CJ2j9tbzgskCFRc6gQodS7sPmw||2||0
+2015-11-09 03:18:03.128392||treatment||google search||BMW||3||0
+2015-11-09 03:18:04.018217||error||visiting||google searchresults||3||0
+2015-11-09 03:18:08.696869||treatment||google search||BMW||4||0
+2015-11-09 03:18:09.591493||error||visiting||google searchresults||4||0
+2015-11-09 03:18:10.293157||treatment||google search||BMW||2||0
+2015-11-09 03:18:11.254745||error||visiting||google searchresults||2||0
+2015-11-09 03:18:14.892137||error||visiting||google searchresults||0||1
+2015-11-09 03:18:16.429889||error||visiting||google searchresults||5||1
+2015-11-09 03:18:17.902245||error||visiting||google searchresults||1||1
+2015-11-09 03:18:22.675768||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 03:18:29.521229||treatment||visit page||http://www.usautomart.com/?gclid=CITEoubzgskCFYw7gQodfJMA8Q||0||1
+2015-11-09 03:18:31.197422||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 03:18:31.263008||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:18:31.740643||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807577?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CNKj2-fzgskCFdgLgQodEQEH0g||1||1
+2015-11-09 03:18:35.103438||treatment||visit page||http://www.carsense.com/?gclid=CNCeg-fzgskCFdcegQodlEsN8w||5||1
+2015-11-09 03:18:36.416620||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 03:18:41.536302||treatment||google search||BMW||0||1
+2015-11-09 03:18:44.642054||treatment||google search||BMW||1||1
+2015-11-09 03:18:46.445068||error||visiting||google searchresults||3||0
+2015-11-09 03:18:47.049674||treatment||google search||BMW||5||1
+2015-11-09 03:18:48.448443||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:18:48.624765||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 03:18:53.964189||error||visiting||google searchresults||0||1
+2015-11-09 03:18:55.823739||error||visiting||google searchresults||1||1
+2015-11-09 03:18:58.033193||error||visiting||google searchresults||5||1
+2015-11-09 03:18:58.487222||error||visiting||google searchresults||4||0
+2015-11-09 03:18:58.665354||error||visiting||google searchresults||2||0
+2015-11-09 03:19:03.542471||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 03:19:13.543317||event||progress-marker||training-end||3||0
+2015-11-09 03:19:21.236813||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 03:19:21.338125||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 03:19:23.198660||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 03:19:23.867219||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 03:19:25.086694||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:19:31.238670||event||progress-marker||training-end||2||0
+2015-11-09 03:19:33.199896||event||progress-marker||training-end||4||0
+2015-11-09 03:19:36.989461||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 03:19:38.985174||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:19:41.304752||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 03:19:57.055441||error||visiting||google searchresults||5||1
+2015-11-09 03:19:59.054238||error||visiting||google searchresults||0||1
+2015-11-09 03:20:01.356794||error||visiting||google searchresults||1||1
+2015-11-09 03:20:13.698423||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 03:20:15.911910||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 03:20:16.235466||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 03:20:23.700333||event||progress-marker||training-end||0||1
+2015-11-09 03:20:25.913718||event||progress-marker||training-end||5||1
+2015-11-09 03:20:26.236562||event||progress-marker||training-end||1||1
+2015-11-09 03:20:26.329985||event||progress-marker||measurement-start||2||0
+2015-11-09 03:20:28.292138||event||progress-marker||measurement-start||4||0
+2015-11-09 03:20:28.669417||event||progress-marker||measurement-start||3||0
+2015-11-09 03:20:28.715231||event||progress-marker||measurement-start||0||1
+2015-11-09 03:20:30.927446||event||progress-marker||measurement-start||5||1
+2015-11-09 03:20:31.251234||event||progress-marker||measurement-start||1||1
+2015-11-09 03:21:21.535183||measurement||ad||2015-11-09 03:20:54.882492@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:21:23.015572||measurement||ad||2015-11-09 03:21:21.255553@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:21:23.264957||measurement||ad||2015-11-09 03:21:21.255553@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:21:23.283943||measurement||loadtime||0:00:49.568075||0||1
+2015-11-09 03:21:23.470176||measurement||ad||2015-11-09 03:20:54.882492@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||2||0
+2015-11-09 03:21:23.641636||measurement||loadtime||0:00:52.310739||2||0
+2015-11-09 03:21:24.542487||measurement||ad||2015-11-09 03:21:23.078909@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 03:21:25.415358||measurement||ad||2015-11-09 03:21:23.078909@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:21:25.448552||measurement||ad||2015-11-09 03:21:07.204246@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 03:21:25.532733||measurement||loadtime||0:00:49.602709||5||1
+2015-11-09 03:21:26.857105||measurement||ad||2015-11-09 03:21:07.204246@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:21:26.877726||measurement||loadtime||0:00:53.584061||4||0
+2015-11-09 03:21:40.956038||measurement||ad||2015-11-09 03:21:40.376480@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:21:41.199573||measurement||ad||2015-11-09 03:21:40.376480@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 03:21:41.223966||measurement||loadtime||0:01:04.971655||1||1
+2015-11-09 03:21:56.750895||measurement||ad||2015-11-09 03:21:56.063036@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||0||1
+2015-11-09 03:21:56.925618||measurement||ad||2015-11-09 03:21:56.063036@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:21:57.015400||measurement||loadtime||0:00:28.730681||0||1
+2015-11-09 03:22:01.337871||measurement||ad||2015-11-09 03:22:00.898690@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 03:22:01.639118||measurement||ad||2015-11-09 03:22:00.898690@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:22:01.650996||measurement||loadtime||0:00:31.117414||5||1
+2015-11-09 03:22:06.997687||measurement||ad||2015-11-09 03:21:57.536585@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 03:22:07.570349||measurement||ad||2015-11-09 03:21:57.758044@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:22:07.937789||measurement||ad||2015-11-09 03:21:57.536585@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:22:07.942203||measurement||loadtime||0:00:36.063625||4||0
+2015-11-09 03:22:08.397488||measurement||ad||2015-11-09 03:21:57.758044@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 03:22:08.404827||measurement||loadtime||0:00:39.762600||2||0
+2015-11-09 03:22:08.953617||measurement||ad||2015-11-09 03:21:19.790821@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:22:16.583169||measurement||ad||2015-11-09 03:22:16.094777@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 03:22:16.857488||measurement||ad||2015-11-09 03:22:16.094777@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 03:22:16.889034||measurement||loadtime||0:00:30.661781||1||1
+2015-11-09 03:22:20.898263||measurement||ad||2015-11-09 03:21:19.790821@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:22:20.945287||measurement||loadtime||0:01:47.274334||3||0
+2015-11-09 03:22:31.282909||measurement||ad||2015-11-09 03:22:29.246326@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:22:31.808629||measurement||ad||2015-11-09 03:22:29.246326@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:22:31.864188||measurement||loadtime||0:00:29.848054||0||1
+2015-11-09 03:22:36.527867||measurement||ad||2015-11-09 03:22:34.454941@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||5||1
+2015-11-09 03:22:37.301393||measurement||ad||2015-11-09 03:22:34.454941@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:22:37.414895||measurement||loadtime||0:00:30.763339||5||1
+2015-11-09 03:22:49.901775||measurement||ad||2015-11-09 03:22:49.507973@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:22:50.266871||measurement||ad||2015-11-09 03:22:49.507973@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 03:22:50.446521||measurement||loadtime||0:00:28.556839||1||1
+2015-11-09 03:22:50.558654||measurement||ad||2015-11-09 03:22:39.755468@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:22:51.117956||measurement||ad||2015-11-09 03:22:39.755468@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:22:51.135717||measurement||loadtime||0:00:38.192331||4||0
+2015-11-09 03:23:02.159073||measurement||ad||2015-11-09 03:22:42.343031@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:23:03.683076||measurement||ad||2015-11-09 03:22:42.343031@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 03:23:03.765408||measurement||loadtime||0:00:50.359925||2||0
+2015-11-09 03:23:17.507425||measurement||ad||2015-11-09 03:23:15.684415@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||1
+2015-11-09 03:23:18.181353||measurement||ad||2015-11-09 03:23:15.684415@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:23:18.457796||measurement||ad||2015-11-09 03:23:16.220295@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||0||1
+2015-11-09 03:23:18.879608||measurement||loadtime||0:00:36.461954||5||1
+2015-11-09 03:23:20.109620||measurement||ad||2015-11-09 03:23:16.220295@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:23:20.339564||measurement||loadtime||0:00:43.474616||0||1
+2015-11-09 03:23:20.485844||measurement||ad||2015-11-09 03:23:05.312626@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:23:24.261841||measurement||ad||2015-11-09 03:23:23.459288@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 03:23:24.481391||measurement||ad||2015-11-09 03:23:23.459288@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 03:23:24.496697||measurement||loadtime||0:00:29.047227||1||1
+2015-11-09 03:23:24.653284||measurement||ad||2015-11-09 03:23:05.312626@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:23:24.667328||measurement||loadtime||0:00:58.720783||3||0
+2015-11-09 03:23:38.533849||measurement||ad||2015-11-09 03:23:29.777497@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:23:39.803763||measurement||ad||2015-11-09 03:23:29.777497@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:23:39.830722||measurement||loadtime||0:00:43.693547||4||0
+2015-11-09 03:23:45.755932||measurement||ad||2015-11-09 03:23:37.274758@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:23:46.786033||measurement||ad||2015-11-09 03:23:37.274758@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 03:23:46.992727||measurement||loadtime||0:00:38.225992||2||0
+2015-11-09 03:23:51.540246||measurement||ad||2015-11-09 03:23:51.073748@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||5||1
+2015-11-09 03:23:51.828085||measurement||ad||2015-11-09 03:23:51.073748@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:23:51.861926||measurement||loadtime||0:00:27.980704||5||1
+2015-11-09 03:23:54.346653||measurement||ad||2015-11-09 03:23:53.973537@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:23:54.532694||measurement||ad||2015-11-09 03:23:53.973537@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 03:23:54.545024||measurement||loadtime||0:00:25.047540||1||1
+2015-11-09 03:23:54.790358||measurement||ad||2015-11-09 03:23:54.155545@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||1
+2015-11-09 03:23:55.172723||measurement||ad||2015-11-09 03:23:54.155545@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:23:55.223017||measurement||loadtime||0:00:29.882809||0||1
+2015-11-09 03:24:02.900510||measurement||ad||2015-11-09 03:23:55.566141@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:24:03.174538||measurement||ad||2015-11-09 03:23:55.566141@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:24:03.180105||measurement||loadtime||0:00:33.511273||3||0
+2015-11-09 03:24:18.129688||measurement||ad||2015-11-09 03:24:09.381035@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:24:18.623892||measurement||ad||2015-11-09 03:24:09.381035@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:24:18.728858||measurement||loadtime||0:00:33.896655||4||0
+2015-11-09 03:24:22.010630||measurement||ad||2015-11-09 03:24:14.358341@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:24:22.117716||measurement||ad||2015-11-09 03:24:14.358341@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 03:24:22.122154||measurement||loadtime||0:00:30.129017||2||0
+2015-11-09 03:24:22.697588||measurement||ad||2015-11-09 03:24:22.369973@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:24:22.771888||measurement||ad||2015-11-09 03:24:22.369973@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:24:22.784013||measurement||loadtime||0:00:25.921357||5||1
+2015-11-09 03:24:25.417031||measurement||ad||2015-11-09 03:24:25.224420@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 03:24:25.474664||measurement||ad||2015-11-09 03:24:25.224420@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:24:25.485123||measurement||loadtime||0:00:25.261499||0||1
+2015-11-09 03:24:26.692213||measurement||ad||2015-11-09 03:24:26.388079@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||1||1
+2015-11-09 03:24:26.795221||measurement||ad||2015-11-09 03:24:26.388079@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 03:24:26.814317||measurement||loadtime||0:00:27.267778||1||1
+2015-11-09 03:24:53.896943||measurement||ad||2015-11-09 03:24:43.746099@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:24:54.534825||measurement||ad||2015-11-09 03:24:43.746099@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:24:54.548276||measurement||loadtime||0:00:46.367464||3||0
+2015-11-09 03:24:55.947490||measurement||ad||2015-11-09 03:24:48.174022@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:24:56.086921||measurement||ad||2015-11-09 03:24:48.174022@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:24:56.091499||measurement||loadtime||0:00:32.362024||4||0
+2015-11-09 03:24:57.431048||measurement||ad||2015-11-09 03:24:56.810966@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:24:57.527928||measurement||ad||2015-11-09 03:24:56.810966@|AncestryDNA ™ Test@|ancestry.com/DNA@|Discover Your Ethnicity w/ Just One Test From The Comfort of Home.||1||1
+2015-11-09 03:24:57.537527||measurement||loadtime||0:00:25.722644||1||1
+2015-11-09 03:24:57.817830||measurement||ad||2015-11-09 03:24:57.330771@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:24:57.887816||measurement||ad||2015-11-09 03:24:57.330771@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:24:57.912504||measurement||loadtime||0:00:30.127535||5||1
+2015-11-09 03:25:02.419585||measurement||ad||2015-11-09 03:24:59.940734@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:25:02.684725||measurement||ad||2015-11-09 03:24:59.940734@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:25:02.697972||measurement||loadtime||0:00:32.211137||0||1
+2015-11-09 03:25:27.292949||error||collecting ads||Error||2||0
+2015-11-09 03:25:30.432293||measurement||ad||2015-11-09 03:25:30.185244@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:25:30.530052||measurement||ad||2015-11-09 03:25:30.185244@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||1||1
+2015-11-09 03:25:30.545094||measurement||loadtime||0:00:28.007074||1||1
+2015-11-09 03:25:35.002613||measurement||ad||2015-11-09 03:25:28.174451@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:25:35.355101||measurement||ad||2015-11-09 03:25:28.174451@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:25:35.369569||measurement||loadtime||0:00:34.277043||4||0
+2015-11-09 03:25:36.126490||measurement||ad||2015-11-09 03:25:35.208312@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:25:36.363137||measurement||ad||2015-11-09 03:25:35.208312@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:25:36.435060||measurement||loadtime||0:00:33.521153||5||1
+2015-11-09 03:25:38.319597||measurement||ad||2015-11-09 03:25:31.321634@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:25:38.482559||measurement||ad||2015-11-09 03:25:31.321634@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:25:38.487577||measurement||loadtime||0:00:38.938700||3||0
+2015-11-09 03:25:44.580321||measurement||ad||2015-11-09 03:25:43.848118@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||0||1
+2015-11-09 03:25:44.670098||measurement||ad||2015-11-09 03:25:43.848118@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:25:44.680249||measurement||loadtime||0:00:36.981004||0||1
+2015-11-09 03:25:57.777611||measurement||ad||2015-11-09 03:25:57.296137@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:25:57.938885||measurement||ad||2015-11-09 03:25:57.296137@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 03:25:57.954757||measurement||loadtime||0:00:22.407677||1||1
+2015-11-09 03:26:03.219438||measurement||ad||2015-11-09 03:25:54.647794@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:26:03.566579||measurement||ad||2015-11-09 03:25:54.647794@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:26:03.572138||measurement||loadtime||0:00:31.277686||2||0
+2015-11-09 03:26:08.266076||measurement||ad||2015-11-09 03:26:07.962035@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||5||1
+2015-11-09 03:26:08.458088||measurement||ad||2015-11-09 03:26:07.962035@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:26:08.488276||measurement||loadtime||0:00:27.049069||5||1
+2015-11-09 03:26:11.215896||measurement||ad||2015-11-09 03:26:03.419549@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:26:11.468248||measurement||ad||2015-11-09 03:26:03.419549@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:26:11.476620||measurement||loadtime||0:00:31.106233||4||0
+2015-11-09 03:26:18.507391||measurement||ad||2015-11-09 03:26:17.645717@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:26:18.668739||measurement||ad||2015-11-09 03:26:17.645717@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:26:18.853686||measurement||loadtime||0:00:29.172120||0||1
+2015-11-09 03:26:27.050211||measurement||ad||2015-11-09 03:26:26.161813@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 03:26:27.093301||measurement||ad||2015-11-09 03:26:15.446671@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:26:27.149055||measurement||ad||2015-11-09 03:26:26.161813@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 03:26:27.159338||measurement||loadtime||0:00:24.203344||1||1
+2015-11-09 03:26:27.162446||event||progress-marker||measurement-end||1||1
+2015-11-09 03:26:27.919690||measurement||ad||2015-11-09 03:26:15.446671@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:26:27.925927||measurement||loadtime||0:00:44.437267||3||0
+2015-11-09 03:26:41.819744||measurement||ad||2015-11-09 03:26:34.452514@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:26:41.983404||measurement||ad||2015-11-09 03:26:34.452514@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:26:41.991106||measurement||loadtime||0:00:33.418173||2||0
+2015-11-09 03:26:45.475943||measurement||ad||2015-11-09 03:26:44.695158@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:26:45.730936||measurement||ad||2015-11-09 03:26:44.695158@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||1
+2015-11-09 03:26:45.743222||measurement||loadtime||0:00:32.253861||5||1
+2015-11-09 03:26:45.744053||event||progress-marker||measurement-end||5||1
+2015-11-09 03:26:48.049852||measurement||ad||2015-11-09 03:26:42.113214@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:26:48.197346||measurement||ad||2015-11-09 03:26:42.113214@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:26:48.202375||measurement||loadtime||0:00:31.724846||4||0
+2015-11-09 03:26:53.432720||measurement||ad||2015-11-09 03:26:53.172263@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 03:26:53.490162||measurement||ad||2015-11-09 03:26:53.172263@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:26:53.499419||measurement||loadtime||0:00:29.644632||0||1
+2015-11-09 03:26:53.499736||event||progress-marker||measurement-end||0||1
+2015-11-09 03:26:58.593273||measurement||ad||2015-11-09 03:26:54.744934@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:26:58.688402||measurement||ad||2015-11-09 03:26:54.744934@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:26:58.691875||measurement||loadtime||0:00:25.764506||3||0
+2015-11-09 03:27:06.410830||measurement||ad||2015-11-09 03:27:03.287482@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:27:06.510935||measurement||ad||2015-11-09 03:27:03.287482@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 03:27:06.515632||measurement||loadtime||0:00:19.524081||2||0
+2015-11-09 03:27:15.248047||measurement||ad||2015-11-09 03:27:11.542728@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 03:27:15.349092||measurement||ad||2015-11-09 03:27:11.542728@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||4||0
+2015-11-09 03:27:15.353955||measurement||loadtime||0:00:22.150131||4||0
+2015-11-09 03:27:15.354191||event||progress-marker||measurement-end||4||0
+2015-11-09 03:27:23.134068||measurement||ad||2015-11-09 03:27:20.302177@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:27:23.230810||measurement||ad||2015-11-09 03:27:20.302177@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:27:23.239239||measurement||loadtime||0:00:19.545549||3||0
+2015-11-09 03:27:30.033222||measurement||ad||2015-11-09 03:27:27.972769@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 03:27:30.102661||measurement||ad||2015-11-09 03:27:27.972769@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:27:30.106375||measurement||loadtime||0:00:18.589746||2||0
+2015-11-09 03:27:30.106773||event||progress-marker||measurement-end||2||0
+2015-11-09 03:27:47.502001||measurement||ad||2015-11-09 03:27:45.341825@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:27:47.564787||measurement||ad||2015-11-09 03:27:45.341825@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:27:47.683063||measurement||loadtime||0:00:19.442365||3||0
+2015-11-09 03:28:10.541748||measurement||ad||2015-11-09 03:28:08.462021@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 03:28:10.654841||measurement||ad||2015-11-09 03:28:08.462021@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:28:10.760368||measurement||loadtime||0:00:18.075191||3||0
+2015-11-09 03:28:10.760684||event||progress-marker||measurement-end||3||0
+2015-11-09 03:28:11.328568||meta||block_id end||4
+2015-11-09 03:28:11.331177||meta||block_id start||5
+2015-11-09 03:28:11.331350||meta||assignment||4@|3@|2@|5@|0@|1
+2015-11-09 03:28:13.519780||event||progress-marker||training-start||2||0
+2015-11-09 03:28:13.662893||event||progress-marker||training-start||4||0
+2015-11-09 03:28:14.592213||event||progress-marker||training-start||3||0
+2015-11-09 03:28:18.406303||treatment||google search||Buy BMW||2||0
+2015-11-09 03:28:18.677014||treatment||google search||Buy BMW||4||0
+2015-11-09 03:28:19.093904||treatment||google search||Buy BMW||3||0
+2015-11-09 03:28:19.175946||event||progress-marker||training-start||0||1
+2015-11-09 03:28:19.287797||event||progress-marker||training-start||5||1
+2015-11-09 03:28:19.690257||error||visiting||google searchresults||2||0
+2015-11-09 03:28:19.699669||event||progress-marker||training-start||1||1
+2015-11-09 03:28:20.021795||error||visiting||google searchresults||4||0
+2015-11-09 03:28:20.442337||error||visiting||google searchresults||3||0
+2015-11-09 03:28:24.117539||treatment||google search||Buy BMW||0||1
+2015-11-09 03:28:24.135080||treatment||google search||Buy BMW||5||1
+2015-11-09 03:28:24.166314||treatment||google search||Buy BMW||1||1
+2015-11-09 03:28:34.919370||error||visiting||google searchresults||5||1
+2015-11-09 03:28:34.971713||error||visiting||google searchresults||0||1
+2015-11-09 03:28:35.188760||error||visiting||google searchresults||1||1
+2015-11-09 03:28:39.823975||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 03:28:40.286056||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 03:28:40.799213||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 03:28:52.650511||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 03:28:52.868006||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 03:28:55.005040||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 03:28:59.699665||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 03:29:00.228352||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 03:29:02.471019||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 03:29:06.275502||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 03:29:06.390726||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 03:29:08.599733||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 03:29:09.726545||error||visiting||google searchresults||3||0
+2015-11-09 03:29:10.263313||error||visiting||google searchresults||2||0
+2015-11-09 03:29:12.502182||error||visiting||google searchresults||4||0
+2015-11-09 03:29:24.152562||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJ70wJ72gskCFYkjgQodPiQO3A||3||0
+2015-11-09 03:29:24.572239||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CIXc4J72gskCFVY9gQodhJwOrg||2||0
+2015-11-09 03:29:26.371115||error||visiting||google searchresults||1||1
+2015-11-09 03:29:26.447426||error||visiting||google searchresults||0||1
+2015-11-09 03:29:26.639285||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLW_6Z_2gskCFUgvgQod-r4Cfw||4||0
+2015-11-09 03:29:28.638396||error||visiting||google searchresults||5||1
+2015-11-09 03:29:35.736805||treatment||google search||BMW dealer||3||0
+2015-11-09 03:29:36.370153||treatment||google search||BMW dealer||2||0
+2015-11-09 03:29:36.376661||error||visiting||google searchresults||3||0
+2015-11-09 03:29:37.406089||error||visiting||google searchresults||2||0
+2015-11-09 03:29:38.163653||treatment||google search||BMW dealer||4||0
+2015-11-09 03:29:39.049362||error||visiting||google searchresults||4||0
+2015-11-09 03:29:39.559096||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CIWTvKb2gskCFdgGgQodtJYOGQ||1||1
+2015-11-09 03:29:39.821280||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=COT5wab2gskCFdgOgQod3CYEoQ||0||1
+2015-11-09 03:29:42.873756||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLSow6f2gskCFYc7gQod-Q0MzA||5||1
+2015-11-09 03:29:55.189326||treatment||google search||BMW dealer||1||1
+2015-11-09 03:29:56.639807||treatment||google search||BMW dealer||0||1
+2015-11-09 03:29:57.162322||treatment||google search||BMW dealer||5||1
+2015-11-09 03:29:59.506676||treatment||visit page||http://www.carsense.com/?gclid=CN6qvKz2gskCFdgcgQodPBMC0w||4||0
+2015-11-09 03:30:06.654900||error||visiting||google searchresults||1||1
+2015-11-09 03:30:07.545280||error||visiting||google searchresults||0||1
+2015-11-09 03:30:08.153807||error||visiting||google searchresults||5||1
+2015-11-09 03:30:14.868765||treatment||visit page||http://www.carsense.com/?gclid=CMeYm7b2gskCFUkvgQod1qsDVQ||4||0
+2015-11-09 03:30:21.723853||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNbkiLr2gskCFdgBgQodMekJLw||0||1
+2015-11-09 03:30:22.849618||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIHgt7r2gskCFZMvgQodgGcBow||5||1
+2015-11-09 03:30:24.900054||error||visiting||google searchresults||4||0
+2015-11-09 03:30:25.174556||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CM3l0Ln2gskCFZM2gQodqtgP5w||1||1
+2015-11-09 03:30:26.423659||error||visiting||google searchresults||3||0
+2015-11-09 03:30:27.460946||error||visiting||google searchresults||2||0
+2015-11-09 03:30:39.915021||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CM_b6MD2gskCFZAkgQodbqcDvw||0||1
+2015-11-09 03:30:41.690247||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COr9rcH2gskCFdgIgQodts4DTw||5||1
+2015-11-09 03:30:41.705133||treatment||visit page||http://www.usautomart.com/?gclid=CICTq8L2gskCFdgOgQod3CYEoQ||4||0
+2015-11-09 03:30:42.353616||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJCkv8L2gskCFUU7gQodHnMD0w||1||1
+2015-11-09 03:30:46.485143||error||visiting||google searchresults||3||0
+2015-11-09 03:30:47.479980||error||visiting||google searchresults||2||0
+2015-11-09 03:30:53.345309||treatment||google search||BMW||4||0
+2015-11-09 03:30:54.317121||error||visiting||google searchresults||4||0
+2015-11-09 03:30:59.952056||error||visiting||google searchresults||0||1
+2015-11-09 03:31:01.736166||error||visiting||google searchresults||5||1
+2015-11-09 03:31:02.403542||error||visiting||google searchresults||1||1
+2015-11-09 03:31:06.504380||error||visiting||google searchresults||3||0
+2015-11-09 03:31:07.490322||error||visiting||google searchresults||2||0
+2015-11-09 03:31:11.151145||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||4||0
+2015-11-09 03:31:18.750579||treatment||visit page||http://www.carsense.com/?gclid=CPPZ89P2gskCFdgTgQodJKoCGw||5||1
+2015-11-09 03:31:19.020982||treatment||visit page||http://www.carsense.com/?gclid=CJzfodT2gskCFRMjgQodg40D8w||1||1
+2015-11-09 03:31:26.528922||error||visiting||google searchresults||3||0
+2015-11-09 03:31:26.584265||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||4||0
+2015-11-09 03:31:27.521342||error||visiting||google searchresults||2||0
+2015-11-09 03:31:30.856707||treatment||google search||BMW||5||1
+2015-11-09 03:31:31.335259||treatment||google search||BMW||1||1
+2015-11-09 03:31:36.622710||error||visiting||google searchresults||4||0
+2015-11-09 03:31:42.107742||error||visiting||google searchresults||5||1
+2015-11-09 03:31:42.944573||error||visiting||google searchresults||1||1
+2015-11-09 03:31:46.580851||error||visiting||google searchresults||3||0
+2015-11-09 03:31:47.546176||error||visiting||google searchresults||2||0
+2015-11-09 03:31:49.984146||error||visiting||google searchresults||0||1
+2015-11-09 03:31:56.785978||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 03:31:58.048658||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||1||1
+2015-11-09 03:31:59.493074||treatment||google search||BMW||3||0
+2015-11-09 03:32:00.098125||treatment||google search||BMW||2||0
+2015-11-09 03:32:00.571841||error||visiting||google searchresults||3||0
+2015-11-09 03:32:00.867853||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||5||1
+2015-11-09 03:32:01.289019||error||visiting||google searchresults||2||0
+2015-11-09 03:32:06.787080||event||progress-marker||training-end||4||0
+2015-11-09 03:32:14.625801||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||1||1
+2015-11-09 03:32:15.961870||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||5||1
+2015-11-09 03:32:21.391977||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 03:32:21.559077||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 03:32:34.746273||error||visiting||google searchresults||1||1
+2015-11-09 03:32:36.049280||error||visiting||google searchresults||5||1
+2015-11-09 03:32:38.005791||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 03:32:38.486277||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 03:32:48.060605||error||visiting||google searchresults||3||0
+2015-11-09 03:32:48.545607||error||visiting||google searchresults||2||0
+2015-11-09 03:32:48.756014||error||visiting||google searchresults||0||1
+2015-11-09 03:32:51.578870||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 03:32:55.329305||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 03:33:01.579742||event||progress-marker||training-end||5||1
+2015-11-09 03:33:05.331310||event||progress-marker||training-end||1||1
+2015-11-09 03:33:07.254005||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 03:33:07.973561||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 03:33:08.769533||error||visiting||google searchresults||0||1
+2015-11-09 03:33:17.255487||event||progress-marker||training-end||3||0
+2015-11-09 03:33:17.974363||event||progress-marker||training-end||2||0
+2015-11-09 03:33:28.795715||error||visiting||google searchresults||0||1
+2015-11-09 03:33:48.808928||error||visiting||google searchresults||0||1
+2015-11-09 03:34:00.490112||treatment||google search||BMW||0||1
+2015-11-09 03:34:11.665088||error||visiting||google searchresults||0||1
+2015-11-09 03:34:31.046538||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:34:46.673815||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:35:06.805224||error||visiting||google searchresults||0||1
+2015-11-09 03:35:23.852501||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 03:35:33.854281||event||progress-marker||training-end||0||1
+2015-11-09 03:35:35.592748||event||progress-marker||measurement-start||1||1
+2015-11-09 03:35:36.841358||event||progress-marker||measurement-start||5||1
+2015-11-09 03:35:37.165183||event||progress-marker||measurement-start||4||0
+2015-11-09 03:35:37.494450||event||progress-marker||measurement-start||3||0
+2015-11-09 03:35:38.220601||event||progress-marker||measurement-start||2||0
+2015-11-09 03:35:38.869333||event||progress-marker||measurement-start||0||1
+2015-11-09 03:35:59.531175||measurement||ad||2015-11-09 03:35:58.853775@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-09 03:35:59.745394||measurement||ad||2015-11-09 03:35:58.853775@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:35:59.760540||measurement||loadtime||0:00:19.166060||1||1
+2015-11-09 03:36:28.169499||measurement||ad||2015-11-09 03:36:12.253723@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:36:29.135395||measurement||ad||2015-11-09 03:36:26.395108@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||1
+2015-11-09 03:36:29.490578||measurement||ad||2015-11-09 03:36:12.253723@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||0
+2015-11-09 03:36:29.523984||measurement||loadtime||0:00:47.028900||3||0
+2015-11-09 03:36:29.587351||measurement||ad||2015-11-09 03:36:26.395108@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 03:36:29.625258||measurement||loadtime||0:00:45.754968||0||1
+2015-11-09 03:36:35.575585||measurement||ad||2015-11-09 03:36:32.062567@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:36:35.803304||measurement||ad||2015-11-09 03:36:19.760808@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||2||0
+2015-11-09 03:36:36.132682||measurement||ad||2015-11-09 03:36:32.062567@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 03:36:36.235864||measurement||loadtime||0:00:54.392990||5||1
+2015-11-09 03:36:36.605512||measurement||ad||2015-11-09 03:36:19.760808@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 03:36:36.675792||measurement||loadtime||0:00:53.454562||2||0
+2015-11-09 03:36:40.159920||measurement||ad||2015-11-09 03:36:39.574724@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-09 03:36:40.346605||measurement||ad||2015-11-09 03:36:39.574724@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:36:40.482066||measurement||loadtime||0:00:35.719615||1||1
+2015-11-09 03:36:49.424977||measurement||ad||2015-11-09 03:36:20.957091@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 03:36:53.494699||measurement||ad||2015-11-09 03:36:20.957091@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 03:36:54.035046||measurement||loadtime||0:01:11.868321||4||0
+2015-11-09 03:37:04.514159||measurement||ad||2015-11-09 03:37:03.993061@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:37:04.766908||measurement||ad||2015-11-09 03:37:03.993061@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:37:04.843699||measurement||loadtime||0:00:30.217394||0||1
+2015-11-09 03:37:12.587055||measurement||ad||2015-11-09 03:37:05.918671@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 03:37:12.882185||measurement||ad||2015-11-09 03:37:05.918671@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:37:12.892908||measurement||loadtime||0:00:31.215563||2||0
+2015-11-09 03:37:18.058148||measurement||ad||2015-11-09 03:37:00.886839@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:37:20.032824||measurement||ad||2015-11-09 03:37:00.886839@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 03:37:20.124892||measurement||loadtime||0:00:45.600331||3||0
+2015-11-09 03:37:23.822007||measurement||ad||2015-11-09 03:37:20.820152@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 03:37:24.344503||measurement||ad||2015-11-09 03:37:20.820152@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:37:24.377986||measurement||loadtime||0:00:38.894609||1||1
+2015-11-09 03:37:26.088029||measurement||ad||2015-11-09 03:37:19.698804@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:37:28.172605||measurement||ad||2015-11-09 03:37:19.698804@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 03:37:28.194068||measurement||loadtime||0:00:46.957163||5||1
+2015-11-09 03:37:51.000016||measurement||ad||2015-11-09 03:37:49.365808@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||0||1
+2015-11-09 03:37:51.407250||measurement||ad||2015-11-09 03:37:49.365808@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 03:37:51.466825||measurement||loadtime||0:00:41.622559||0||1
+2015-11-09 03:37:53.302421||measurement||ad||2015-11-09 03:37:40.683418@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:37:53.970338||measurement||ad||2015-11-09 03:37:40.683418@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||2||0
+2015-11-09 03:37:54.007157||measurement||loadtime||0:00:36.113495||2||0
+2015-11-09 03:37:55.898567||measurement||ad||2015-11-09 03:37:27.425641@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 03:37:56.548090||measurement||ad||2015-11-09 03:37:27.425641@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 03:37:56.743904||measurement||loadtime||0:00:57.707995||4||0
+2015-11-09 03:38:00.418332||measurement||ad||2015-11-09 03:37:59.958000@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 03:38:00.667992||measurement||ad||2015-11-09 03:37:59.958000@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:38:00.683938||measurement||loadtime||0:00:31.304197||1||1
+2015-11-09 03:38:09.638201||measurement||ad||2015-11-09 03:37:53.862588@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:38:10.708101||measurement||ad||2015-11-09 03:37:53.862588@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 03:38:10.920735||measurement||loadtime||0:00:45.794214||3||0
+2015-11-09 03:38:16.564449||measurement||ad||2015-11-09 03:38:15.553526@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:38:16.929889||measurement||ad||2015-11-09 03:38:15.553526@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 03:38:17.137901||measurement||loadtime||0:00:43.943168||5||1
+2015-11-09 03:38:27.928809||measurement||ad||2015-11-09 03:38:26.071854@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||1
+2015-11-09 03:38:28.686820||measurement||ad||2015-11-09 03:38:26.071854@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||0||1
+2015-11-09 03:38:28.864239||measurement||loadtime||0:00:32.396383||0||1
+2015-11-09 03:38:34.116545||measurement||ad||2015-11-09 03:38:28.032859@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 03:38:34.398653||measurement||ad||2015-11-09 03:38:28.032859@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:38:34.406720||measurement||loadtime||0:00:35.398301||2||0
+2015-11-09 03:38:37.181838||measurement||ad||2015-11-09 03:38:36.632623@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:38:37.551224||measurement||ad||2015-11-09 03:38:36.632623@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 03:38:37.597320||measurement||loadtime||0:00:31.912725||1||1
+2015-11-09 03:38:53.090131||measurement||ad||2015-11-09 03:38:52.047837@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:38:53.197318||measurement||ad||2015-11-09 03:38:52.047837@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 03:38:53.220211||measurement||loadtime||0:00:31.081433||5||1
+2015-11-09 03:38:57.049630||measurement||ad||2015-11-09 03:38:47.720139@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:38:57.736572||measurement||ad||2015-11-09 03:38:47.720139@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 03:38:57.747640||measurement||loadtime||0:00:41.825460||3||0
+2015-11-09 03:39:02.325722||error||collecting ads||Error||4||0
+2015-11-09 03:39:02.668841||measurement||ad||2015-11-09 03:38:57.247138@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||2||0
+2015-11-09 03:39:03.029631||measurement||ad||2015-11-09 03:38:57.247138@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:39:03.044565||measurement||loadtime||0:00:23.635787||2||0
+2015-11-09 03:39:05.394459||measurement||ad||2015-11-09 03:39:04.415136@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 03:39:05.960385||measurement||ad||2015-11-09 03:39:04.415136@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:39:05.985892||measurement||loadtime||0:00:32.119348||0||1
+2015-11-09 03:39:14.580216||measurement||ad||2015-11-09 03:39:13.752919@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-09 03:39:14.832107||measurement||ad||2015-11-09 03:39:13.752919@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 03:39:14.895380||measurement||loadtime||0:00:32.297546||1||1
+2015-11-09 03:39:26.433225||measurement||ad||2015-11-09 03:39:26.106675@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:39:26.581195||measurement||ad||2015-11-09 03:39:26.106675@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 03:39:26.596854||measurement||loadtime||0:00:28.375517||5||1
+2015-11-09 03:39:33.530717||measurement||ad||2015-11-09 03:39:28.344341@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 03:39:33.661230||measurement||ad||2015-11-09 03:39:28.344341@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||2||0
+2015-11-09 03:39:33.670663||measurement||loadtime||0:00:25.625229||2||0
+2015-11-09 03:39:36.696594||measurement||ad||2015-11-09 03:39:27.992627@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:39:37.114201||measurement||ad||2015-11-09 03:39:27.992627@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 03:39:37.125883||measurement||loadtime||0:00:34.377522||3||0
+2015-11-09 03:39:37.432752||measurement||ad||2015-11-09 03:39:37.071683@|Want Rapid Weight Loss?@|thyroid-weight-loss.com@|Power-Boost Your Metabolism With A A Simple Thyroid Fix! Learn More.||0||1
+2015-11-09 03:39:37.534575||measurement||ad||2015-11-09 03:39:37.071683@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 03:39:37.552219||measurement||loadtime||0:00:26.565618||0||1
+2015-11-09 03:39:48.555443||measurement||ad||2015-11-09 03:39:47.827590@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||1||1
+2015-11-09 03:39:48.706850||measurement||ad||2015-11-09 03:39:47.827590@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:39:48.735486||measurement||loadtime||0:00:28.839477||1||1
+2015-11-09 03:39:53.054019||measurement||ad||2015-11-09 03:39:45.390723@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 03:39:53.454742||measurement||ad||2015-11-09 03:39:45.390723@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 03:39:53.502274||measurement||loadtime||0:00:46.174888||4||0
+2015-11-09 03:39:59.659149||measurement||ad||2015-11-09 03:39:59.173566@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:39:59.773006||measurement||ad||2015-11-09 03:39:59.173566@|Auto Insurance Quote Sale@|shopperstop.us/Insurance@|Top 2015 Daily Deals! Find Auto Insurance Quote  Save||5||1
+2015-11-09 03:39:59.792964||measurement||loadtime||0:00:28.195195||5||1
+2015-11-09 03:40:01.163703||measurement||ad||2015-11-09 03:39:56.846967@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:40:01.268078||measurement||ad||2015-11-09 03:39:56.846967@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 03:40:01.273249||measurement||loadtime||0:00:22.601523||2||0
+2015-11-09 03:40:07.208872||measurement||ad||2015-11-09 03:40:06.610306@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||0||1
+2015-11-09 03:40:07.364707||measurement||ad||2015-11-09 03:40:06.610306@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||1
+2015-11-09 03:40:07.382195||measurement||loadtime||0:00:24.829172||0||1
+2015-11-09 03:40:10.822804||measurement||ad||2015-11-09 03:40:04.507600@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:40:11.069241||measurement||ad||2015-11-09 03:40:04.507600@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 03:40:11.079544||measurement||loadtime||0:00:28.952592||3||0
+2015-11-09 03:40:18.856987||measurement||ad||2015-11-09 03:40:18.204608@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-09 03:40:19.103074||measurement||ad||2015-11-09 03:40:18.204608@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 03:40:19.143650||measurement||loadtime||0:00:25.407378||1||1
+2015-11-09 03:40:27.032716||measurement||ad||2015-11-09 03:40:26.489724@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:40:27.286413||measurement||ad||2015-11-09 03:40:26.489724@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 03:40:27.307424||measurement||loadtime||0:00:22.513738||5||1
+2015-11-09 03:40:27.945408||measurement||ad||2015-11-09 03:40:23.744551@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:40:28.064972||measurement||ad||2015-11-09 03:40:23.744551@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||2||0
+2015-11-09 03:40:28.070456||measurement||loadtime||0:00:21.795987||2||0
+2015-11-09 03:40:35.026918||measurement||ad||2015-11-09 03:40:34.308614@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 03:40:35.640530||measurement||ad||2015-11-09 03:40:34.308614@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:40:35.657450||measurement||loadtime||0:00:23.274270||0||1
+2015-11-09 03:40:45.529452||measurement||ad||2015-11-09 03:40:45.116301@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:40:45.612686||measurement||ad||2015-11-09 03:40:45.116301@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 03:40:45.633657||measurement||loadtime||0:00:21.489182||1||1
+2015-11-09 03:40:46.734160||measurement||ad||2015-11-09 03:40:39.008978@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 03:40:46.934411||measurement||ad||2015-11-09 03:40:39.008978@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 03:40:46.941787||measurement||loadtime||0:00:48.438548||4||0
+2015-11-09 03:40:47.543215||measurement||ad||2015-11-09 03:40:39.068879@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:40:47.943730||measurement||ad||2015-11-09 03:40:39.068879@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 03:40:48.041743||measurement||loadtime||0:00:31.959764||3||0
+2015-11-09 03:40:56.203143||measurement||ad||2015-11-09 03:40:55.333748@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:40:56.515848||measurement||ad||2015-11-09 03:40:55.333748@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 03:40:56.646540||measurement||loadtime||0:00:24.337447||5||1
+2015-11-09 03:40:57.113438||measurement||ad||2015-11-09 03:40:53.083532@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:40:57.237128||measurement||ad||2015-11-09 03:40:53.083532@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||2||0
+2015-11-09 03:40:57.241507||measurement||loadtime||0:00:24.170209||2||0
+2015-11-09 03:41:07.196894||measurement||ad||2015-11-09 03:41:06.154365@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 03:41:07.409750||measurement||ad||2015-11-09 03:41:06.154365@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||0||1
+2015-11-09 03:41:07.426595||measurement||loadtime||0:00:26.768692||0||1
+2015-11-09 03:41:19.133560||measurement||ad||2015-11-09 03:41:18.808185@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:41:19.184418||measurement||ad||2015-11-09 03:41:18.808185@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-09 03:41:19.251236||measurement||loadtime||0:00:28.615215||1||1
+2015-11-09 03:41:19.251549||event||progress-marker||measurement-end||1||1
+2015-11-09 03:41:24.785717||measurement||ad||2015-11-09 03:41:16.119163@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 03:41:25.671277||measurement||ad||2015-11-09 03:41:16.119163@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 03:41:25.675778||measurement||loadtime||0:00:33.732576||4||0
+2015-11-09 03:41:26.923656||measurement||ad||2015-11-09 03:41:22.457931@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:41:27.041533||measurement||ad||2015-11-09 03:41:22.457931@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 03:41:27.046666||measurement||loadtime||0:00:24.803962||2||0
+2015-11-09 03:41:27.046923||event||progress-marker||measurement-end||2||0
+2015-11-09 03:41:27.376184||measurement||ad||2015-11-09 03:41:19.653222@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 03:41:27.495234||measurement||ad||2015-11-09 03:41:19.653222@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:41:27.500926||measurement||loadtime||0:00:34.457778||3||0
+2015-11-09 03:41:29.582981||measurement||ad||2015-11-09 03:41:28.720762@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:41:30.109812||measurement||ad||2015-11-09 03:41:28.720762@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 03:41:30.201627||measurement||loadtime||0:00:28.554295||5||1
+2015-11-09 03:41:38.123692||measurement||ad||2015-11-09 03:41:37.933127@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 03:41:38.178650||measurement||ad||2015-11-09 03:41:37.933127@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 03:41:38.189683||measurement||loadtime||0:00:25.762386||0||1
+2015-11-09 03:41:38.190981||event||progress-marker||measurement-end||0||1
+2015-11-09 03:41:49.824189||measurement||ad||2015-11-09 03:41:46.372435@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 03:41:49.911776||measurement||ad||2015-11-09 03:41:46.372435@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 03:41:49.917707||measurement||loadtime||0:00:19.241369||4||0
+2015-11-09 03:41:53.704299||measurement||ad||2015-11-09 03:41:50.684945@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:41:53.777844||measurement||ad||2015-11-09 03:41:50.684945@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 03:41:53.781542||measurement||loadtime||0:00:21.279157||3||0
+2015-11-09 03:41:54.182107||measurement||ad||2015-11-09 03:41:54.043710@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||5||1
+2015-11-09 03:41:54.229211||measurement||ad||2015-11-09 03:41:54.043710@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 03:41:54.235498||measurement||loadtime||0:00:19.033414||5||1
+2015-11-09 03:41:54.235760||event||progress-marker||measurement-end||5||1
+2015-11-09 03:42:13.184647||measurement||ad||2015-11-09 03:42:11.294571@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 03:42:13.248328||measurement||ad||2015-11-09 03:42:11.294571@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 03:42:13.252072||measurement||loadtime||0:00:18.333812||4||0
+2015-11-09 03:42:16.268409||measurement||ad||2015-11-09 03:42:14.621273@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 03:42:16.324780||measurement||ad||2015-11-09 03:42:14.621273@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 03:42:16.327858||measurement||loadtime||0:00:17.545424||3||0
+2015-11-09 03:42:16.328170||event||progress-marker||measurement-end||3||0
+2015-11-09 03:42:34.060651||measurement||ad||2015-11-09 03:42:32.303555@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 03:42:34.116467||measurement||ad||2015-11-09 03:42:32.303555@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 03:42:34.119969||measurement||loadtime||0:00:15.866513||4||0
+2015-11-09 03:42:56.345878||measurement||ad||2015-11-09 03:42:54.518635@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 03:42:56.402279||measurement||ad||2015-11-09 03:42:54.518635@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 03:42:56.405243||measurement||loadtime||0:00:17.283771||4||0
+2015-11-09 03:42:56.405599||event||progress-marker||measurement-end||4||0
+2015-11-09 03:42:56.924342||meta||block_id end||5
+2015-11-09 03:42:56.928112||meta||block_id start||6
+2015-11-09 03:42:56.928238||meta||assignment||4@|2@|5@|1@|0@|3
+2015-11-09 03:43:00.699398||event||progress-marker||training-start||2||0
+2015-11-09 03:43:00.784835||event||progress-marker||training-start||4||0
+2015-11-09 03:43:00.901770||event||progress-marker||training-start||5||0
+2015-11-09 03:43:03.801336||event||progress-marker||training-start||1||1
+2015-11-09 03:43:04.351881||event||progress-marker||training-start||3||1
+2015-11-09 03:43:04.434605||event||progress-marker||training-start||0||1
+2015-11-09 03:43:05.449746||treatment||google search||Buy BMW||4||0
+2015-11-09 03:43:05.580805||treatment||google search||Buy BMW||5||0
+2015-11-09 03:43:06.377733||treatment||google search||Buy BMW||2||0
+2015-11-09 03:43:07.790960||error||visiting||google searchresults||4||0
+2015-11-09 03:43:07.804070||error||visiting||google searchresults||5||0
+2015-11-09 03:43:08.430191||error||visiting||google searchresults||2||0
+2015-11-09 03:43:09.589819||treatment||google search||Buy BMW||0||1
+2015-11-09 03:43:09.636730||treatment||google search||Buy BMW||1||1
+2015-11-09 03:43:09.674241||treatment||google search||Buy BMW||3||1
+2015-11-09 03:43:20.431396||error||visiting||google searchresults||0||1
+2015-11-09 03:43:20.509420||error||visiting||google searchresults||1||1
+2015-11-09 03:43:20.636352||error||visiting||google searchresults||3||1
+2015-11-09 03:43:27.644132||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 03:43:29.141776||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 03:43:29.510415||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 03:43:37.312662||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||1
+2015-11-09 03:43:37.371493||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 03:43:39.800011||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 03:43:44.145567||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 03:43:46.518995||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 03:43:46.724145||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 03:43:52.157696||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||1
+2015-11-09 03:43:52.632317||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 03:43:53.925607||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 03:43:54.201585||error||visiting||google searchresults||5||0
+2015-11-09 03:43:56.553727||error||visiting||google searchresults||4||0
+2015-11-09 03:43:56.758591||error||visiting||google searchresults||2||0
+2015-11-09 03:44:08.935141||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJieoMT5gskCFRMjgQodg40D8w||5||0
+2015-11-09 03:44:10.883056||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CL2mr8X5gskCFVI7gQodrjYBDQ||4||0
+2015-11-09 03:44:11.148483||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CN2TvMX5gskCFYc7gQod-Q0MzA||2||0
+2015-11-09 03:44:12.205747||error||visiting||google searchresults||3||1
+2015-11-09 03:44:12.668619||error||visiting||google searchresults||1||1
+2015-11-09 03:44:13.977459||error||visiting||google searchresults||0||1
+2015-11-09 03:44:20.578400||treatment||google search||BMW dealer||5||0
+2015-11-09 03:44:21.268979||error||visiting||google searchresults||5||0
+2015-11-09 03:44:23.117207||treatment||google search||BMW dealer||4||0
+2015-11-09 03:44:23.456502||treatment||google search||BMW dealer||2||0
+2015-11-09 03:44:24.062468||error||visiting||google searchresults||4||0
+2015-11-09 03:44:24.234454||error||visiting||google searchresults||2||0
+2015-11-09 03:44:26.025498||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COHyjc35gskCFdgGgQodtJYOGQ||1||1
+2015-11-09 03:44:26.940042||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COPM7Mz5gskCFUs8gQodYHoPqw||3||1
+2015-11-09 03:44:27.279549||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CMyh3c35gskCFUUlgQodxcoKZQ||0||1
+2015-11-09 03:44:39.259913||treatment||visit page||http://www.carsense.com/?gclid=CL7_kNH5gskCFdcYgQodr0oJqg||5||0
+2015-11-09 03:44:41.365332||treatment||google search||BMW dealer||1||1
+2015-11-09 03:44:42.070018||treatment||google search||BMW dealer||3||1
+2015-11-09 03:44:42.639038||treatment||google search||BMW dealer||0||1
+2015-11-09 03:44:43.607925||treatment||visit page||http://www.carsense.com/?gclid=CPqFvNL5gskCFYE2gQodAXcLFQ||4||0
+2015-11-09 03:44:44.329124||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKHHx9L5gskCFU06gQodJ08OJw||2||0
+2015-11-09 03:44:52.545209||error||visiting||google searchresults||1||1
+2015-11-09 03:44:53.547486||error||visiting||google searchresults||3||1
+2015-11-09 03:44:53.702353||error||visiting||google searchresults||0||1
+2015-11-09 03:44:54.615518||treatment||visit page||http://www.carsense.com/?gclid=CInH29n5gskCFYI8gQodSNAOFA||5||0
+2015-11-09 03:44:59.432671||treatment||visit page||http://www.carsense.com/?gclid=CJCC5dv5gskCFU47gQod-GIG7g||4||0
+2015-11-09 03:45:00.236504||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIr0lNz5gskCFdgDgQodN8QD6w||2||0
+2015-11-09 03:45:04.653901||error||visiting||google searchresults||5||0
+2015-11-09 03:45:09.492392||error||visiting||google searchresults||4||0
+2015-11-09 03:45:10.297006||error||visiting||google searchresults||2||0
+2015-11-09 03:45:10.912047||treatment||visit page||http://www.carsense.com/?gclid=CJq90-D5gskCFUg9gQodzgsGsg||0||1
+2015-11-09 03:45:11.176545||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJX1huD5gskCFUM2gQodwkkDeA||1||1
+2015-11-09 03:45:12.750408||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COnLyOD5gskCFZYkgQod96sHBA||3||1
+2015-11-09 03:45:19.560988||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CJn-6eX5gskCFUEvgQodvQgC1w||5||0
+2015-11-09 03:45:25.336133||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=COSnkuj5gskCFVY2gQodCsIKEQ||4||0
+2015-11-09 03:45:26.700929||treatment||visit page||http://www.carsense.com/?gclid=CNCc7-j5gskCFUUdgQodBswGAg||0||1
+2015-11-09 03:45:27.031869||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COaThen5gskCFYkjgQodPiQO3A||1||1
+2015-11-09 03:45:28.873249||treatment||visit page||http://www.carsense.com/?gclid=CPKXxuj5gskCFYcbgQodIbkOIw||2||0
+2015-11-09 03:45:29.079831||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CI6B3-n5gskCFdcSgQodbsAAfg||3||1
+2015-11-09 03:45:31.359843||treatment||google search||BMW||5||0
+2015-11-09 03:45:32.144317||error||visiting||google searchresults||5||0
+2015-11-09 03:45:37.020550||treatment||google search||BMW||4||0
+2015-11-09 03:45:37.982764||error||visiting||google searchresults||4||0
+2015-11-09 03:45:40.620377||treatment||google search||BMW||2||0
+2015-11-09 03:45:41.502714||error||visiting||google searchresults||2||0
+2015-11-09 03:45:46.794569||error||visiting||google searchresults||0||1
+2015-11-09 03:45:47.173993||error||visiting||google searchresults||1||1
+2015-11-09 03:45:49.148076||error||visiting||google searchresults||3||1
+2015-11-09 03:45:51.243814||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 03:45:55.737347||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:46:00.111077||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 03:46:04.606437||treatment||visit page||http://www.usautomart.com/?gclid=CMvI9vn5gskCFVMvgQodTycJrA||0||1
+2015-11-09 03:46:06.658701||treatment||visit page||http://www.carsense.com/?gclid=CNjii_v5gskCFdgNgQodcuEFZg||3||1
+2015-11-09 03:46:07.538328||treatment||visit page||http://www.carsense.com/?gclid=CPvXjvr5gskCFdgBgQodMekJLw||1||1
+2015-11-09 03:46:08.856793||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 03:46:12.667103||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:46:16.576336||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 03:46:16.688743||treatment||google search||BMW||0||1
+2015-11-09 03:46:18.761629||treatment||google search||BMW||3||1
+2015-11-09 03:46:18.911044||error||visiting||google searchresults||5||0
+2015-11-09 03:46:19.581882||treatment||google search||BMW||1||1
+2015-11-09 03:46:22.701913||error||visiting||google searchresults||4||0
+2015-11-09 03:46:26.611364||error||visiting||google searchresults||2||0
+2015-11-09 03:46:27.903675||error||visiting||google searchresults||0||1
+2015-11-09 03:46:29.802843||error||visiting||google searchresults||3||1
+2015-11-09 03:46:30.572930||error||visiting||google searchresults||1||1
+2015-11-09 03:46:36.422756||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 03:46:40.789310||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 03:46:46.253385||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 03:46:46.424563||event||progress-marker||training-end||5||0
+2015-11-09 03:46:50.790274||event||progress-marker||training-end||4||0
+2015-11-09 03:46:56.254227||event||progress-marker||training-end||2||0
+2015-11-09 03:46:58.593475||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 03:46:58.773468||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 03:47:00.395940||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:47:13.716014||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:47:14.488886||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 03:47:15.292598||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 03:47:33.771555||error||visiting||google searchresults||0||1
+2015-11-09 03:47:34.526429||error||visiting||google searchresults||3||1
+2015-11-09 03:47:35.347125||error||visiting||google searchresults||1||1
+2015-11-09 03:47:52.536535||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 03:47:52.722281||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 03:47:52.964155||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 03:48:02.538333||event||progress-marker||training-end||3||1
+2015-11-09 03:48:02.724025||event||progress-marker||training-end||1||1
+2015-11-09 03:48:02.966573||event||progress-marker||training-end||0||1
+2015-11-09 03:48:05.955518||event||progress-marker||measurement-start||4||0
+2015-11-09 03:48:06.411928||event||progress-marker||measurement-start||2||0
+2015-11-09 03:48:06.611189||event||progress-marker||measurement-start||5||0
+2015-11-09 03:48:07.555453||event||progress-marker||measurement-start||3||1
+2015-11-09 03:48:07.742179||event||progress-marker||measurement-start||1||1
+2015-11-09 03:48:07.982366||event||progress-marker||measurement-start||0||1
+2015-11-09 03:48:45.596797||measurement||ad||2015-11-09 03:48:44.324843@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||1||1
+2015-11-09 03:48:45.905114||measurement||ad||2015-11-09 03:48:44.324843@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:48:46.028304||measurement||loadtime||0:00:33.284813||1||1
+2015-11-09 03:48:47.379923||measurement||ad||2015-11-09 03:48:46.718749@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:48:47.861479||measurement||ad||2015-11-09 03:48:46.718749@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:48:47.937608||measurement||loadtime||0:00:34.954475||0||1
+2015-11-09 03:48:52.859739||measurement||ad||2015-11-09 03:48:51.160725@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:48:53.321468||measurement||ad||2015-11-09 03:48:51.160725@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||1
+2015-11-09 03:48:53.656011||measurement||loadtime||0:00:41.099783||3||1
+2015-11-09 03:49:09.071091||measurement||ad||2015-11-09 03:48:49.861391@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 03:49:10.862353||measurement||ad||2015-11-09 03:48:49.861391@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:49:10.882901||measurement||loadtime||0:00:59.925770||4||0
+2015-11-09 03:49:13.350634||measurement||ad||2015-11-09 03:48:55.843232@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 03:49:14.454985||measurement||ad||2015-11-09 03:48:55.843232@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 03:49:14.595981||measurement||loadtime||0:01:02.984247||5||0
+2015-11-09 03:49:16.825711||measurement||ad||2015-11-09 03:48:52.844766@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:49:18.346472||measurement||ad||2015-11-09 03:48:52.844766@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 03:49:18.680302||measurement||loadtime||0:01:07.266762||2||0
+2015-11-09 03:49:21.617713||measurement||ad||2015-11-09 03:49:20.940826@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 03:49:21.786549||measurement||ad||2015-11-09 03:49:20.940826@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:49:21.876522||measurement||loadtime||0:00:28.938004||0||1
+2015-11-09 03:49:30.010098||measurement||ad||2015-11-09 03:49:26.239866@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:49:31.059456||measurement||ad||2015-11-09 03:49:26.239866@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||1||1
+2015-11-09 03:49:31.133282||measurement||loadtime||0:00:40.104088||1||1
+2015-11-09 03:49:32.883865||measurement||ad||2015-11-09 03:49:32.367667@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:49:33.319673||measurement||ad||2015-11-09 03:49:32.367667@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||1
+2015-11-09 03:49:33.336332||measurement||loadtime||0:00:34.678718||3||1
+2015-11-09 03:49:56.174861||measurement||ad||2015-11-09 03:49:45.354893@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 03:49:57.311165||measurement||ad||2015-11-09 03:49:45.354893@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:49:57.318701||measurement||loadtime||0:00:41.434373||4||0
+2015-11-09 03:49:59.992025||measurement||ad||2015-11-09 03:49:48.569682@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 03:50:00.976442||measurement||ad||2015-11-09 03:49:48.569682@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 03:50:00.987971||measurement||loadtime||0:00:41.391394||5||0
+2015-11-09 03:50:01.574136||measurement||ad||2015-11-09 03:49:58.273055@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 03:50:02.001254||measurement||ad||2015-11-09 03:49:58.273055@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:50:02.073058||measurement||loadtime||0:00:35.195211||0||1
+2015-11-09 03:50:04.381005||measurement||ad||2015-11-09 03:49:51.861422@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:50:04.864558||measurement||ad||2015-11-09 03:49:51.861422@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 03:50:04.870240||measurement||loadtime||0:00:41.189034||2||0
+2015-11-09 03:50:14.875259||measurement||ad||2015-11-09 03:50:12.323886@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:50:15.233115||measurement||ad||2015-11-09 03:50:12.323886@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||1
+2015-11-09 03:50:15.393293||measurement||loadtime||0:00:37.056359||3||1
+2015-11-09 03:50:36.976501||error||collecting ads||Error||1||1
+2015-11-09 03:50:37.747321||measurement||ad||2015-11-09 03:50:26.661227@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:50:38.574615||measurement||ad||2015-11-09 03:50:26.661227@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:50:38.586182||measurement||loadtime||0:00:36.266154||4||0
+2015-11-09 03:50:40.244762||measurement||ad||2015-11-09 03:50:38.273874@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 03:50:40.492959||measurement||ad||2015-11-09 03:50:38.273874@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:50:40.536555||measurement||loadtime||0:00:33.462842||0||1
+2015-11-09 03:50:47.354448||measurement||ad||2015-11-09 03:50:38.025250@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:50:48.981195||measurement||ad||2015-11-09 03:50:38.025250@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:50:49.061195||measurement||ad||2015-11-09 03:50:31.672060@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:50:49.092407||measurement||loadtime||0:00:39.221457||2||0
+2015-11-09 03:50:50.136161||measurement||ad||2015-11-09 03:50:31.672060@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 03:50:50.199303||measurement||loadtime||0:00:44.209790||5||0
+2015-11-09 03:50:53.492743||measurement||ad||2015-11-09 03:50:52.424707@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:50:53.760898||measurement||ad||2015-11-09 03:50:52.424707@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-09 03:50:53.795379||measurement||loadtime||0:00:33.400667||3||1
+2015-11-09 03:50:59.369929||measurement||ad||2015-11-09 03:50:56.272087@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:50:59.556679||measurement||ad||2015-11-09 03:50:56.272087@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||1||1
+2015-11-09 03:50:59.728282||measurement||loadtime||0:00:17.750826||1||1
+2015-11-09 03:51:15.447565||measurement||ad||2015-11-09 03:51:14.524510@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||0||1
+2015-11-09 03:51:15.691236||measurement||ad||2015-11-09 03:51:14.524510@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:51:15.876647||measurement||loadtime||0:00:30.339168||0||1
+2015-11-09 03:51:17.480527||measurement||ad||2015-11-09 03:51:08.838285@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:51:18.168202||measurement||ad||2015-11-09 03:51:08.838285@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:51:18.189348||measurement||loadtime||0:00:34.602605||4||0
+2015-11-09 03:51:29.393266||measurement||ad||2015-11-09 03:51:21.928830@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:51:29.534379||measurement||ad||2015-11-09 03:51:21.972900@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:51:29.740839||measurement||ad||2015-11-09 03:51:29.164238@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:51:29.973544||measurement||ad||2015-11-09 03:51:29.164238@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-09 03:51:29.988401||measurement||loadtime||0:00:31.190991||3||1
+2015-11-09 03:51:30.161942||measurement||ad||2015-11-09 03:51:21.928830@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 03:51:30.293943||measurement||loadtime||0:00:36.200830||2||0
+2015-11-09 03:51:30.303327||measurement||ad||2015-11-09 03:51:21.972900@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 03:51:30.336840||measurement||loadtime||0:00:35.136135||5||0
+2015-11-09 03:51:37.752617||measurement||ad||2015-11-09 03:51:36.354787@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:51:38.133175||measurement||ad||2015-11-09 03:51:36.354787@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||1||1
+2015-11-09 03:51:38.246205||measurement||loadtime||0:00:33.517056||1||1
+2015-11-09 03:51:50.159423||measurement||ad||2015-11-09 03:51:49.172627@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 03:51:50.250113||measurement||ad||2015-11-09 03:51:49.172627@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:51:50.266500||measurement||loadtime||0:00:29.388115||0||1
+2015-11-09 03:51:51.226602||measurement||ad||2015-11-09 03:51:45.508163@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:51:51.512296||measurement||ad||2015-11-09 03:51:45.508163@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:51:51.525093||measurement||loadtime||0:00:28.334472||4||0
+2015-11-09 03:51:59.591792||measurement||ad||2015-11-09 03:51:58.740950@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:51:59.659026||measurement||ad||2015-11-09 03:51:58.740950@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-09 03:51:59.686342||measurement||loadtime||0:00:24.696999||3||1
+2015-11-09 03:52:04.961708||measurement||ad||2015-11-09 03:51:58.007451@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 03:52:04.997570||measurement||ad||2015-11-09 03:51:58.247529@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:52:05.262938||measurement||ad||2015-11-09 03:51:58.007451@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:52:05.268995||measurement||loadtime||0:00:29.974422||2||0
+2015-11-09 03:52:05.428260||measurement||ad||2015-11-09 03:51:58.247529@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:52:05.433205||measurement||loadtime||0:00:30.095808||5||0
+2015-11-09 03:52:11.904317||measurement||ad||2015-11-09 03:52:10.881979@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:52:12.144663||measurement||ad||2015-11-09 03:52:10.881979@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||1||1
+2015-11-09 03:52:12.166719||measurement||loadtime||0:00:28.919326||1||1
+2015-11-09 03:52:20.301299||measurement||ad||2015-11-09 03:52:19.589043@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 03:52:20.458877||measurement||ad||2015-11-09 03:52:19.589043@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:52:20.516402||measurement||loadtime||0:00:25.248940||0||1
+2015-11-09 03:52:25.775818||measurement||ad||2015-11-09 03:52:18.609645@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:52:26.045425||measurement||ad||2015-11-09 03:52:18.609645@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:52:26.051187||measurement||loadtime||0:00:29.525518||4||0
+2015-11-09 03:52:28.385421||measurement||ad||2015-11-09 03:52:26.970556@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:52:28.546118||measurement||ad||2015-11-09 03:52:26.970556@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-09 03:52:28.561538||measurement||loadtime||0:00:23.873999||3||1
+2015-11-09 03:52:44.351187||measurement||ad||2015-11-09 03:52:34.634175@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:52:44.836777||measurement||ad||2015-11-09 03:52:34.634175@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:52:44.949510||measurement||loadtime||0:00:34.515663||5||0
+2015-11-09 03:52:47.808034||measurement||ad||2015-11-09 03:52:36.685435@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:52:48.131729||measurement||ad||2015-11-09 03:52:36.685435@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:52:48.139338||measurement||loadtime||0:00:37.868815||2||0
+2015-11-09 03:52:54.978985||measurement||ad||2015-11-09 03:52:54.208357@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 03:52:55.122022||measurement||ad||2015-11-09 03:52:54.208357@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:52:55.134525||measurement||loadtime||0:00:29.616703||0||1
+2015-11-09 03:53:04.003982||measurement||ad||2015-11-09 03:52:57.034847@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:53:04.254232||measurement||ad||2015-11-09 03:52:57.034847@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:53:04.267856||measurement||loadtime||0:00:33.216141||4||0
+2015-11-09 03:53:04.968695||measurement||ad||2015-11-09 03:53:02.002915@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:53:05.686339||measurement||ad||2015-11-09 03:53:02.002915@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 03:53:05.716796||measurement||loadtime||0:00:32.153418||3||1
+2015-11-09 03:53:17.207657||error||collecting ads||Error||1||1
+2015-11-09 03:53:19.319418||measurement||ad||2015-11-09 03:53:13.100702@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:53:19.670476||measurement||ad||2015-11-09 03:53:13.100702@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:53:19.675358||measurement||loadtime||0:00:29.725230||5||0
+2015-11-09 03:53:28.922485||measurement||ad||2015-11-09 03:53:20.725106@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:53:29.213748||measurement||ad||2015-11-09 03:53:20.725106@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:53:29.246241||measurement||loadtime||0:00:36.105842||2||0
+2015-11-09 03:53:30.295691||measurement||ad||2015-11-09 03:53:29.475097@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 03:53:30.368338||measurement||ad||2015-11-09 03:53:29.475097@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 03:53:30.387460||measurement||loadtime||0:00:30.251520||0||1
+2015-11-09 03:53:34.555681||measurement||ad||2015-11-09 03:53:33.929107@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:53:34.629572||measurement||ad||2015-11-09 03:53:33.929107@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-09 03:53:34.650743||measurement||loadtime||0:00:23.932416||3||1
+2015-11-09 03:53:35.518160||measurement||ad||2015-11-09 03:53:34.702930@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:53:35.711856||measurement||ad||2015-11-09 03:53:34.702930@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||1||1
+2015-11-09 03:53:35.722993||measurement||loadtime||0:00:13.513713||1||1
+2015-11-09 03:53:39.739646||measurement||ad||2015-11-09 03:53:33.079728@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:53:39.984484||measurement||ad||2015-11-09 03:53:33.079728@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:53:39.989223||measurement||loadtime||0:00:30.719977||4||0
+2015-11-09 03:53:56.718046||measurement||ad||2015-11-09 03:53:48.092090@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:53:56.985906||measurement||ad||2015-11-09 03:53:48.092090@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:53:56.992292||measurement||loadtime||0:00:32.315547||5||0
+2015-11-09 03:54:04.541302||measurement||ad||2015-11-09 03:53:58.303874@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:54:04.695694||measurement||ad||2015-11-09 03:53:58.303874@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:54:04.704758||measurement||loadtime||0:00:30.457672||2||0
+2015-11-09 03:54:07.681336||measurement||ad||2015-11-09 03:54:07.369126@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 03:54:07.794402||measurement||ad||2015-11-09 03:54:07.369126@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||0||1
+2015-11-09 03:54:07.803210||measurement||loadtime||0:00:32.415217||0||1
+2015-11-09 03:54:07.803563||event||progress-marker||measurement-end||0||1
+2015-11-09 03:54:09.715979||measurement||ad||2015-11-09 03:54:09.169565@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 03:54:09.792561||measurement||ad||2015-11-09 03:54:09.169565@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||1
+2015-11-09 03:54:09.820470||measurement||loadtime||0:00:30.168671||3||1
+2015-11-09 03:54:09.820842||event||progress-marker||measurement-end||3||1
+2015-11-09 03:54:10.655485||measurement||ad||2015-11-09 03:54:09.574391@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:54:10.991920||measurement||ad||2015-11-09 03:54:09.574391@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||1||1
+2015-11-09 03:54:11.012361||measurement||loadtime||0:00:30.288730||1||1
+2015-11-09 03:54:13.355527||measurement||ad||2015-11-09 03:54:08.034950@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:54:13.472020||measurement||ad||2015-11-09 03:54:08.034950@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:54:13.476192||measurement||loadtime||0:00:28.486363||4||0
+2015-11-09 03:54:27.340740||measurement||ad||2015-11-09 03:54:21.781739@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||0
+2015-11-09 03:54:27.496601||measurement||ad||2015-11-09 03:54:21.781739@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:54:27.501419||measurement||loadtime||0:00:25.508672||5||0
+2015-11-09 03:54:34.118975||measurement||ad||2015-11-09 03:54:29.438590@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 03:54:34.225550||measurement||ad||2015-11-09 03:54:29.438590@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:54:34.229169||measurement||loadtime||0:00:24.523827||2||0
+2015-11-09 03:54:38.169627||measurement||ad||2015-11-09 03:54:37.840573@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||1||1
+2015-11-09 03:54:38.286231||measurement||ad||2015-11-09 03:54:37.840573@|Claim Your Free Samples@|www.getitfree.us@|Try Your Favorite Brands for Free! No Catch, No Credit Card. 100% Free||1||1
+2015-11-09 03:54:38.377789||measurement||loadtime||0:00:22.364113||1||1
+2015-11-09 03:54:38.378091||event||progress-marker||measurement-end||1||1
+2015-11-09 03:54:42.025452||measurement||ad||2015-11-09 03:54:37.214802@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 03:54:42.099555||measurement||ad||2015-11-09 03:54:37.214802@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 03:54:42.104152||measurement||loadtime||0:00:23.626455||4||0
+2015-11-09 03:54:42.104531||event||progress-marker||measurement-end||4||0
+2015-11-09 03:54:51.285497||measurement||ad||2015-11-09 03:54:48.989578@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 03:54:51.357945||measurement||ad||2015-11-09 03:54:48.989578@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 03:54:51.361696||measurement||loadtime||0:00:18.859387||5||0
+2015-11-09 03:54:51.361915||event||progress-marker||measurement-end||5||0
+2015-11-09 03:54:56.629765||measurement||ad||2015-11-09 03:54:55.353230@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 03:54:56.692984||measurement||ad||2015-11-09 03:54:55.353230@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 03:54:57.047889||measurement||loadtime||0:00:17.796642||2||0
+2015-11-09 03:54:57.048183||event||progress-marker||measurement-end||2||0
+2015-11-09 03:54:57.565018||meta||block_id end||6
+2015-11-09 03:54:57.567862||meta||block_id start||7
+2015-11-09 03:54:57.568038||meta||assignment||4@|3@|5@|1@|2@|0
+2015-11-09 03:55:01.276077||event||progress-marker||training-start||4||0
+2015-11-09 03:55:01.423518||event||progress-marker||training-start||3||0
+2015-11-09 03:55:01.423532||event||progress-marker||training-start||5||0
+2015-11-09 03:55:04.567369||event||progress-marker||training-start||1||1
+2015-11-09 03:55:04.601583||event||progress-marker||training-start||0||1
+2015-11-09 03:55:05.101085||event||progress-marker||training-start||2||1
+2015-11-09 03:55:06.213246||treatment||google search||Buy BMW||4||0
+2015-11-09 03:55:06.238170||treatment||google search||Buy BMW||5||0
+2015-11-09 03:55:06.320583||treatment||google search||Buy BMW||3||0
+2015-11-09 03:55:08.105791||error||visiting||google searchresults||4||0
+2015-11-09 03:55:08.124920||error||visiting||google searchresults||5||0
+2015-11-09 03:55:08.340322||error||visiting||google searchresults||3||0
+2015-11-09 03:55:09.773629||treatment||google search||Buy BMW||1||1
+2015-11-09 03:55:09.975476||treatment||google search||Buy BMW||0||1
+2015-11-09 03:55:10.515682||treatment||google search||Buy BMW||2||1
+2015-11-09 03:55:20.739429||error||visiting||google searchresults||1||1
+2015-11-09 03:55:20.873943||error||visiting||google searchresults||0||1
+2015-11-09 03:55:21.259249||error||visiting||google searchresults||2||1
+2015-11-09 03:55:24.591035||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 03:55:25.175221||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 03:55:27.177032||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 03:55:34.629102||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 03:55:38.463372||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 03:55:38.822605||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 03:55:40.148179||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 03:55:40.422082||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 03:55:41.909222||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 03:55:50.209737||error||visiting||google searchresults||3||0
+2015-11-09 03:55:50.254919||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 03:55:50.464523||error||visiting||google searchresults||5||0
+2015-11-09 03:55:51.943473||error||visiting||google searchresults||4||0
+2015-11-09 03:55:53.264340||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 03:55:53.657858||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 03:56:06.886277||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||5||0
+2015-11-09 03:56:07.269876||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||4||0
+2015-11-09 03:56:09.094038||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||3||0
+2015-11-09 03:56:10.326917||error||visiting||google searchresults||0||1
+2015-11-09 03:56:13.384922||error||visiting||google searchresults||1||1
+2015-11-09 03:56:13.693691||error||visiting||google searchresults||2||1
+2015-11-09 03:56:18.555903||treatment||google search||BMW dealer||5||0
+2015-11-09 03:56:18.923344||treatment||google search||BMW dealer||4||0
+2015-11-09 03:56:19.206661||error||visiting||google searchresults||5||0
+2015-11-09 03:56:19.564619||error||visiting||google searchresults||4||0
+2015-11-09 03:56:21.097567||treatment||google search||BMW dealer||3||0
+2015-11-09 03:56:21.748434||error||visiting||google searchresults||3||0
+2015-11-09 03:56:25.413702||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||0||1
+2015-11-09 03:56:28.487423||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||2||1
+2015-11-09 03:56:28.787866||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||1||1
+2015-11-09 03:56:38.635542||treatment||google search||BMW dealer||0||1
+2015-11-09 03:56:41.179832||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNrk1Kf8gskCFUU7gQodHnMD0w||4||0
+2015-11-09 03:56:42.065787||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CN7cw6f8gskCFZQjgQodp6QJLQ||5||0
+2015-11-09 03:56:43.039715||treatment||google search||BMW dealer||1||1
+2015-11-09 03:56:43.302346||treatment||google search||BMW dealer||2||1
+2015-11-09 03:56:43.439083||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIyt3Kj8gskCFdc2gQodWIsEdg||3||0
+2015-11-09 03:56:50.231951||error||visiting||google searchresults||0||1
+2015-11-09 03:56:54.003506||error||visiting||google searchresults||1||1
+2015-11-09 03:56:54.222475||error||visiting||google searchresults||2||1
+2015-11-09 03:56:56.685834||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIvS-rH8gskCFdgQgQodo1cHHw||4||0
+2015-11-09 03:56:57.365569||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJebhrP8gskCFdgWgQodnTAApA||3||0
+2015-11-09 03:57:06.735489||error||visiting||google searchresults||4||0
+2015-11-09 03:57:07.402113||error||visiting||google searchresults||3||0
+2015-11-09 03:57:07.573097||treatment||visit page||http://www.carsense.com/?gclid=CMOXprb8gskCFVUlgQodJdoD7Q||0||1
+2015-11-09 03:57:11.337770||treatment||visit page||http://www.carsense.com/?gclid=CMz4nrj8gskCFdgQgQodo1cHHw||2||1
+2015-11-09 03:57:12.022612||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP2ZtLL8gskCFdQ2gQodFwwNcw||5||0
+2015-11-09 03:57:13.607237||treatment||visit page||http://www.carsense.com/?gclid=CJOri7j8gskCFZYkgQod96sHBA||1||1
+2015-11-09 03:57:22.071297||error||visiting||google searchresults||5||0
+2015-11-09 03:57:22.739938||treatment||visit page||http://www.carsense.com/?gclid=CL6wy778gskCFdcXgQodQqMC1A||0||1
+2015-11-09 03:57:25.755963||treatment||visit page||http://www.carsense.com/?gclid=CKyrusD8gskCFVY2gQodCsIKEQ||2||1
+2015-11-09 03:57:25.788853||treatment||visit page||http://www.carsense.com/?gclid=CL2Fkr78gskCFYc7gQod-Q0MzA||4||0
+2015-11-09 03:57:25.944414||treatment||visit page||http://www.carsense.com/?gclid=CKa3vL78gskCFdgQgQodo1cHHw||3||0
+2015-11-09 03:57:30.678317||treatment||visit page||http://www.carsense.com/?gclid=CLbRt8H8gskCFdgWgQodnTAApA||1||1
+2015-11-09 03:57:37.567332||treatment||google search||BMW||4||0
+2015-11-09 03:57:37.760150||treatment||google search||BMW||3||0
+2015-11-09 03:57:38.413646||error||visiting||google searchresults||4||0
+2015-11-09 03:57:38.908530||error||visiting||google searchresults||3||0
+2015-11-09 03:57:39.104950||treatment||visit page||http://www.carsense.com/?gclid=CNqLvcX8gskCFdgPgQodEnsOlw||5||0
+2015-11-09 03:57:42.777144||error||visiting||google searchresults||0||1
+2015-11-09 03:57:45.795863||error||visiting||google searchresults||2||1
+2015-11-09 03:57:50.732460||error||visiting||google searchresults||1||1
+2015-11-09 03:57:51.662013||treatment||google search||BMW||5||0
+2015-11-09 03:57:53.137113||error||visiting||google searchresults||5||0
+2015-11-09 03:57:55.214565||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||3||0
+2015-11-09 03:57:56.187807||treatment||visit page||http://www.usautomart.com/?gclid=CK-psc_8gskCFY49gQodmmkLMA||0||1
+2015-11-09 03:57:57.596732||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:58:01.145987||treatment||visit page||http://www.usautomart.com/?gclid=CN3o49D8gskCFdgcgQodPBMC0w||2||1
+2015-11-09 03:58:06.800977||treatment||visit page||http://www.usautomart.com/?gclid=CNWWkNP8gskCFdgOgQod3CYEoQ||1||1
+2015-11-09 03:58:09.497965||treatment||google search||BMW||0||1
+2015-11-09 03:58:10.696338||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||3||0
+2015-11-09 03:58:12.062058||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 03:58:13.492441||treatment||google search||BMW||2||1
+2015-11-09 03:58:13.704769||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 03:58:18.565939||treatment||google search||BMW||1||1
+2015-11-09 03:58:20.623085||error||visiting||google searchresults||0||1
+2015-11-09 03:58:20.750404||error||visiting||google searchresults||3||0
+2015-11-09 03:58:23.760696||error||visiting||google searchresults||4||0
+2015-11-09 03:58:24.450070||error||visiting||google searchresults||2||1
+2015-11-09 03:58:27.773559||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 03:58:29.630256||error||visiting||google searchresults||1||1
+2015-11-09 03:58:37.802636||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||3||0
+2015-11-09 03:58:37.834769||error||visiting||google searchresults||5||0
+2015-11-09 03:58:44.792364||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 03:58:46.133466||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 03:58:46.216501||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 03:58:47.804790||event||progress-marker||training-end||3||0
+2015-11-09 03:58:49.119035||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:58:54.796104||event||progress-marker||training-end||4||0
+2015-11-09 03:58:55.300131||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 03:58:59.602781||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 03:59:02.033852||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 03:59:04.610777||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 03:59:05.301626||event||progress-marker||training-end||5||0
+2015-11-09 03:59:19.652386||error||visiting||google searchresults||2||1
+2015-11-09 03:59:22.100520||error||visiting||google searchresults||1||1
+2015-11-09 03:59:24.675084||error||visiting||google searchresults||0||1
+2015-11-09 03:59:36.735962||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 03:59:36.895136||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 03:59:39.019281||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 03:59:46.739143||event||progress-marker||training-end||1||1
+2015-11-09 03:59:46.896858||event||progress-marker||training-end||2||1
+2015-11-09 03:59:49.020832||event||progress-marker||training-end||0||1
+2015-11-09 03:59:49.925484||event||progress-marker||measurement-start||4||0
+2015-11-09 03:59:50.407547||event||progress-marker||measurement-start||5||0
+2015-11-09 03:59:51.759410||event||progress-marker||measurement-start||1||1
+2015-11-09 03:59:51.918403||event||progress-marker||measurement-start||2||1
+2015-11-09 03:59:52.981379||event||progress-marker||measurement-start||3||0
+2015-11-09 03:59:54.040735||event||progress-marker||measurement-start||0||1
+2015-11-09 04:00:22.103199||measurement||ad||2015-11-09 04:00:18.043308@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:00:22.224097||measurement||ad||2015-11-09 04:00:18.043308@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 04:00:22.229407||measurement||loadtime||0:00:24.246352||3||0
+2015-11-09 04:00:47.681659||measurement||ad||2015-11-09 04:00:43.429567@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:00:47.766528||measurement||ad||2015-11-09 04:00:43.429567@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 04:00:47.783240||measurement||loadtime||0:00:20.552362||3||0
+2015-11-09 04:00:56.780904||error||collecting ads||Error||1||1
+2015-11-09 04:00:56.944147||error||collecting ads||Error||2||1
+2015-11-09 04:00:59.077995||error||collecting ads||Error||0||1
+2015-11-09 04:01:10.457765||measurement||ad||2015-11-09 04:01:07.267523@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:01:10.552077||measurement||ad||2015-11-09 04:01:07.267523@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 04:01:10.560051||measurement||loadtime||0:00:17.775367||3||0
+2015-11-09 04:01:33.868199||measurement||ad||2015-11-09 04:01:30.933235@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:01:33.949559||measurement||ad||2015-11-09 04:01:30.933235@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 04:01:33.954562||measurement||loadtime||0:00:18.394008||3||0
+2015-11-09 04:01:58.078966||measurement||ad||2015-11-09 04:01:54.249966@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:01:58.191788||measurement||ad||2015-11-09 04:01:54.249966@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:01:58.196039||measurement||loadtime||0:00:19.240795||3||0
+2015-11-09 04:02:21.542202||measurement||ad||2015-11-09 04:02:18.847663@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:02:21.632702||measurement||ad||2015-11-09 04:02:18.847663@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:02:21.636443||measurement||loadtime||0:00:18.438724||3||0
+2015-11-09 04:03:12.464711||measurement||ad||2015-11-09 04:03:11.864869@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:03:12.556984||measurement||ad||2015-11-09 04:03:11.923097@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 04:03:12.823455||measurement||ad||2015-11-09 04:03:11.923097@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 04:03:12.875045||measurement||loadtime||0:02:10.930354||2||1
+2015-11-09 04:03:13.111950||measurement||ad||2015-11-09 04:03:11.864869@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 04:03:13.240254||measurement||loadtime||0:02:09.161115||0||1
+2015-11-09 04:03:21.573746||measurement||loadtime||0:02:19.791069||1||1
+2015-11-09 04:03:26.709659||error||collecting ads||Error||3||0
+2015-11-09 04:03:52.085441||measurement||ad||2015-11-09 04:03:35.182775@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 04:03:53.643032||measurement||ad||2015-11-09 04:03:35.182775@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||0
+2015-11-09 04:03:53.647517||measurement||loadtime||0:03:58.720423||4||0
+2015-11-09 04:03:55.705157||measurement||ad||2015-11-09 04:03:54.304479@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||0||1
+2015-11-09 04:03:56.359267||measurement||ad||2015-11-09 04:03:54.304479@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:03:56.439422||measurement||loadtime||0:00:38.197858||0||1
+2015-11-09 04:03:56.591873||measurement||ad||2015-11-09 04:03:55.067784@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||2||1
+2015-11-09 04:03:56.986550||measurement||ad||2015-11-09 04:03:55.067784@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 04:03:57.023509||measurement||loadtime||0:00:39.147823||2||1
+2015-11-09 04:04:00.674868||measurement||ad||2015-11-09 04:03:41.106245@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:04:01.691956||measurement||ad||2015-11-09 04:03:41.106245@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:04:01.755312||measurement||loadtime||0:04:06.346162||5||0
+2015-11-09 04:04:03.573922||measurement||ad||2015-11-09 04:04:02.640222@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:04:03.897019||measurement||ad||2015-11-09 04:04:02.640222@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 04:04:04.090557||measurement||loadtime||0:00:37.516023||1||1
+2015-11-09 04:04:17.109003||measurement||ad||2015-11-09 04:04:06.891874@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 04:04:18.058101||measurement||ad||2015-11-09 04:04:06.891874@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 04:04:18.117050||measurement||loadtime||0:00:46.405526||3||0
+2015-11-09 04:04:29.683827||measurement||ad||2015-11-09 04:04:28.535799@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||2||1
+2015-11-09 04:04:30.013236||measurement||ad||2015-11-09 04:04:28.535799@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:04:30.310489||measurement||loadtime||0:00:28.286275||2||1
+2015-11-09 04:04:33.870328||measurement||ad||2015-11-09 04:04:32.556184@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 04:04:34.370272||measurement||ad||2015-11-09 04:04:32.556184@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:04:34.733708||measurement||loadtime||0:00:33.293349||0||1
+2015-11-09 04:04:40.742650||measurement||ad||2015-11-09 04:04:26.385004@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 04:04:41.678911||measurement||ad||2015-11-09 04:04:26.385004@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 04:04:41.683483||measurement||loadtime||0:00:43.035033||4||0
+2015-11-09 04:04:46.067252||measurement||ad||2015-11-09 04:04:45.491042@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 04:04:46.232254||measurement||ad||2015-11-09 04:04:45.491042@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:04:46.286998||measurement||loadtime||0:00:37.195754||1||1
+2015-11-09 04:04:56.127236||measurement||ad||2015-11-09 04:04:37.689426@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:04:57.885157||measurement||ad||2015-11-09 04:04:37.689426@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:04:57.890736||measurement||loadtime||0:00:51.134335||5||0
+2015-11-09 04:05:02.994699||measurement||ad||2015-11-09 04:04:54.202246@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:05:03.783508||measurement||ad||2015-11-09 04:04:54.202246@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 04:05:03.794283||measurement||loadtime||0:00:40.676349||3||0
+2015-11-09 04:05:07.133364||measurement||ad||2015-11-09 04:05:06.347332@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 04:05:07.431052||measurement||ad||2015-11-09 04:05:06.347332@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:05:07.591972||measurement||loadtime||0:00:32.280834||2||1
+2015-11-09 04:05:10.115300||measurement||ad||2015-11-09 04:05:09.105729@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||0||1
+2015-11-09 04:05:10.511016||measurement||ad||2015-11-09 04:05:09.105729@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:05:10.538142||measurement||loadtime||0:00:30.802695||0||1
+2015-11-09 04:05:18.629283||measurement||ad||2015-11-09 04:05:18.059738@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:05:18.732943||measurement||ad||2015-11-09 04:05:18.059738@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 04:05:18.890924||measurement||loadtime||0:00:27.601713||1||1
+2015-11-09 04:05:25.693460||measurement||ad||2015-11-09 04:05:10.558229@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 04:05:26.969621||measurement||ad||2015-11-09 04:05:10.558229@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 04:05:26.979471||measurement||loadtime||0:00:40.295130||4||0
+2015-11-09 04:05:43.105037||measurement||ad||2015-11-09 04:05:30.477413@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:05:43.818908||measurement||ad||2015-11-09 04:05:30.477413@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:05:43.832251||measurement||loadtime||0:00:40.940228||5||0
+2015-11-09 04:05:46.943440||measurement||ad||2015-11-09 04:05:45.589240@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 04:05:47.685817||measurement||ad||2015-11-09 04:05:45.589240@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:05:47.739612||measurement||loadtime||0:00:32.200786||0||1
+2015-11-09 04:05:50.750197||measurement||ad||2015-11-09 04:05:50.179173@|Free Public Record Search@|www.backgroundalert.com@|Enter any Name and State for Free. See What They Might Be Hiding||2||1
+2015-11-09 04:05:50.927245||measurement||ad||2015-11-09 04:05:50.179173@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:05:50.969960||measurement||loadtime||0:00:38.377267||2||1
+2015-11-09 04:05:53.031215||measurement||ad||2015-11-09 04:05:45.440157@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:05:53.293744||measurement||ad||2015-11-09 04:05:45.440157@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:05:53.299127||measurement||loadtime||0:00:44.504294||3||0
+2015-11-09 04:05:53.299536||event||progress-marker||measurement-end||3||0
+2015-11-09 04:05:55.059332||measurement||ad||2015-11-09 04:05:53.249553@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 04:05:55.206060||measurement||ad||2015-11-09 04:05:53.249553@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:05:55.216383||measurement||loadtime||0:00:31.324850||1||1
+2015-11-09 04:06:11.611573||measurement||ad||2015-11-09 04:06:01.412316@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 04:06:19.192388||measurement||ad||2015-11-09 04:06:01.412316@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 04:06:19.222181||measurement||loadtime||0:00:47.241764||4||0
+2015-11-09 04:06:22.753286||measurement||ad||2015-11-09 04:06:20.062446@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||2||1
+2015-11-09 04:06:22.922397||measurement||ad||2015-11-09 04:06:20.062446@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:06:22.968075||measurement||loadtime||0:00:26.996189||2||1
+2015-11-09 04:06:27.278752||measurement||ad||2015-11-09 04:06:26.818902@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:06:27.520804||measurement||ad||2015-11-09 04:06:26.818902@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:06:27.538941||measurement||loadtime||0:00:34.797767||0||1
+2015-11-09 04:06:28.011642||measurement||ad||2015-11-09 04:06:27.588760@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||1
+2015-11-09 04:06:28.099811||measurement||ad||2015-11-09 04:06:27.588760@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:06:28.118851||measurement||loadtime||0:00:27.901338||1||1
+2015-11-09 04:06:32.146947||measurement||ad||2015-11-09 04:06:18.116451@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:06:35.159403||measurement||ad||2015-11-09 04:06:18.116451@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:06:35.358874||measurement||loadtime||0:00:46.524602||5||0
+2015-11-09 04:06:55.676462||measurement||ad||2015-11-09 04:06:46.853972@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 04:06:55.884577||measurement||ad||2015-11-09 04:06:55.239812@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||2||1
+2015-11-09 04:06:56.091865||measurement||ad||2015-11-09 04:06:55.239812@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:06:56.115776||measurement||loadtime||0:00:28.147131||2||1
+2015-11-09 04:06:56.959607||measurement||ad||2015-11-09 04:06:46.853972@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 04:06:56.987044||measurement||loadtime||0:00:32.763956||4||0
+2015-11-09 04:06:58.074238||measurement||ad||2015-11-09 04:06:57.689985@|AncestryDNA™ Official@|ancestry.com/DNA@|Discover your genetic ethnicity  geographic origins with DNA!||1||1
+2015-11-09 04:06:58.384419||measurement||ad||2015-11-09 04:06:57.689985@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:06:58.500831||measurement||loadtime||0:00:25.380697||1||1
+2015-11-09 04:06:59.138005||measurement||ad||2015-11-09 04:06:58.661897@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:06:59.335022||measurement||ad||2015-11-09 04:06:58.661897@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||0||1
+2015-11-09 04:06:59.363745||measurement||loadtime||0:00:26.823499||0||1
+2015-11-09 04:07:16.646028||measurement||ad||2015-11-09 04:07:07.012672@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:07:17.275569||measurement||ad||2015-11-09 04:07:07.012672@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:07:17.282673||measurement||loadtime||0:00:36.922826||5||0
+2015-11-09 04:07:24.628042||measurement||ad||2015-11-09 04:07:23.973112@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||2||1
+2015-11-09 04:07:24.843460||measurement||ad||2015-11-09 04:07:23.973112@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:07:24.853779||measurement||loadtime||0:00:23.737178||2||1
+2015-11-09 04:07:34.479428||measurement||ad||2015-11-09 04:07:33.767757@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 04:07:34.876813||measurement||ad||2015-11-09 04:07:33.767757@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 04:07:34.931826||measurement||loadtime||0:00:31.430473||1||1
+2015-11-09 04:07:38.771877||measurement||ad||2015-11-09 04:07:37.868511@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 04:07:39.123120||measurement||ad||2015-11-09 04:07:37.868511@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||0||1
+2015-11-09 04:07:39.135538||measurement||loadtime||0:00:34.770874||0||1
+2015-11-09 04:07:47.386127||measurement||ad||2015-11-09 04:07:36.238129@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 04:07:48.423339||measurement||ad||2015-11-09 04:07:36.238129@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 04:07:48.490810||measurement||loadtime||0:00:46.503082||4||0
+2015-11-09 04:07:52.597899||measurement||ad||2015-11-09 04:07:45.984618@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:07:52.819345||measurement||ad||2015-11-09 04:07:45.984618@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:07:52.830893||measurement||loadtime||0:00:30.547097||5||0
+2015-11-09 04:07:56.975221||measurement||ad||2015-11-09 04:07:56.542185@|Free Public Record Search@|www.backgroundalert.com@|Enter any Name and State for Free. See What They Might Be Hiding||2||1
+2015-11-09 04:07:57.107652||measurement||ad||2015-11-09 04:07:56.542185@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:07:57.142408||measurement||loadtime||0:00:27.287350||2||1
+2015-11-09 04:07:57.142955||event||progress-marker||measurement-end||2||1
+2015-11-09 04:08:06.854017||measurement||ad||2015-11-09 04:08:06.382905@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||1
+2015-11-09 04:08:06.972594||measurement||ad||2015-11-09 04:08:06.382905@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 04:08:06.991768||measurement||loadtime||0:00:27.059253||1||1
+2015-11-09 04:08:06.992360||event||progress-marker||measurement-end||1||1
+2015-11-09 04:08:18.338883||measurement||ad||2015-11-09 04:08:15.691414@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 04:08:18.451804||measurement||ad||2015-11-09 04:08:15.691414@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 04:08:18.455562||measurement||loadtime||0:00:24.964092||4||0
+2015-11-09 04:08:23.546871||measurement||ad||2015-11-09 04:08:20.575553@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:08:23.661625||measurement||ad||2015-11-09 04:08:20.575553@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:08:23.667740||measurement||loadtime||0:00:25.835468||5||0
+2015-11-09 04:08:43.436231||measurement||ad||2015-11-09 04:08:41.308128@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 04:08:43.728337||measurement||ad||2015-11-09 04:08:41.308128@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 04:08:43.743985||measurement||loadtime||0:00:20.287811||4||0
+2015-11-09 04:08:44.305012||error||collecting ads||Error||0||1
+2015-11-09 04:08:44.305472||event||progress-marker||measurement-end||0||1
+2015-11-09 04:08:47.260455||measurement||ad||2015-11-09 04:08:45.439154@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:08:47.482241||measurement||ad||2015-11-09 04:08:45.439154@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:08:47.488116||measurement||loadtime||0:00:18.818558||5||0
+2015-11-09 04:09:07.279460||measurement||ad||2015-11-09 04:09:04.894741@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 04:09:07.361860||measurement||ad||2015-11-09 04:09:04.894741@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 04:09:07.365352||measurement||loadtime||0:00:18.620816||4||0
+2015-11-09 04:09:34.652706||measurement||ad||2015-11-09 04:09:30.775663@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 04:09:34.715371||measurement||ad||2015-11-09 04:09:30.775663@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||4||0
+2015-11-09 04:09:34.718791||measurement||loadtime||0:00:22.352370||4||0
+2015-11-09 04:09:34.719007||event||progress-marker||measurement-end||4||0
+2015-11-09 04:09:52.574480||error||collecting ads||Error||5||0
+2015-11-09 04:10:17.544696||measurement||ad||2015-11-09 04:10:13.913446@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:10:17.603734||measurement||ad||2015-11-09 04:10:13.913446@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||0
+2015-11-09 04:10:17.606944||measurement||loadtime||0:00:20.030805||5||0
+2015-11-09 04:10:17.607196||event||progress-marker||measurement-end||5||0
+2015-11-09 04:10:18.245328||meta||block_id end||7
+2015-11-09 04:10:18.247577||meta||block_id start||8
+2015-11-09 04:10:18.247663||meta||assignment||3@|0@|5@|4@|1@|2
+2015-11-09 04:10:21.864873||event||progress-marker||training-start||0||0
+2015-11-09 04:10:22.143210||event||progress-marker||training-start||5||0
+2015-11-09 04:10:22.333736||event||progress-marker||training-start||3||0
+2015-11-09 04:10:24.985348||event||progress-marker||training-start||2||1
+2015-11-09 04:10:25.405711||event||progress-marker||training-start||1||1
+2015-11-09 04:10:25.469712||event||progress-marker||training-start||4||1
+2015-11-09 04:10:26.865347||treatment||google search||Buy BMW||5||0
+2015-11-09 04:10:28.027233||treatment||google search||Buy BMW||0||0
+2015-11-09 04:10:28.042861||treatment||google search||Buy BMW||3||0
+2015-11-09 04:10:29.118638||error||visiting||google searchresults||5||0
+2015-11-09 04:10:29.779277||error||visiting||google searchresults||3||0
+2015-11-09 04:10:29.845782||error||visiting||google searchresults||0||0
+2015-11-09 04:10:30.575103||treatment||google search||Buy BMW||2||1
+2015-11-09 04:10:30.747096||treatment||google search||Buy BMW||4||1
+2015-11-09 04:10:31.044942||treatment||google search||Buy BMW||1||1
+2015-11-09 04:10:41.559608||error||visiting||google searchresults||2||1
+2015-11-09 04:10:41.594326||error||visiting||google searchresults||4||1
+2015-11-09 04:10:41.813130||error||visiting||google searchresults||1||1
+2015-11-09 04:10:48.768200||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 04:10:49.433948||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||0
+2015-11-09 04:10:51.200559||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 04:10:56.241524||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 04:10:58.763549||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||1
+2015-11-09 04:10:58.914795||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||1
+2015-11-09 04:11:07.100462||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 04:11:08.589699||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||0
+2015-11-09 04:11:09.449717||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 04:11:10.315641||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 04:11:12.319135||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||1
+2015-11-09 04:11:12.649951||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||1
+2015-11-09 04:11:17.132834||error||visiting||google searchresults||5||0
+2015-11-09 04:11:18.623036||error||visiting||google searchresults||0||0
+2015-11-09 04:11:19.481962||error||visiting||google searchresults||3||0
+2015-11-09 04:11:30.408742||error||visiting||google searchresults||1||1
+2015-11-09 04:11:31.550394||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CJHQ19P_gskCFUgvgQod-r4Cfw||5||0
+2015-11-09 04:11:32.366809||error||visiting||google searchresults||2||1
+2015-11-09 04:11:32.747581||error||visiting||google searchresults||4||1
+2015-11-09 04:11:32.988501||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CI3or9T_gskCFZMvgQodgGcBow||0||0
+2015-11-09 04:11:34.393985||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CNit5dT_gskCFZQ6gQodgPIGrA||3||0
+2015-11-09 04:11:43.503487||treatment||google search||BMW dealer||5||0
+2015-11-09 04:11:44.214769||error||visiting||google searchresults||5||0
+2015-11-09 04:11:44.404442||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CN-pgNr_gskCFdgLgQodfDYHIg||1||1
+2015-11-09 04:11:45.365978||treatment||google search||BMW dealer||0||0
+2015-11-09 04:11:46.011447||error||visiting||google searchresults||0||0
+2015-11-09 04:11:46.083772||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=COrJkdv_gskCFdc2gQodWIsEdg||4||1
+2015-11-09 04:11:46.584787||treatment||google search||BMW dealer||3||0
+2015-11-09 04:11:46.952297||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CISW-Nr_gskCFZAkgQodbqcDvw||2||1
+2015-11-09 04:11:47.569912||error||visiting||google searchresults||3||0
+2015-11-09 04:11:59.501619||treatment||google search||BMW dealer||1||1
+2015-11-09 04:12:00.717524||treatment||google search||BMW dealer||4||1
+2015-11-09 04:12:01.441852||treatment||google search||BMW dealer||2||1
+2015-11-09 04:12:03.433038||treatment||visit page||http://www.carsense.com/?gclid=COWJx-D_gskCFdgLgQodfDYHIg||5||0
+2015-11-09 04:12:05.665811||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COqkuOH_gskCFYc8gQod2K0NTg||0||0
+2015-11-09 04:12:08.471151||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMKVluL_gskCFdcZgQod5yUGlQ||3||0
+2015-11-09 04:12:10.972887||error||visiting||google searchresults||1||1
+2015-11-09 04:12:11.529928||error||visiting||google searchresults||4||1
+2015-11-09 04:12:12.252375||error||visiting||google searchresults||2||1
+2015-11-09 04:12:18.819209||treatment||visit page||http://www.carsense.com/?gclid=CMOl3en_gskCFUg9gQodzgsGsg||5||0
+2015-11-09 04:12:21.119780||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJKd5er_gskCFdgWgQodnTAApA||0||0
+2015-11-09 04:12:24.450847||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CO7Ckuz_gskCFdcRgQodXmkCzw||3||0
+2015-11-09 04:12:26.000199||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNDR-u3_gskCFYkjgQodPiQO3A||2||1
+2015-11-09 04:12:27.885382||treatment||visit page||http://www.carsense.com/?gclid=CLnvrO3_gskCFdgGgQodtJYOGQ||1||1
+2015-11-09 04:12:28.024718||treatment||visit page||http://www.carsense.com/?gclid=CMGmzu3_gskCFYY9gQodPk0Okw||4||1
+2015-11-09 04:12:28.879155||error||visiting||google searchresults||5||0
+2015-11-09 04:12:31.159890||error||visiting||google searchresults||0||0
+2015-11-09 04:12:34.482957||error||visiting||google searchresults||3||0
+2015-11-09 04:12:43.137680||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNGHv_T_gskCFdgUgQod7XIEQg||2||1
+2015-11-09 04:12:44.407658||treatment||visit page||http://www.usautomart.com/?gclid=CPL87_X_gskCFdgQgQodo1cHHw||5||0
+2015-11-09 04:12:44.546879||treatment||visit page||http://www.carsense.com/?gclid=CIGkvPX_gskCFYE8gQodHBICvw||4||1
+2015-11-09 04:12:46.844841||treatment||visit page||http://www.carsense.com/?gclid=CK3QsvX_gskCFZUlgQodkSENrQ||1||1
+2015-11-09 04:12:48.898888||treatment||visit page||http://www.carsense.com/?gclid=CLnH-vb_gskCFYkjgQodPiQO3A||0||0
+2015-11-09 04:12:53.136810||treatment||visit page||http://www.carsense.com/?gclid=CNyzxfj_gskCFdcSgQodbsAAfg||3||0
+2015-11-09 04:12:56.022114||treatment||google search||BMW||5||0
+2015-11-09 04:12:56.919656||error||visiting||google searchresults||5||0
+2015-11-09 04:13:00.553304||treatment||google search||BMW||0||0
+2015-11-09 04:13:01.273934||error||visiting||google searchresults||0||0
+2015-11-09 04:13:03.166346||error||visiting||google searchresults||2||1
+2015-11-09 04:13:04.657322||error||visiting||google searchresults||4||1
+2015-11-09 04:13:04.797035||treatment||google search||BMW||3||0
+2015-11-09 04:13:05.541926||error||visiting||google searchresults||3||0
+2015-11-09 04:13:06.898424||error||visiting||google searchresults||1||1
+2015-11-09 04:13:15.392894||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 04:13:20.378002||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CM2o_IaAg8kCFYY9gQodPk0Okw||4||1
+2015-11-09 04:13:21.723676||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807577?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CJeshIiAg8kCFYc7gQod-Q0MzA||1||1
+2015-11-09 04:13:22.283900||treatment||visit page||http://www.carsense.com/?gclid=CMWJnoaAg8kCFdgPgQodEnsOlw||2||1
+2015-11-09 04:13:22.755604||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 04:13:25.006909||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 04:13:31.568614||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 04:13:33.210971||treatment||google search||BMW||4||1
+2015-11-09 04:13:34.675126||treatment||google search||BMW||1||1
+2015-11-09 04:13:35.847794||treatment||google search||BMW||2||1
+2015-11-09 04:13:40.163230||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 04:13:41.396732||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 04:13:41.605597||error||visiting||google searchresults||5||0
+2015-11-09 04:13:45.719736||error||visiting||google searchresults||4||1
+2015-11-09 04:13:46.132728||error||visiting||google searchresults||1||1
+2015-11-09 04:13:47.162743||error||visiting||google searchresults||2||1
+2015-11-09 04:13:50.190473||error||visiting||google searchresults||0||0
+2015-11-09 04:13:51.427791||error||visiting||google searchresults||3||0
+2015-11-09 04:14:01.346347||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 04:14:11.348045||event||progress-marker||training-end||5||0
+2015-11-09 04:14:11.368652||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 04:14:13.727554||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||0
+2015-11-09 04:14:14.412702||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 04:14:16.665260||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 04:14:17.311053||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 04:14:23.729373||event||progress-marker||training-end||0||0
+2015-11-09 04:14:24.413488||event||progress-marker||training-end||3||0
+2015-11-09 04:14:27.007947||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 04:14:31.644280||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 04:14:36.397824||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 04:14:47.092909||error||visiting||google searchresults||2||1
+2015-11-09 04:14:51.704007||error||visiting||google searchresults||4||1
+2015-11-09 04:14:56.444420||error||visiting||google searchresults||1||1
+2015-11-09 04:15:03.787199||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 04:15:08.965084||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||1
+2015-11-09 04:15:13.405977||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 04:15:13.789052||event||progress-marker||training-end||2||1
+2015-11-09 04:15:18.967047||event||progress-marker||training-end||4||1
+2015-11-09 04:15:23.408273||event||progress-marker||training-end||1||1
+2015-11-09 04:15:23.826219||event||progress-marker||measurement-start||2||1
+2015-11-09 04:15:23.913243||event||progress-marker||measurement-start||0||0
+2015-11-09 04:15:23.988730||event||progress-marker||measurement-start||4||1
+2015-11-09 04:15:24.580688||event||progress-marker||measurement-start||3||0
+2015-11-09 04:15:26.556234||event||progress-marker||measurement-start||5||0
+2015-11-09 04:15:28.432599||event||progress-marker||measurement-start||1||1
+2015-11-09 04:16:17.582088||measurement||ad||2015-11-09 04:16:15.483616@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 04:16:18.385574||measurement||ad||2015-11-09 04:16:15.483616@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 04:16:18.740127||measurement||loadtime||0:00:49.912289||2||1
+2015-11-09 04:16:27.793916||measurement||ad||2015-11-09 04:16:02.076895@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||0
+2015-11-09 04:16:28.525482||measurement||ad||2015-11-09 04:16:02.076895@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:16:28.563275||measurement||loadtime||0:00:59.648448||0||0
+2015-11-09 04:16:30.602390||measurement||ad||2015-11-09 04:16:11.800120@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:16:31.021529||measurement||ad||2015-11-09 04:16:30.614344@|Risk Management Courses@|stanford.edu@|Strategic Decisions  Risk Mgmt. Online  Campus Certificate Courses||4||1
+2015-11-09 04:16:31.137674||measurement||ad||2015-11-09 04:16:30.614344@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:16:31.158003||measurement||loadtime||0:01:02.167337||4||1
+2015-11-09 04:16:31.520436||measurement||ad||2015-11-09 04:16:11.800120@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:16:31.559430||measurement||loadtime||0:01:01.976962||3||0
+2015-11-09 04:16:36.608601||measurement||ad||2015-11-09 04:16:35.866134@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||1||1
+2015-11-09 04:16:36.669917||measurement||ad||2015-11-09 04:16:35.866134@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:16:36.684846||measurement||loadtime||0:01:03.250623||1||1
+2015-11-09 04:16:39.887630||measurement||ad||2015-11-09 04:16:18.087187@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:16:41.120777||measurement||ad||2015-11-09 04:16:18.087187@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||0
+2015-11-09 04:16:41.187150||measurement||loadtime||0:01:09.629716||5||0
+2015-11-09 04:17:03.572546||measurement||ad||2015-11-09 04:16:56.226144@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||2||1
+2015-11-09 04:17:08.016389||measurement||ad||2015-11-09 04:16:56.226144@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:17:08.205515||measurement||loadtime||0:00:44.464639||2||1
+2015-11-09 04:17:08.521414||measurement||ad||2015-11-09 04:17:07.645257@|Risk Management Courses@|stanford.edu@|Strategic Decisions  Risk Mgmt. Online  Campus Certificate Courses||4||1
+2015-11-09 04:17:08.933492||measurement||ad||2015-11-09 04:17:07.645257@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:17:08.959732||measurement||loadtime||0:00:32.800482||4||1
+2015-11-09 04:17:15.311667||measurement||ad||2015-11-09 04:17:13.930066@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:17:15.820724||measurement||ad||2015-11-09 04:17:13.930066@|Data Mining Courses@|stanford.edu/Data-Mining@|Online Data Mining Courses, earn World-Class Credentials. Learn More||1||1
+2015-11-09 04:17:16.284605||measurement||loadtime||0:00:34.598835||1||1
+2015-11-09 04:17:22.718751||measurement||ad||2015-11-09 04:17:04.673997@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:17:23.207175||measurement||ad||2015-11-09 04:17:04.673997@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:17:23.213634||measurement||loadtime||0:00:49.649756||0||0
+2015-11-09 04:17:25.619277||measurement||ad||2015-11-09 04:17:05.552848@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:17:26.421785||measurement||ad||2015-11-09 04:17:15.609018@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||5||0
+2015-11-09 04:17:26.574454||measurement||ad||2015-11-09 04:17:05.552848@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:17:26.579071||measurement||loadtime||0:00:50.018315||3||0
+2015-11-09 04:17:27.444640||measurement||ad||2015-11-09 04:17:15.609018@|Free Public Record Search@|www.backgroundalert.com@|Enter any Name and State for Free. See What They Might Be Hiding||5||0
+2015-11-09 04:17:27.479952||measurement||loadtime||0:00:41.290779||5||0
+2015-11-09 04:17:44.906432||measurement||ad||2015-11-09 04:17:44.126011@|Risk Management Courses@|stanford.edu@|Strategic Decisions  Risk Mgmt. Online  Campus Certificate Courses||4||1
+2015-11-09 04:17:45.343648||measurement||ad||2015-11-09 04:17:44.126011@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:17:45.358534||measurement||loadtime||0:00:31.398039||4||1
+2015-11-09 04:17:48.739400||measurement||ad||2015-11-09 04:17:47.722120@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:17:49.622480||measurement||ad||2015-11-09 04:17:47.722120@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 04:17:49.698214||measurement||loadtime||0:00:36.491336||2||1
+2015-11-09 04:17:52.701336||measurement||ad||2015-11-09 04:17:51.423834@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 04:17:53.118078||measurement||ad||2015-11-09 04:17:51.423834@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||1||1
+2015-11-09 04:17:53.267644||measurement||loadtime||0:00:31.981757||1||1
+2015-11-09 04:18:10.622568||measurement||ad||2015-11-09 04:17:59.336018@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:18:12.555193||measurement||ad||2015-11-09 04:17:59.336018@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:18:12.763079||measurement||loadtime||0:00:44.548603||0||0
+2015-11-09 04:18:14.208571||measurement||ad||2015-11-09 04:18:00.582166@|Free Public Record Search@|www.backgroundalert.com@|Enter any Name and State for Free. See What They Might Be Hiding||5||0
+2015-11-09 04:18:16.250573||measurement||ad||2015-11-09 04:18:00.582166@|Arrest Records: 2 Secrets@|criminal.instantcheckmate.com@|1) Enter Name and State. 2) Access Full Background Checks Instantly.||5||0
+2015-11-09 04:18:16.271209||measurement||loadtime||0:00:43.790178||5||0
+2015-11-09 04:18:18.598442||measurement||ad||2015-11-09 04:18:17.467830@|Risk Management Courses@|stanford.edu@|Strategic Decisions  Risk Mgmt. Online  Campus Certificate Courses||4||1
+2015-11-09 04:18:18.895139||measurement||ad||2015-11-09 04:18:17.467830@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:18:18.930770||measurement||loadtime||0:00:28.571341||4||1
+2015-11-09 04:18:21.051110||measurement||ad||2015-11-09 04:17:59.107068@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:18:21.948936||measurement||ad||2015-11-09 04:17:59.107068@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:18:22.093740||measurement||loadtime||0:00:50.513946||3||0
+2015-11-09 04:18:26.856471||measurement||ad||2015-11-09 04:18:26.127615@|VA Home Loan Eligibility@|veteransunited.com@|See if You're Eligible for VA Loan. Requirements Listed. Find Out Now.||2||1
+2015-11-09 04:18:27.191653||measurement||ad||2015-11-09 04:18:26.127615@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 04:18:27.358831||measurement||loadtime||0:00:32.659128||2||1
+2015-11-09 04:18:37.623539||measurement||ad||2015-11-09 04:18:37.296894@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 04:18:37.727715||measurement||ad||2015-11-09 04:18:37.296894@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||1||1
+2015-11-09 04:18:37.807195||measurement||loadtime||0:00:39.538075||1||1
+2015-11-09 04:18:48.000420||measurement||ad||2015-11-09 04:18:47.542010@|Risk Management Courses@|stanford.edu@|Strategic Decisions  Risk Mgmt. Online  Campus Certificate Courses||4||1
+2015-11-09 04:18:48.081999||measurement||ad||2015-11-09 04:18:47.542010@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:18:48.093636||measurement||loadtime||0:00:24.161993||4||1
+2015-11-09 04:18:58.342327||measurement||ad||2015-11-09 04:18:47.860724@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:18:58.828544||measurement||ad||2015-11-09 04:18:47.860724@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:18:58.833751||measurement||loadtime||0:00:41.069214||0||0
+2015-11-09 04:19:03.188947||measurement||ad||2015-11-09 04:18:51.141763@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:19:04.000409||measurement||ad||2015-11-09 04:18:51.141763@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||5||0
+2015-11-09 04:19:04.072281||measurement||loadtime||0:00:42.800487||5||0
+2015-11-09 04:19:09.020022||measurement||ad||2015-11-09 04:19:07.280137@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||2||1
+2015-11-09 04:19:11.587410||measurement||ad||2015-11-09 04:19:07.280137@|Medicare Part D Plans@|medicare2015.org/Part-D-Options@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:19:11.609118||measurement||loadtime||0:00:39.249639||2||1
+2015-11-09 04:19:14.747162||measurement||ad||2015-11-09 04:19:13.562819@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 04:19:15.303471||measurement||ad||2015-11-09 04:19:13.562819@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:19:15.321950||measurement||loadtime||0:00:32.513297||1||1
+2015-11-09 04:19:17.566922||measurement||ad||2015-11-09 04:19:07.379839@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:19:18.165385||measurement||ad||2015-11-09 04:19:07.379839@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:19:18.180183||measurement||loadtime||0:00:51.085579||3||0
+2015-11-09 04:19:26.717819||measurement||ad||2015-11-09 04:19:25.854032@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||1
+2015-11-09 04:19:27.548466||measurement||ad||2015-11-09 04:19:25.854032@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:19:27.580884||measurement||loadtime||0:00:34.486583||4||1
+2015-11-09 04:19:43.430249||measurement||ad||2015-11-09 04:19:33.082865@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:19:43.810144||measurement||ad||2015-11-09 04:19:33.082865@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:19:43.845975||measurement||loadtime||0:00:40.011426||0||0
+2015-11-09 04:19:50.653509||measurement||ad||2015-11-09 04:19:50.232902@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 04:19:50.879093||measurement||ad||2015-11-09 04:19:50.232902@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:19:50.905473||measurement||loadtime||0:00:30.582162||1||1
+2015-11-09 04:19:53.434841||measurement||ad||2015-11-09 04:19:52.096817@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||2||1
+2015-11-09 04:19:53.633653||measurement||ad||2015-11-09 04:19:52.096817@|Medicare Part D Plans@|medicare2015.org/Part-D-Options@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:19:53.650582||measurement||loadtime||0:00:37.039946||2||1
+2015-11-09 04:19:54.344252||measurement||ad||2015-11-09 04:19:42.562698@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||0
+2015-11-09 04:19:55.345765||measurement||ad||2015-11-09 04:19:42.562698@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:19:55.357189||measurement||loadtime||0:00:46.283546||5||0
+2015-11-09 04:20:05.177414||measurement||ad||2015-11-09 04:20:04.444159@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:20:05.496426||measurement||ad||2015-11-09 04:19:57.185489@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:20:05.644544||measurement||ad||2015-11-09 04:20:04.444159@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:20:05.657009||measurement||loadtime||0:00:33.075354||4||1
+2015-11-09 04:20:05.731454||measurement||ad||2015-11-09 04:19:57.185489@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:20:05.736463||measurement||loadtime||0:00:42.555053||3||0
+2015-11-09 04:20:21.323583||measurement||ad||2015-11-09 04:20:13.389633@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:20:21.793073||measurement||ad||2015-11-09 04:20:13.389633@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:20:21.882341||measurement||loadtime||0:00:33.035751||0||0
+2015-11-09 04:20:24.674800||measurement||ad||2015-11-09 04:20:24.070035@|Free Diabetic Cookbook@|www.diabetes-cooking.com@|Limited Time offer for a 100% Free Cookbook full of Diabetic Recipes!||1||1
+2015-11-09 04:20:24.858296||measurement||ad||2015-11-09 04:20:24.070035@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:20:24.870250||measurement||loadtime||0:00:28.964285||1||1
+2015-11-09 04:20:33.806000||measurement||ad||2015-11-09 04:20:32.353415@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||2||1
+2015-11-09 04:20:35.536077||measurement||ad||2015-11-09 04:20:32.353415@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:20:35.632795||measurement||loadtime||0:00:36.980925||2||1
+2015-11-09 04:20:38.114253||measurement||ad||2015-11-09 04:20:29.664569@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:20:38.251338||measurement||ad||2015-11-09 04:20:29.664569@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||0
+2015-11-09 04:20:38.256486||measurement||loadtime||0:00:37.896778||5||0
+2015-11-09 04:20:40.342353||measurement||ad||2015-11-09 04:20:39.619346@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||1
+2015-11-09 04:20:41.376773||measurement||ad||2015-11-09 04:20:39.619346@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:20:41.388651||measurement||loadtime||0:00:30.730354||4||1
+2015-11-09 04:20:46.932521||measurement||ad||2015-11-09 04:20:38.601262@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:20:47.341091||measurement||ad||2015-11-09 04:20:38.601262@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:20:47.443492||measurement||loadtime||0:00:36.705936||3||0
+2015-11-09 04:20:59.157076||measurement||ad||2015-11-09 04:20:58.310726@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||1||1
+2015-11-09 04:20:59.394841||measurement||ad||2015-11-09 04:20:58.310726@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:20:59.544595||measurement||loadtime||0:00:29.673750||1||1
+2015-11-09 04:21:06.598954||measurement||ad||2015-11-09 04:20:56.677803@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:21:06.861611||measurement||ad||2015-11-09 04:20:56.677803@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:21:06.870490||measurement||loadtime||0:00:39.987015||0||0
+2015-11-09 04:21:07.466199||measurement||ad||2015-11-09 04:21:06.869752@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||2||1
+2015-11-09 04:21:07.561559||measurement||ad||2015-11-09 04:21:06.869752@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||2||1
+2015-11-09 04:21:07.578088||measurement||loadtime||0:00:26.944389||2||1
+2015-11-09 04:21:09.127752||measurement||ad||2015-11-09 04:21:08.778512@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:21:09.249750||measurement||ad||2015-11-09 04:21:08.778512@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:21:09.517421||measurement||loadtime||0:00:23.127261||4||1
+2015-11-09 04:21:16.155936||measurement||ad||2015-11-09 04:21:09.053645@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:21:16.350606||measurement||ad||2015-11-09 04:21:09.053645@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||0
+2015-11-09 04:21:16.357319||measurement||loadtime||0:00:33.100052||5||0
+2015-11-09 04:21:28.662296||measurement||ad||2015-11-09 04:21:28.196224@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||1||1
+2015-11-09 04:21:28.823988||measurement||ad||2015-11-09 04:21:28.196224@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:21:28.884160||measurement||loadtime||0:00:24.338330||1||1
+2015-11-09 04:21:32.684066||measurement||ad||2015-11-09 04:21:21.273587@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:21:34.016670||measurement||ad||2015-11-09 04:21:21.273587@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:21:34.026022||measurement||loadtime||0:00:41.581455||3||0
+2015-11-09 04:21:40.729702||measurement||ad||2015-11-09 04:21:40.348170@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:21:40.886751||measurement||ad||2015-11-09 04:21:40.348170@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 04:21:40.899680||measurement||loadtime||0:00:26.381670||4||1
+2015-11-09 04:21:40.903273||event||progress-marker||measurement-end||4||1
+2015-11-09 04:21:44.422823||measurement||ad||2015-11-09 04:21:43.469859@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:21:44.960259||measurement||ad||2015-11-09 04:21:43.469859@|VA Home Loan Eligibility@|veteransunited.com@|See if You're Eligible for VA Loan. Requirements Listed. Find Out Now.||2||1
+2015-11-09 04:21:44.990876||measurement||loadtime||0:00:32.412207||2||1
+2015-11-09 04:21:47.890207||measurement||ad||2015-11-09 04:21:40.717578@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:21:48.020253||measurement||ad||2015-11-09 04:21:40.717578@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:21:48.078454||measurement||loadtime||0:00:36.207346||0||0
+2015-11-09 04:21:57.923167||measurement||ad||2015-11-09 04:21:57.710882@|Public Arrest Records@|background.instantcheckmate.com@|1) Enter a Name  Search for Free. 2) View Background Check Instantly.||1||1
+2015-11-09 04:21:57.999989||measurement||ad||2015-11-09 04:21:57.710882@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 04:21:58.010592||measurement||loadtime||0:00:24.125140||1||1
+2015-11-09 04:21:58.010894||event||progress-marker||measurement-end||1||1
+2015-11-09 04:21:59.860822||measurement||ad||2015-11-09 04:21:52.799911@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:22:00.006473||measurement||ad||2015-11-09 04:21:52.799911@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||0
+2015-11-09 04:22:00.012506||measurement||loadtime||0:00:38.654527||5||0
+2015-11-09 04:22:11.856020||measurement||ad||2015-11-09 04:22:05.628890@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:22:12.023604||measurement||ad||2015-11-09 04:22:05.628890@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:22:12.031290||measurement||loadtime||0:00:33.004333||3||0
+2015-11-09 04:22:14.965379||measurement||ad||2015-11-09 04:22:14.769613@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||2||1
+2015-11-09 04:22:15.007173||measurement||ad||2015-11-09 04:22:14.769613@|Medicare Part D Plans@|medicare2015.org/Part-D-Options@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 04:22:15.013907||measurement||loadtime||0:00:25.022084||2||1
+2015-11-09 04:22:15.014382||event||progress-marker||measurement-end||2||1
+2015-11-09 04:22:19.893545||measurement||ad||2015-11-09 04:22:16.489982@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||0
+2015-11-09 04:22:20.113259||measurement||ad||2015-11-09 04:22:16.489982@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||0
+2015-11-09 04:22:20.121241||measurement||loadtime||0:00:27.041836||0||0
+2015-11-09 04:22:27.762860||measurement||ad||2015-11-09 04:22:24.868536@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 04:22:27.857806||measurement||ad||2015-11-09 04:22:24.868536@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||0
+2015-11-09 04:22:27.861225||measurement||loadtime||0:00:22.847214||5||0
+2015-11-09 04:22:37.740078||measurement||ad||2015-11-09 04:22:35.465746@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:22:38.065107||measurement||ad||2015-11-09 04:22:35.465746@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:22:38.073056||measurement||loadtime||0:00:21.040936||3||0
+2015-11-09 04:23:02.385081||measurement||ad||2015-11-09 04:22:59.758043@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:23:02.507154||measurement||ad||2015-11-09 04:22:59.758043@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||3||0
+2015-11-09 04:23:02.510416||measurement||loadtime||0:00:19.436102||3||0
+2015-11-09 04:23:02.510680||event||progress-marker||measurement-end||3||0
+2015-11-09 04:23:25.212211||error||collecting ads||Error||0||0
+2015-11-09 04:23:25.212487||event||progress-marker||measurement-end||0||0
+2015-11-09 04:23:32.915340||error||collecting ads||Error||5||0
+2015-11-09 04:23:32.915635||event||progress-marker||measurement-end||5||0
+2015-11-09 04:23:33.473306||meta||block_id end||8
+2015-11-09 04:23:33.475368||meta||block_id start||9
+2015-11-09 04:23:33.475473||meta||assignment||3@|2@|1@|0@|4@|5
+2015-11-09 04:23:37.087645||event||progress-marker||training-start||1||0
+2015-11-09 04:23:37.283453||event||progress-marker||training-start||2||0
+2015-11-09 04:23:37.428404||event||progress-marker||training-start||3||0
+2015-11-09 04:23:40.724728||event||progress-marker||training-start||0||1
+2015-11-09 04:23:40.753176||event||progress-marker||training-start||4||1
+2015-11-09 04:23:41.242660||event||progress-marker||training-start||5||1
+2015-11-09 04:23:41.940302||treatment||google search||Buy BMW||2||0
+2015-11-09 04:23:42.049707||treatment||google search||Buy BMW||3||0
+2015-11-09 04:23:42.534662||treatment||google search||Buy BMW||1||0
+2015-11-09 04:23:43.697587||error||visiting||google searchresults||2||0
+2015-11-09 04:23:43.872583||error||visiting||google searchresults||3||0
+2015-11-09 04:23:44.559069||error||visiting||google searchresults||1||0
+2015-11-09 04:23:46.230831||treatment||google search||Buy BMW||5||1
+2015-11-09 04:23:46.291335||treatment||google search||Buy BMW||0||1
+2015-11-09 04:23:46.363314||treatment||google search||Buy BMW||4||1
+2015-11-09 04:23:57.121151||error||visiting||google searchresults||5||1
+2015-11-09 04:23:57.185032||error||visiting||google searchresults||0||1
+2015-11-09 04:23:57.216640||error||visiting||google searchresults||4||1
+2015-11-09 04:24:00.505454||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 04:24:00.879803||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 04:24:01.092735||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 04:24:11.312617||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 04:24:11.496130||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 04:24:15.809966||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 04:24:16.437795||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 04:24:16.694840||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 04:24:17.415384||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 04:24:25.844332||error||visiting||google searchresults||1||0
+2015-11-09 04:24:26.437464||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 04:24:26.662065||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 04:24:26.734065||error||visiting||google searchresults||2||0
+2015-11-09 04:24:27.489041||error||visiting||google searchresults||3||0
+2015-11-09 04:24:29.698046||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 04:24:41.522641||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||2||0
+2015-11-09 04:24:46.519722||error||visiting||google searchresults||0||1
+2015-11-09 04:24:46.741744||error||visiting||google searchresults||4||1
+2015-11-09 04:24:47.499226||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 04:24:49.815290||error||visiting||google searchresults||5||1
+2015-11-09 04:25:00.127517||treatment||google search||BMW dealer||1||0
+2015-11-09 04:25:00.720024||treatment||google search||BMW dealer||2||0
+2015-11-09 04:25:00.904435||error||visiting||google searchresults||1||0
+2015-11-09 04:25:01.462378||error||visiting||google searchresults||2||0
+2015-11-09 04:25:01.708535||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||0||1
+2015-11-09 04:25:02.452808||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||4||1
+2015-11-09 04:25:03.164850||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 04:25:03.622673||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||5||1
+2015-11-09 04:25:16.946164||treatment||google search||BMW dealer||3||0
+2015-11-09 04:25:17.533050||treatment||google search||BMW dealer||0||1
+2015-11-09 04:25:17.911695||treatment||google search||BMW dealer||4||1
+2015-11-09 04:25:17.929064||error||visiting||google searchresults||3||0
+2015-11-09 04:25:18.355177||treatment||google search||BMW dealer||5||1
+2015-11-09 04:25:20.122602||treatment||visit page||http://www.carsense.com/?gclid=CIvrudyCg8kCFUUdgQodBswGAg||1||0
+2015-11-09 04:25:23.064307||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIbb3dyCg8kCFcUkgQod5NkDfg||2||0
+2015-11-09 04:25:28.496302||error||visiting||google searchresults||0||1
+2015-11-09 04:25:28.851782||error||visiting||google searchresults||4||1
+2015-11-09 04:25:29.317551||error||visiting||google searchresults||5||1
+2015-11-09 04:25:35.531537||treatment||visit page||http://www.carsense.com/?gclid=CI2Az-WCg8kCFVA6gQodiFIFoQ||1||0
+2015-11-09 04:25:36.295530||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP66yOSCg8kCFdgQgQodo1cHHw||3||0
+2015-11-09 04:25:38.423145||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CI6hhOeCg8kCFdcXgQodQqMC1A||2||0
+2015-11-09 04:25:42.773669||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMPXieqCg8kCFdgNgQodcuEFZg||5||1
+2015-11-09 04:25:45.596878||error||visiting||google searchresults||1||0
+2015-11-09 04:25:47.313867||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP7V0emCg8kCFVIbgQodFFQFtw||0||1
+2015-11-09 04:25:48.458026||error||visiting||google searchresults||2||0
+2015-11-09 04:25:48.658997||treatment||visit page||http://www.carsense.com/?gclid=CIz85umCg8kCFdgBgQodMekJLw||4||1
+2015-11-09 04:25:51.685971||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIfwqu2Cg8kCFY49gQodmmkLMA||3||0
+2015-11-09 04:26:00.065291||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIjZuPCCg8kCFdcYgQodr0oJqg||5||1
+2015-11-09 04:26:00.283207||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CO7e4_GCg8kCFdgJgQodmYkNDA||1||0
+2015-11-09 04:26:01.738362||error||visiting||google searchresults||3||0
+2015-11-09 04:26:04.148571||treatment||visit page||http://www.carsense.com/?gclid=CO6vpvOCg8kCFZQ6gQodgPIGrA||4||1
+2015-11-09 04:26:04.893214||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKDiy_KCg8kCFdcSgQodbsAAfg||0||1
+2015-11-09 04:26:11.739730||treatment||google search||BMW||1||0
+2015-11-09 04:26:12.961639||error||visiting||google searchresults||1||0
+2015-11-09 04:26:18.491072||treatment||visit page||http://www.carsense.com/?gclid=CI24u_mCg8kCFZQjgQodp6QJLQ||3||0
+2015-11-09 04:26:20.140404||error||visiting||google searchresults||5||1
+2015-11-09 04:26:24.248633||error||visiting||google searchresults||4||1
+2015-11-09 04:26:24.989973||error||visiting||google searchresults||0||1
+2015-11-09 04:26:28.256191||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||1||0
+2015-11-09 04:26:30.174570||treatment||google search||BMW||3||0
+2015-11-09 04:26:31.464341||error||visiting||google searchresults||3||0
+2015-11-09 04:26:37.879214||treatment||visit page||http://www.carsense.com/?gclid=CP7uoIKDg8kCFUUdgQodBswGAg||5||1
+2015-11-09 04:26:38.511602||error||visiting||google searchresults||2||0
+2015-11-09 04:26:38.548840||treatment||visit page||http://dealers.car.com/dealers/bmw?ukwid=a504797f-59a0-42f3-847d-e88ad8efd72e&udv=c&gclid=CPzBmoSDg8kCFdgNgQodcuEFZg||4||1
+2015-11-09 04:26:40.149222||treatment||visit page||http://www.carsense.com/?gclid=CIPVyYSDg8kCFYI8gQodSNAOFA||0||1
+2015-11-09 04:26:44.987351||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||1||0
+2015-11-09 04:26:49.872674||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 04:26:50.212300||treatment||google search||BMW||5||1
+2015-11-09 04:26:52.324778||treatment||google search||BMW||4||1
+2015-11-09 04:26:52.961616||treatment||google search||BMW||0||1
+2015-11-09 04:26:55.021529||error||visiting||google searchresults||1||0
+2015-11-09 04:26:58.555368||error||visiting||google searchresults||2||0
+2015-11-09 04:27:01.770166||error||visiting||google searchresults||5||1
+2015-11-09 04:27:03.400181||error||visiting||google searchresults||4||1
+2015-11-09 04:27:04.238763||error||visiting||google searchresults||0||1
+2015-11-09 04:27:06.259279||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 04:27:12.729341||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 04:27:16.304362||error||visiting||google searchresults||3||0
+2015-11-09 04:27:18.571824||error||visiting||google searchresults||2||0
+2015-11-09 04:27:21.453603||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 04:27:22.730563||event||progress-marker||training-end||1||0
+2015-11-09 04:27:22.765327||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 04:27:22.860301||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 04:27:31.438059||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||3||0
+2015-11-09 04:27:35.459292||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 04:27:36.992855||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 04:27:37.559059||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 04:27:38.602581||error||visiting||google searchresults||2||0
+2015-11-09 04:27:41.439709||event||progress-marker||training-end||3||0
+2015-11-09 04:27:55.562396||error||visiting||google searchresults||4||1
+2015-11-09 04:27:57.066926||error||visiting||google searchresults||5||1
+2015-11-09 04:27:57.601122||error||visiting||google searchresults||0||1
+2015-11-09 04:27:58.628446||error||visiting||google searchresults||2||0
+2015-11-09 04:28:09.565356||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||1
+2015-11-09 04:28:11.513917||treatment||google search||BMW||2||0
+2015-11-09 04:28:13.276702||error||visiting||google searchresults||2||0
+2015-11-09 04:28:14.706975||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 04:28:14.928659||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 04:28:19.566687||event||progress-marker||training-end||4||1
+2015-11-09 04:28:24.707620||event||progress-marker||training-end||5||1
+2015-11-09 04:28:24.929400||event||progress-marker||training-end||0||1
+2015-11-09 04:28:30.893687||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 04:28:46.611829||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 04:28:56.645862||error||visiting||google searchresults||2||0
+2015-11-09 04:29:11.733267||treatment||visit page||http://www.bmwusa.com/Standard/Content/SalesandPrograms/Offers.aspx||2||0
+2015-11-09 04:29:21.735161||event||progress-marker||training-end||2||0
+2015-11-09 04:29:21.763338||event||progress-marker||measurement-start||3||0
+2015-11-09 04:29:23.097057||event||progress-marker||measurement-start||1||0
+2015-11-09 04:29:24.749794||event||progress-marker||measurement-start||4||1
+2015-11-09 04:29:24.874309||event||progress-marker||measurement-start||5||1
+2015-11-09 04:29:25.098236||event||progress-marker||measurement-start||0||1
+2015-11-09 04:29:26.760888||event||progress-marker||measurement-start||2||0
+2015-11-09 04:30:07.114913||measurement||ad||2015-11-09 04:30:06.500323@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:30:07.318850||measurement||ad||2015-11-09 04:30:06.500323@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||1
+2015-11-09 04:30:07.338055||measurement||loadtime||0:00:37.462780||5||1
+2015-11-09 04:30:10.904160||measurement||ad||2015-11-09 04:30:10.464937@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:30:11.122628||measurement||ad||2015-11-09 04:30:10.464937@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||1
+2015-11-09 04:30:11.145793||measurement||loadtime||0:00:41.394862||4||1
+2015-11-09 04:30:12.705321||measurement||ad||2015-11-09 04:29:57.986359@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 04:30:13.154363||measurement||ad||2015-11-09 04:29:57.986359@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:30:13.164178||measurement||loadtime||0:00:46.399212||3||0
+2015-11-09 04:30:21.806892||measurement||ad||2015-11-09 04:30:04.170424@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:30:22.909074||measurement||ad||2015-11-09 04:30:04.170424@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 04:30:22.922315||measurement||loadtime||0:00:54.824484||1||0
+2015-11-09 04:30:39.127725||measurement||ad||2015-11-09 04:30:38.217521@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 04:30:39.434909||measurement||ad||2015-11-09 04:30:38.217521@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:30:39.605613||measurement||loadtime||0:01:09.506578||0||1
+2015-11-09 04:30:44.571629||measurement||ad||2015-11-09 04:30:14.401278@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:30:45.571673||measurement||ad||2015-11-09 04:30:14.401278@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||2||0
+2015-11-09 04:30:45.576552||measurement||loadtime||0:01:13.814732||2||0
+2015-11-09 04:30:49.555379||measurement||ad||2015-11-09 04:30:48.050748@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:30:49.806049||measurement||ad||2015-11-09 04:30:48.050748@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||1
+2015-11-09 04:30:49.823546||measurement||loadtime||0:00:37.485006||5||1
+2015-11-09 04:30:55.413235||measurement||ad||2015-11-09 04:30:53.519178@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:30:55.719944||measurement||ad||2015-11-09 04:30:53.519178@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||1
+2015-11-09 04:30:55.732232||measurement||loadtime||0:00:39.585563||4||1
+2015-11-09 04:31:08.057064||measurement||ad||2015-11-09 04:30:49.439377@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 04:31:09.104493||measurement||ad||2015-11-09 04:30:49.439377@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:31:09.116019||measurement||loadtime||0:00:50.951303||3||0
+2015-11-09 04:31:16.752337||measurement||ad||2015-11-09 04:30:57.000418@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:31:18.241168||measurement||ad||2015-11-09 04:30:57.000418@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 04:31:18.269686||measurement||loadtime||0:00:50.345762||1||0
+2015-11-09 04:31:18.814601||measurement||ad||2015-11-09 04:31:17.310093@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 04:31:19.914221||measurement||ad||2015-11-09 04:31:17.310093@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:31:19.948067||measurement||loadtime||0:00:35.341345||0||1
+2015-11-09 04:31:37.592575||measurement||ad||2015-11-09 04:31:35.869087@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:31:38.145606||measurement||ad||2015-11-09 04:31:35.869087@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||1
+2015-11-09 04:31:38.412731||measurement||loadtime||0:00:43.588452||5||1
+2015-11-09 04:31:41.602920||measurement||ad||2015-11-09 04:31:21.435629@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:31:43.046920||measurement||ad||2015-11-09 04:31:21.435629@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||2||0
+2015-11-09 04:31:43.120999||measurement||loadtime||0:00:52.543811||2||0
+2015-11-09 04:31:44.070696||measurement||ad||2015-11-09 04:31:42.319368@|Get Hulu Commercial Free@|www.hulu.com/start@|Come TV With Us. Watch New Series  Returning Faves with a Free Trial!||4||1
+2015-11-09 04:31:44.661805||measurement||ad||2015-11-09 04:31:42.319368@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:31:44.708401||measurement||loadtime||0:00:43.974648||4||1
+2015-11-09 04:31:56.665129||measurement||ad||2015-11-09 04:31:44.912845@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:31:57.222473||measurement||ad||2015-11-09 04:31:44.912845@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:31:57.229052||measurement||loadtime||0:00:43.111940||3||0
+2015-11-09 04:32:03.165344||measurement||ad||2015-11-09 04:31:55.173059@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:32:03.414953||measurement||ad||2015-11-09 04:31:55.173059@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 04:32:03.453230||measurement||loadtime||0:00:40.182761||1||0
+2015-11-09 04:32:05.271736||measurement||ad||2015-11-09 04:32:04.322724@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 04:32:05.532726||measurement||ad||2015-11-09 04:32:04.322724@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:32:05.896980||measurement||loadtime||0:00:40.948291||0||1
+2015-11-09 04:32:25.010212||measurement||ad||2015-11-09 04:32:16.317577@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:32:25.437476||measurement||ad||2015-11-09 04:32:16.317577@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||2||0
+2015-11-09 04:32:25.444040||measurement||loadtime||0:00:37.322242||2||0
+2015-11-09 04:32:26.713844||measurement||ad||2015-11-09 04:32:24.985149@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||1
+2015-11-09 04:32:27.205983||measurement||ad||2015-11-09 04:32:24.985149@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||1
+2015-11-09 04:32:27.268815||measurement||loadtime||0:00:37.559582||4||1
+2015-11-09 04:32:38.914549||measurement||ad||2015-11-09 04:32:30.876832@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:32:39.217872||measurement||ad||2015-11-09 04:32:30.876832@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:32:39.225274||measurement||loadtime||0:00:36.995478||3||0
+2015-11-09 04:32:41.249385||measurement||ad||2015-11-09 04:32:41.005143@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:32:41.315259||measurement||ad||2015-11-09 04:32:41.005143@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 04:32:41.352771||measurement||loadtime||0:00:57.939510||5||1
+2015-11-09 04:32:53.752573||measurement||ad||2015-11-09 04:32:49.527289@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 04:32:53.825663||measurement||ad||2015-11-09 04:32:49.527289@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:32:53.840676||measurement||loadtime||0:00:42.943211||0||1
+2015-11-09 04:32:57.265288||measurement||ad||2015-11-09 04:32:43.332420@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:32:57.805140||measurement||ad||2015-11-09 04:32:43.332420@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 04:32:57.819517||measurement||loadtime||0:00:49.365858||1||0
+2015-11-09 04:33:12.186889||measurement||ad||2015-11-09 04:33:00.561986@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:33:12.950949||measurement||ad||2015-11-09 04:33:00.561986@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||2||0
+2015-11-09 04:33:13.015445||measurement||loadtime||0:00:42.570137||2||0
+2015-11-09 04:33:13.162916||measurement||ad||2015-11-09 04:33:11.336219@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||1
+2015-11-09 04:33:13.461552||measurement||ad||2015-11-09 04:33:11.336219@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:33:13.538955||measurement||loadtime||0:00:41.269611||4||1
+2015-11-09 04:33:25.154199||measurement||ad||2015-11-09 04:33:14.162697@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:33:26.215246||measurement||ad||2015-11-09 04:33:14.162697@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 04:33:26.232775||measurement||loadtime||0:00:42.005990||3||0
+2015-11-09 04:33:29.816404||measurement||ad||2015-11-09 04:33:28.565906@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:33:29.963900||measurement||ad||2015-11-09 04:33:28.565906@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 04:33:30.005920||measurement||loadtime||0:00:43.651312||5||1
+2015-11-09 04:33:40.455303||measurement||ad||2015-11-09 04:33:39.667175@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||0||1
+2015-11-09 04:33:40.628735||measurement||ad||2015-11-09 04:33:39.667175@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:33:40.649061||measurement||loadtime||0:00:41.807321||0||1
+2015-11-09 04:33:47.194164||measurement||ad||2015-11-09 04:33:37.950374@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:33:47.839814||measurement||ad||2015-11-09 04:33:37.950374@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||1||0
+2015-11-09 04:33:48.016210||measurement||loadtime||0:00:45.196086||1||0
+2015-11-09 04:33:53.579652||measurement||ad||2015-11-09 04:33:52.998147@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||1
+2015-11-09 04:33:53.766980||measurement||ad||2015-11-09 04:33:52.998147@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:33:53.785948||measurement||loadtime||0:00:35.245486||4||1
+2015-11-09 04:34:08.537588||measurement||ad||2015-11-09 04:34:07.940392@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:34:08.613384||measurement||ad||2015-11-09 04:34:07.940392@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 04:34:08.623571||measurement||loadtime||0:00:33.617054||5||1
+2015-11-09 04:34:12.538042||measurement||ad||2015-11-09 04:34:01.272690@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:34:12.954606||measurement||ad||2015-11-09 04:34:01.272690@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:34:13.071121||measurement||loadtime||0:00:41.837859||3||0
+2015-11-09 04:34:15.132584||measurement||ad||2015-11-09 04:33:57.275767@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:34:17.144938||measurement||ad||2015-11-09 04:33:57.275767@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||2||0
+2015-11-09 04:34:17.201721||measurement||loadtime||0:00:59.184633||2||0
+2015-11-09 04:34:22.021705||measurement||ad||2015-11-09 04:34:21.224128@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:34:22.421307||measurement||ad||2015-11-09 04:34:21.224128@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:34:22.432961||measurement||loadtime||0:00:36.782916||0||1
+2015-11-09 04:34:30.139233||measurement||ad||2015-11-09 04:34:21.425339@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:34:30.459789||measurement||ad||2015-11-09 04:34:21.425339@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 04:34:30.513861||measurement||ad||2015-11-09 04:34:29.920392@|Get Hulu Commercial Free@|www.hulu.com/start@|Come TV With Us. Watch New Series  Returning Faves with a Free Trial!||4||1
+2015-11-09 04:34:30.566188||measurement||loadtime||0:00:37.549486||1||0
+2015-11-09 04:34:30.650262||measurement||ad||2015-11-09 04:34:29.920392@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||1
+2015-11-09 04:34:30.664287||measurement||loadtime||0:00:31.877521||4||1
+2015-11-09 04:34:51.497842||measurement||ad||2015-11-09 04:34:50.738007@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:34:51.846952||measurement||ad||2015-11-09 04:34:50.738007@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 04:34:51.899476||measurement||loadtime||0:00:38.275207||5||1
+2015-11-09 04:35:03.514511||measurement||ad||2015-11-09 04:35:02.403120@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||0||1
+2015-11-09 04:35:03.951932||measurement||ad||2015-11-09 04:35:02.403120@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:35:03.974366||measurement||loadtime||0:00:36.540775||0||1
+2015-11-09 04:35:08.179091||measurement||ad||2015-11-09 04:34:53.197830@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:35:09.385117||measurement||ad||2015-11-09 04:34:53.197830@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 04:35:09.399083||measurement||loadtime||0:00:47.196731||2||0
+2015-11-09 04:35:15.204270||measurement||ad||2015-11-09 04:35:03.526043@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:35:16.092279||measurement||ad||2015-11-09 04:35:03.526043@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 04:35:16.136056||measurement||loadtime||0:00:40.568887||1||0
+2015-11-09 04:35:18.336351||error||collecting ads||Error||3||0
+2015-11-09 04:35:33.737221||measurement||ad||2015-11-09 04:35:33.286399@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:35:34.115840||measurement||ad||2015-11-09 04:35:33.286399@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 04:35:34.134944||measurement||loadtime||0:00:37.234002||5||1
+2015-11-09 04:35:35.715886||error||collecting ads||Error||4||1
+2015-11-09 04:35:45.134910||measurement||ad||2015-11-09 04:35:44.884401@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 04:35:45.219160||measurement||ad||2015-11-09 04:35:44.884401@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:35:45.233278||measurement||loadtime||0:00:36.257509||0||1
+2015-11-09 04:35:54.598596||measurement||ad||2015-11-09 04:35:46.319385@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:35:55.369890||measurement||ad||2015-11-09 04:35:46.319385@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 04:35:55.532587||measurement||loadtime||0:00:41.132542||2||0
+2015-11-09 04:35:57.831689||measurement||ad||2015-11-09 04:35:55.072773@|Get Hulu Commercial Free@|www.hulu.com/start@|Come TV With Us. Watch New Series  Returning Faves with a Free Trial!||4||1
+2015-11-09 04:36:00.167198||measurement||ad||2015-11-09 04:35:52.216306@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:36:00.777534||measurement||ad||2015-11-09 04:35:52.216306@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:36:00.795352||measurement||loadtime||0:00:37.457997||3||0
+2015-11-09 04:36:01.126675||measurement||ad||2015-11-09 04:35:55.072773@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||1
+2015-11-09 04:36:01.277246||measurement||loadtime||0:00:20.559247||4||1
+2015-11-09 04:36:09.074034||measurement||ad||2015-11-09 04:36:08.127054@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:36:09.156699||measurement||ad||2015-11-09 04:36:08.127054@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 04:36:09.177343||measurement||loadtime||0:00:30.041439||5||1
+2015-11-09 04:36:18.956189||measurement||ad||2015-11-09 04:36:17.803746@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 04:36:19.136934||measurement||ad||2015-11-09 04:36:17.803746@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:36:19.159814||measurement||loadtime||0:00:28.925754||0||1
+2015-11-09 04:36:21.382366||error||collecting ads||Error||1||0
+2015-11-09 04:36:34.344835||measurement||ad||2015-11-09 04:36:25.715102@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:36:34.542821||measurement||ad||2015-11-09 04:36:25.715102@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 04:36:34.548007||measurement||loadtime||0:00:34.013806||2||0
+2015-11-09 04:36:39.570910||measurement||ad||2015-11-09 04:36:38.057334@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||1
+2015-11-09 04:36:40.042664||measurement||ad||2015-11-09 04:36:38.057334@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||1
+2015-11-09 04:36:40.067848||measurement||loadtime||0:00:33.789055||4||1
+2015-11-09 04:36:40.075099||event||progress-marker||measurement-end||4||1
+2015-11-09 04:36:46.911121||measurement||ad||2015-11-09 04:36:38.334388@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:36:47.134611||measurement||ad||2015-11-09 04:36:38.334388@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:36:47.158954||measurement||loadtime||0:00:41.362708||3||0
+2015-11-09 04:36:51.772557||measurement||ad||2015-11-09 04:36:48.725410@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 04:36:51.895380||measurement||ad||2015-11-09 04:36:48.725410@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 04:36:51.913157||measurement||loadtime||0:00:37.734783||5||1
+2015-11-09 04:36:51.915532||event||progress-marker||measurement-end||5||1
+2015-11-09 04:36:54.872454||measurement||ad||2015-11-09 04:36:54.401586@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:36:54.976116||measurement||ad||2015-11-09 04:36:54.401586@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 04:36:55.024250||measurement||loadtime||0:00:30.863790||0||1
+2015-11-09 04:36:55.026452||event||progress-marker||measurement-end||0||1
+2015-11-09 04:37:04.623333||measurement||ad||2015-11-09 04:37:00.023907@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:37:04.764017||measurement||ad||2015-11-09 04:37:00.023907@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 04:37:04.783519||measurement||loadtime||0:00:38.397628||1||0
+2015-11-09 04:37:14.970720||measurement||ad||2015-11-09 04:37:11.706058@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 04:37:15.081733||measurement||ad||2015-11-09 04:37:11.706058@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:37:15.085404||measurement||loadtime||0:00:22.925819||3||0
+2015-11-09 04:37:15.085749||event||progress-marker||measurement-end||3||0
+2015-11-09 04:37:19.478668||measurement||ad||2015-11-09 04:37:11.502613@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:37:20.068243||measurement||ad||2015-11-09 04:37:11.502613@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 04:37:20.136645||measurement||loadtime||0:00:40.587979||2||0
+2015-11-09 04:37:29.024950||measurement||ad||2015-11-09 04:37:26.576605@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||1||0
+2015-11-09 04:37:29.139409||measurement||ad||2015-11-09 04:37:26.576605@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 04:37:29.145268||measurement||loadtime||0:00:19.361246||1||0
+2015-11-09 04:37:29.145693||event||progress-marker||measurement-end||1||0
+2015-11-09 04:37:45.243589||measurement||ad||2015-11-09 04:37:42.945430@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 04:37:45.324170||measurement||ad||2015-11-09 04:37:42.945430@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 04:37:45.327840||measurement||loadtime||0:00:20.190367||2||0
+2015-11-09 04:37:45.328115||event||progress-marker||measurement-end||2||0
+2015-11-09 04:37:45.876736||meta||block_id end||9
+2015-11-09 04:37:45.878760||meta||block_id start||10
+2015-11-09 04:37:45.878978||meta||assignment||2@|3@|4@|0@|5@|1
+2015-11-09 04:37:49.561336||event||progress-marker||training-start||2||0
+2015-11-09 04:37:49.612201||event||progress-marker||training-start||3||0
+2015-11-09 04:37:49.621096||event||progress-marker||training-start||4||0
+2015-11-09 04:37:52.511133||event||progress-marker||training-start||0||1
+2015-11-09 04:37:52.826041||event||progress-marker||training-start||5||1
+2015-11-09 04:37:52.951468||event||progress-marker||training-start||1||1
+2015-11-09 04:37:54.277908||treatment||google search||Buy BMW||3||0
+2015-11-09 04:37:54.353030||treatment||google search||Buy BMW||2||0
+2015-11-09 04:37:55.556747||treatment||google search||Buy BMW||4||0
+2015-11-09 04:37:56.192377||error||visiting||google searchresults||3||0
+2015-11-09 04:37:56.264708||error||visiting||google searchresults||2||0
+2015-11-09 04:37:56.863004||error||visiting||google searchresults||4||0
+2015-11-09 04:37:57.375303||treatment||google search||Buy BMW||0||1
+2015-11-09 04:37:57.420619||treatment||google search||Buy BMW||5||1
+2015-11-09 04:37:58.015881||treatment||google search||Buy BMW||1||1
+2015-11-09 04:38:08.255744||error||visiting||google searchresults||0||1
+2015-11-09 04:38:08.290096||error||visiting||google searchresults||5||1
+2015-11-09 04:38:08.708722||error||visiting||google searchresults||1||1
+2015-11-09 04:38:17.529483||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 04:38:19.528872||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 04:38:20.352663||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 04:38:25.327482||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 04:38:25.420012||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 04:38:25.473480||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 04:38:33.596552||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 04:38:39.687398||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 04:38:40.428075||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 04:38:40.790624||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 04:38:40.837409||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 04:38:40.936071||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 04:38:43.630749||error||visiting||google searchresults||3||0
+2015-11-09 04:38:49.721785||error||visiting||google searchresults||2||0
+2015-11-09 04:38:50.461609||error||visiting||google searchresults||4||0
+2015-11-09 04:38:57.587898||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CMOP5OSFg8kCFUUdgQodBswGAg||3||0
+2015-11-09 04:39:00.822390||error||visiting||google searchresults||5||1
+2015-11-09 04:39:00.881739||error||visiting||google searchresults||1||1
+2015-11-09 04:39:01.060120||error||visiting||google searchresults||0||1
+2015-11-09 04:39:03.974815||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CISB2OeFg8kCFdgVgQodCWoF0w||2||0
+2015-11-09 04:39:04.662492||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CIuQhuiFg8kCFYkjgQodPiQO3A||4||0
+2015-11-09 04:39:09.202960||treatment||google search||BMW dealer||3||0
+2015-11-09 04:39:09.865030||error||visiting||google searchresults||3||0
+2015-11-09 04:39:14.327621||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CLjPju2Fg8kCFUg9gQodzgsGsg||0||1
+2015-11-09 04:39:15.725073||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CMiU_uyFg8kCFVI7gQodrjYBDQ||5||1
+2015-11-09 04:39:15.771848||treatment||google search||BMW dealer||2||0
+2015-11-09 04:39:15.979694||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CI_Rgu2Fg8kCFYE8gQodHBICvw||1||1
+2015-11-09 04:39:16.524729||treatment||google search||BMW dealer||4||0
+2015-11-09 04:39:16.871581||error||visiting||google searchresults||2||0
+2015-11-09 04:39:17.217786||error||visiting||google searchresults||4||0
+2015-11-09 04:39:26.480783||treatment||google search||BMW dealer||0||1
+2015-11-09 04:39:29.113278||treatment||google search||BMW dealer||5||1
+2015-11-09 04:39:29.885825||treatment||google search||BMW dealer||1||1
+2015-11-09 04:39:33.638585||treatment||visit page||http://www.carsense.com/?gclid=COC85fSFg8kCFVUlgQodJdoD7Q||4||0
+2015-11-09 04:39:36.471855||treatment||visit page||http://www.carsense.com/?gclid=CJ3l0fSFg8kCFdgBgQodMekJLw||2||0
+2015-11-09 04:39:37.814733||error||visiting||google searchresults||0||1
+2015-11-09 04:39:40.574414||error||visiting||google searchresults||5||1
+2015-11-09 04:39:41.047717||error||visiting||google searchresults||1||1
+2015-11-09 04:39:49.106393||treatment||visit page||http://www.carsense.com/?gclid=CPmNzvyFg8kCFU47gQod-GIG7g||4||0
+2015-11-09 04:39:53.032156||treatment||visit page||http://www.carsense.com/?gclid=CPCM-_2Fg8kCFdcXgQodQqMC1A||2||0
+2015-11-09 04:39:55.289872||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPq7mICGg8kCFZMvgQodgGcBow||1||1
+2015-11-09 04:39:56.589029||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CO-1zf6Fg8kCFZYkgQod96sHBA||0||1
+2015-11-09 04:39:59.144111||error||visiting||google searchresults||4||0
+2015-11-09 04:39:59.920095||error||visiting||google searchresults||3||0
+2015-11-09 04:40:00.700551||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNa29_-Fg8kCFdgagQodCK4AMg||5||1
+2015-11-09 04:40:03.071535||error||visiting||google searchresults||2||0
+2015-11-09 04:40:09.987789||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CM70yIeGg8kCFUs8gQodYHoPqw||0||1
+2015-11-09 04:40:11.572236||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPSW-IaGg8kCFdgcgQodPBMC0w||1||1
+2015-11-09 04:40:14.851652||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807577?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389140104&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CKn15YiGg8kCFUkvgQod1qsDVQ||4||0
+2015-11-09 04:40:14.987535||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKmBzImGg8kCFYc7gQod-Q0MzA||5||1
+2015-11-09 04:40:18.597144||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CK2c1YqGg8kCFdgTgQodJKoCGw||2||0
+2015-11-09 04:40:19.940974||error||visiting||google searchresults||3||0
+2015-11-09 04:40:26.510373||treatment||google search||BMW||4||0
+2015-11-09 04:40:27.426802||error||visiting||google searchresults||4||0
+2015-11-09 04:40:30.059613||error||visiting||google searchresults||0||1
+2015-11-09 04:40:30.291551||treatment||google search||BMW||2||0
+2015-11-09 04:40:31.223835||error||visiting||google searchresults||2||0
+2015-11-09 04:40:31.606361||error||visiting||google searchresults||1||1
+2015-11-09 04:40:35.026011||error||visiting||google searchresults||5||1
+2015-11-09 04:40:39.950320||error||visiting||google searchresults||3||0
+2015-11-09 04:40:44.459925||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CNO4xZeGg8kCFdQ2gQodFwwNcw||0||1
+2015-11-09 04:40:47.184014||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 04:40:51.370165||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 04:40:51.563088||treatment||visit page||http://www.carsense.com/?gclid=CJepo5iGg8kCFRMjgQodg40D8w||1||1
+2015-11-09 04:40:52.299410||treatment||visit page||http://www.carsense.com/?gclid=CISG_ZmGg8kCFdUvgQodVzINNw||5||1
+2015-11-09 04:40:56.168233||treatment||google search||BMW||0||1
+2015-11-09 04:40:59.979690||error||visiting||google searchresults||3||0
+2015-11-09 04:41:02.722711||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 04:41:04.202014||treatment||google search||BMW||1||1
+2015-11-09 04:41:04.996011||treatment||google search||BMW||5||1
+2015-11-09 04:41:07.183216||error||visiting||google searchresults||0||1
+2015-11-09 04:41:08.432011||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 04:41:12.750239||error||visiting||google searchresults||4||0
+2015-11-09 04:41:15.589004||error||visiting||google searchresults||1||1
+2015-11-09 04:41:16.240222||error||visiting||google searchresults||5||1
+2015-11-09 04:41:18.467022||error||visiting||google searchresults||2||0
+2015-11-09 04:41:20.033298||error||visiting||google searchresults||3||0
+2015-11-09 04:41:27.311970||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 04:41:30.643197||treatment||visit page||http://www.bmwusa.com/Standard/Content/SalesandPrograms/Offers.aspx||4||0
+2015-11-09 04:41:34.649355||treatment||google search||BMW||3||0
+2015-11-09 04:41:35.918667||error||visiting||google searchresults||3||0
+2015-11-09 04:41:39.806047||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 04:41:40.644461||event||progress-marker||training-end||4||0
+2015-11-09 04:41:42.257286||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 04:41:47.125136||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 04:41:47.278073||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 04:41:49.807481||event||progress-marker||training-end||2||0
+2015-11-09 04:41:54.064638||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 04:42:02.314914||error||visiting||google searchresults||0||1
+2015-11-09 04:42:03.540872||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 04:42:03.595748||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 04:42:09.727766||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 04:42:19.762296||error||visiting||google searchresults||3||0
+2015-11-09 04:42:21.180573||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 04:42:23.603856||error||visiting||google searchresults||1||1
+2015-11-09 04:42:23.718386||error||visiting||google searchresults||5||1
+2015-11-09 04:42:31.183328||event||progress-marker||training-end||0||1
+2015-11-09 04:42:37.686336||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 04:42:39.813254||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 04:42:42.910961||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 04:42:47.687662||event||progress-marker||training-end||3||0
+2015-11-09 04:42:49.814933||event||progress-marker||training-end||5||1
+2015-11-09 04:42:52.912699||event||progress-marker||training-end||1||1
+2015-11-09 04:42:54.843419||event||progress-marker||measurement-start||5||1
+2015-11-09 04:42:55.021802||event||progress-marker||measurement-start||2||0
+2015-11-09 04:42:55.875774||event||progress-marker||measurement-start||4||0
+2015-11-09 04:42:56.277730||event||progress-marker||measurement-start||0||1
+2015-11-09 04:42:57.724886||event||progress-marker||measurement-start||3||0
+2015-11-09 04:42:57.937567||event||progress-marker||measurement-start||1||1
+2015-11-09 04:43:30.844238||measurement||ad||2015-11-09 04:43:29.956001@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 04:43:31.264279||measurement||ad||2015-11-09 04:43:29.956001@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:43:31.289070||measurement||loadtime||0:00:31.444086||5||1
+2015-11-09 04:43:43.700251||measurement||ad||2015-11-09 04:43:42.896389@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:43:43.972623||measurement||ad||2015-11-09 04:43:42.896389@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||1||1
+2015-11-09 04:43:43.999956||measurement||loadtime||0:00:41.060870||1||1
+2015-11-09 04:43:56.970912||measurement||ad||2015-11-09 04:43:56.164565@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:43:57.350914||measurement||ad||2015-11-09 04:43:38.842626@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:43:57.399174||measurement||ad||2015-11-09 04:43:56.164565@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 04:43:57.433496||measurement||loadtime||0:00:56.155143||0||1
+2015-11-09 04:43:58.059931||measurement||ad||2015-11-09 04:43:38.842626@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:43:58.066416||measurement||loadtime||0:00:55.340484||3||0
+2015-11-09 04:44:06.273719||measurement||ad||2015-11-09 04:43:48.543013@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:44:07.023384||measurement||ad||2015-11-09 04:43:48.543013@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||0
+2015-11-09 04:44:07.031352||measurement||loadtime||0:01:06.155061||4||0
+2015-11-09 04:44:09.191040||measurement||ad||2015-11-09 04:43:38.786627@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 04:44:09.844102||measurement||ad||2015-11-09 04:44:09.154023@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 04:44:10.070977||measurement||ad||2015-11-09 04:44:09.154023@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:44:10.084705||measurement||loadtime||0:00:33.794567||5||1
+2015-11-09 04:44:11.265866||measurement||ad||2015-11-09 04:43:38.786627@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 04:44:11.507504||measurement||loadtime||0:01:11.484242||2||0
+2015-11-09 04:44:24.887149||measurement||ad||2015-11-09 04:44:23.969501@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:44:25.158136||measurement||ad||2015-11-09 04:44:23.969501@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||1||1
+2015-11-09 04:44:25.172315||measurement||loadtime||0:00:36.171093||1||1
+2015-11-09 04:44:34.611201||measurement||ad||2015-11-09 04:44:32.932636@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:44:34.916634||measurement||ad||2015-11-09 04:44:32.932636@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:44:34.996372||measurement||loadtime||0:00:32.561422||0||1
+2015-11-09 04:44:45.759630||measurement||ad||2015-11-09 04:44:43.876597@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 04:44:45.992817||measurement||ad||2015-11-09 04:44:43.876597@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:44:46.121090||measurement||loadtime||0:00:31.035180||5||1
+2015-11-09 04:44:48.696762||measurement||ad||2015-11-09 04:44:31.536696@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:44:50.222448||measurement||ad||2015-11-09 04:44:31.536696@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:44:50.227127||measurement||loadtime||0:00:47.159336||3||0
+2015-11-09 04:45:03.138142||measurement||ad||2015-11-09 04:44:48.095987@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 04:45:03.995412||measurement||ad||2015-11-09 04:44:44.909202@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:45:04.636039||measurement||ad||2015-11-09 04:45:03.833363@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:45:04.864810||measurement||ad||2015-11-09 04:45:03.833363@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||1||1
+2015-11-09 04:45:04.933303||measurement||loadtime||0:00:34.759274||1||1
+2015-11-09 04:45:05.809150||measurement||ad||2015-11-09 04:44:44.909202@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 04:45:05.834785||measurement||loadtime||0:00:53.802681||4||0
+2015-11-09 04:45:08.377302||measurement||ad||2015-11-09 04:44:48.095987@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 04:45:08.420474||measurement||loadtime||0:00:51.912087||2||0
+2015-11-09 04:45:09.138759||measurement||ad||2015-11-09 04:45:08.064433@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:45:09.340977||measurement||ad||2015-11-09 04:45:08.064433@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:45:09.356615||measurement||loadtime||0:00:29.358962||0||1
+2015-11-09 04:45:20.131328||measurement||ad||2015-11-09 04:45:19.502069@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 04:45:20.218841||measurement||ad||2015-11-09 04:45:19.502069@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:45:20.281750||measurement||loadtime||0:00:29.160059||5||1
+2015-11-09 04:45:35.106314||measurement||ad||2015-11-09 04:45:23.820816@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:45:35.560934||measurement||ad||2015-11-09 04:45:23.820816@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:45:35.565344||measurement||loadtime||0:00:40.337578||3||0
+2015-11-09 04:45:37.822967||measurement||ad||2015-11-09 04:45:37.163452@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:45:38.677490||measurement||ad||2015-11-09 04:45:37.163452@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 04:45:38.703656||measurement||loadtime||0:00:28.769086||1||1
+2015-11-09 04:45:41.819000||measurement||ad||2015-11-09 04:45:41.169054@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:45:41.941780||measurement||ad||2015-11-09 04:45:41.169054@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:45:41.956527||measurement||loadtime||0:00:27.598361||0||1
+2015-11-09 04:45:51.055709||measurement||ad||2015-11-09 04:45:37.622293@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:45:51.554733||measurement||ad||2015-11-09 04:45:37.622293@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 04:45:51.560121||measurement||loadtime||0:00:40.722548||4||0
+2015-11-09 04:46:03.939879||measurement||ad||2015-11-09 04:46:02.905112@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 04:46:04.001826||measurement||ad||2015-11-09 04:46:02.905112@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:46:04.160352||measurement||loadtime||0:00:38.877721||5||1
+2015-11-09 04:46:07.304162||measurement||ad||2015-11-09 04:45:45.134390@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 04:46:08.410020||measurement||ad||2015-11-09 04:45:45.134390@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 04:46:08.415550||measurement||loadtime||0:00:54.993905||2||0
+2015-11-09 04:46:17.143274||measurement||ad||2015-11-09 04:46:16.507100@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:46:17.313237||measurement||ad||2015-11-09 04:46:16.507100@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:46:17.341796||measurement||loadtime||0:00:30.384309||0||1
+2015-11-09 04:46:19.598989||measurement||ad||2015-11-09 04:46:18.805830@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:46:19.782879||measurement||ad||2015-11-09 04:46:18.805830@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 04:46:19.893814||measurement||loadtime||0:00:36.188713||1||1
+2015-11-09 04:46:20.253389||measurement||ad||2015-11-09 04:46:11.211007@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:46:20.872767||measurement||ad||2015-11-09 04:46:11.211007@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:46:20.914808||measurement||loadtime||0:00:40.348049||3||0
+2015-11-09 04:46:37.047633||measurement||ad||2015-11-09 04:46:25.426443@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:46:37.231099||measurement||ad||2015-11-09 04:46:25.426443@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:46:37.236612||measurement||loadtime||0:00:40.675227||4||0
+2015-11-09 04:47:09.294712||error||collecting ads||Error||5||1
+2015-11-09 04:47:09.809759||measurement||ad||2015-11-09 04:47:04.805174@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:47:09.944235||measurement||ad||2015-11-09 04:47:04.805174@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:47:09.950376||measurement||loadtime||0:00:27.710876||4||0
+2015-11-09 04:47:13.779587||error||collecting ads||Error||2||0
+2015-11-09 04:47:22.772252||error||collecting ads||Error||0||1
+2015-11-09 04:47:24.958002||error||collecting ads||Error||1||1
+2015-11-09 04:47:25.760312||measurement||ad||2015-11-09 04:47:25.113588@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 04:47:26.000195||measurement||ad||2015-11-09 04:47:25.113588@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:47:26.018831||measurement||loadtime||0:00:11.722977||5||1
+2015-11-09 04:47:26.560916||error||collecting ads||Error||3||0
+2015-11-09 04:47:40.676439||measurement||ad||2015-11-09 04:47:39.668441@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:47:40.801250||measurement||ad||2015-11-09 04:47:39.668441@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:47:40.829075||measurement||loadtime||0:00:13.054447||0||1
+2015-11-09 04:47:44.651349||measurement||ad||2015-11-09 04:47:42.843419@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:47:44.974819||measurement||ad||2015-11-09 04:47:42.843419@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 04:47:44.986673||measurement||loadtime||0:00:15.026798||1||1
+2015-11-09 04:47:48.521601||measurement||ad||2015-11-09 04:47:36.760969@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:47:50.089035||measurement||ad||2015-11-09 04:47:36.760969@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:47:50.227431||measurement||loadtime||0:00:35.276250||4||0
+2015-11-09 04:48:07.540725||measurement||ad||2015-11-09 04:48:06.714268@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 04:48:07.802468||measurement||ad||2015-11-09 04:48:06.714268@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:48:07.818188||measurement||loadtime||0:00:36.798664||5||1
+2015-11-09 04:48:07.954969||measurement||ad||2015-11-09 04:47:58.840677@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:48:08.713490||measurement||ad||2015-11-09 04:47:58.840677@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 04:48:08.830788||measurement||loadtime||0:00:37.268238||3||0
+2015-11-09 04:48:14.875673||measurement||ad||2015-11-09 04:48:14.341968@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:48:15.239142||measurement||ad||2015-11-09 04:48:14.341968@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:48:15.265015||measurement||loadtime||0:00:29.433961||0||1
+2015-11-09 04:48:22.515295||measurement||ad||2015-11-09 04:48:21.202284@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:48:22.870538||measurement||ad||2015-11-09 04:48:21.202284@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||1||1
+2015-11-09 04:48:22.887204||measurement||loadtime||0:00:32.899398||1||1
+2015-11-09 04:48:27.641111||measurement||ad||2015-11-09 04:48:21.408750@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:48:27.908088||measurement||ad||2015-11-09 04:48:21.408750@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:48:27.916026||measurement||loadtime||0:00:32.687941||4||0
+2015-11-09 04:48:29.016602||error||collecting ads||Error||2||0
+2015-11-09 04:48:34.521213||measurement||ad||2015-11-09 04:48:34.050828@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 04:48:34.619171||measurement||ad||2015-11-09 04:48:34.050828@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:48:34.629100||measurement||loadtime||0:00:21.810140||5||1
+2015-11-09 04:48:39.978177||measurement||ad||2015-11-09 04:48:33.938771@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:48:40.374594||measurement||ad||2015-11-09 04:48:33.938771@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:48:40.408662||measurement||loadtime||0:00:26.576294||3||0
+2015-11-09 04:48:44.315280||measurement||ad||2015-11-09 04:48:44.054218@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:48:44.395611||measurement||ad||2015-11-09 04:48:44.054218@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:48:44.420811||measurement||loadtime||0:00:24.154075||0||1
+2015-11-09 04:49:01.413595||measurement||ad||2015-11-09 04:49:00.644340@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 04:49:01.574017||measurement||ad||2015-11-09 04:49:00.644340@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||5||1
+2015-11-09 04:49:01.596694||measurement||loadtime||0:00:21.965013||5||1
+2015-11-09 04:49:01.597337||event||progress-marker||measurement-end||5||1
+2015-11-09 04:49:01.968190||measurement||ad||2015-11-09 04:48:53.935611@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:49:02.199037||measurement||ad||2015-11-09 04:48:53.935611@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:49:02.215933||measurement||loadtime||0:00:29.296658||4||0
+2015-11-09 04:49:13.402637||measurement||ad||2015-11-09 04:49:08.398042@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:49:13.559282||measurement||ad||2015-11-09 04:49:08.398042@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:49:13.566993||measurement||loadtime||0:00:28.157791||3||0
+2015-11-09 04:49:13.801226||measurement||ad||2015-11-09 04:49:13.358762@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 04:49:13.876309||measurement||ad||2015-11-09 04:49:13.358762@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 04:49:13.890558||measurement||loadtime||0:00:24.468472||0||1
+2015-11-09 04:49:13.891348||event||progress-marker||measurement-end||0||1
+2015-11-09 04:49:27.927377||error||collecting ads||Error||1||1
+2015-11-09 04:49:29.686972||measurement||ad||2015-11-09 04:49:26.629671@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:49:29.774721||measurement||ad||2015-11-09 04:49:26.629671@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:49:29.781697||measurement||loadtime||0:00:22.562655||4||0
+2015-11-09 04:49:40.157614||measurement||ad||2015-11-09 04:49:36.570442@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:49:40.263696||measurement||ad||2015-11-09 04:49:36.570442@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:49:40.284772||measurement||loadtime||0:00:21.716995||3||0
+2015-11-09 04:49:43.970035||measurement||ad||2015-11-09 04:49:43.487684@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 04:49:44.038379||error||collecting ads||Error||2||0
+2015-11-09 04:49:44.226608||measurement||ad||2015-11-09 04:49:43.487684@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 04:49:44.282625||measurement||loadtime||0:00:11.354741||1||1
+2015-11-09 04:49:44.282909||event||progress-marker||measurement-end||1||1
+2015-11-09 04:49:53.845596||measurement||ad||2015-11-09 04:49:51.606104@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 04:49:53.923438||measurement||ad||2015-11-09 04:49:51.606104@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||0
+2015-11-09 04:49:53.928028||measurement||loadtime||0:00:19.145417||4||0
+2015-11-09 04:49:53.928416||event||progress-marker||measurement-end||4||0
+2015-11-09 04:50:01.360856||measurement||ad||2015-11-09 04:49:59.591774@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 04:50:01.531662||measurement||ad||2015-11-09 04:49:59.591774@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||3||0
+2015-11-09 04:50:01.544695||measurement||loadtime||0:00:16.259076||3||0
+2015-11-09 04:50:01.545081||event||progress-marker||measurement-end||3||0
+2015-11-09 04:50:59.060182||error||collecting ads||Error||2||0
+2015-11-09 04:52:14.078481||error||collecting ads||Error||2||0
+2015-11-09 04:53:29.100197||error||collecting ads||Error||2||0
+2015-11-09 04:54:44.121905||error||collecting ads||Error||2||0
+2015-11-09 04:54:44.122284||event||progress-marker||measurement-end||2||0
+2015-11-09 04:54:44.620636||meta||block_id end||10
+2015-11-09 04:54:44.623156||meta||block_id start||11
+2015-11-09 04:54:44.623271||meta||assignment||4@|1@|5@|0@|3@|2
+2015-11-09 04:54:48.372395||event||progress-marker||training-start||5||0
+2015-11-09 04:54:48.382350||event||progress-marker||training-start||1||0
+2015-11-09 04:54:48.728443||event||progress-marker||training-start||4||0
+2015-11-09 04:54:51.375740||event||progress-marker||training-start||3||1
+2015-11-09 04:54:51.463936||event||progress-marker||training-start||2||1
+2015-11-09 04:54:51.752889||event||progress-marker||training-start||0||1
+2015-11-09 04:54:53.057251||treatment||google search||Buy BMW||1||0
+2015-11-09 04:54:53.191585||treatment||google search||Buy BMW||4||0
+2015-11-09 04:54:54.546566||treatment||google search||Buy BMW||5||0
+2015-11-09 04:54:55.276774||error||visiting||google searchresults||1||0
+2015-11-09 04:54:55.397727||error||visiting||google searchresults||4||0
+2015-11-09 04:54:56.100188||error||visiting||google searchresults||5||0
+2015-11-09 04:54:57.089531||treatment||google search||Buy BMW||2||1
+2015-11-09 04:54:57.128361||treatment||google search||Buy BMW||0||1
+2015-11-09 04:54:57.190706||treatment||google search||Buy BMW||3||1
+2015-11-09 04:55:07.914178||error||visiting||google searchresults||2||1
+2015-11-09 04:55:07.919762||error||visiting||google searchresults||0||1
+2015-11-09 04:55:08.176582||error||visiting||google searchresults||3||1
+2015-11-09 04:55:11.266401||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 04:55:12.837047||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 04:55:13.143397||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 04:55:21.886510||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 04:55:24.452370||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 04:55:25.990429||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 04:55:27.789624||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 04:55:27.899046||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 04:55:34.487199||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 04:55:36.025520||error||visiting||google searchresults||1||0
+2015-11-09 04:55:36.627050||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 04:55:37.694253||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 04:55:37.835774||error||visiting||google searchresults||5||0
+2015-11-09 04:55:37.945656||error||visiting||google searchresults||4||0
+2015-11-09 04:55:50.351641||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 04:55:54.498422||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||4||0
+2015-11-09 04:55:54.527257||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 04:55:55.334201||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||5||0
+2015-11-09 04:55:56.694341||error||visiting||google searchresults||3||1
+2015-11-09 04:55:57.743156||error||visiting||google searchresults||2||1
+2015-11-09 04:56:06.129540||treatment||google search||BMW dealer||1||0
+2015-11-09 04:56:06.404339||treatment||google search||BMW dealer||4||0
+2015-11-09 04:56:06.904395||error||visiting||google searchresults||1||0
+2015-11-09 04:56:07.186198||error||visiting||google searchresults||4||0
+2015-11-09 04:56:07.306632||treatment||google search||BMW dealer||5||0
+2015-11-09 04:56:08.181965||error||visiting||google searchresults||5||0
+2015-11-09 04:56:09.989243||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||3||1
+2015-11-09 04:56:10.412589||error||visiting||google searchresults||0||1
+2015-11-09 04:56:10.955634||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||2||1
+2015-11-09 04:56:24.261588||treatment||google search||BMW dealer||3||1
+2015-11-09 04:56:24.579699||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||0||1
+2015-11-09 04:56:26.424981||treatment||google search||BMW dealer||2||1
+2015-11-09 04:56:27.500537||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||1||0
+2015-11-09 04:56:29.272940||treatment||visit page||http://www.carsense.com/?gclid=CJ707taJg8kCFYE8gQodHBICvw||5||0
+2015-11-09 04:56:35.439936||error||visiting||google searchresults||3||1
+2015-11-09 04:56:36.334982||treatment||google search||BMW dealer||0||1
+2015-11-09 04:56:37.325057||error||visiting||google searchresults||2||1
+2015-11-09 04:56:43.165749||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810||1||0
+2015-11-09 04:56:44.766772||treatment||visit page||http://www.carsense.com/?gclid=COWz9uCJg8kCFUgvgQod-r4Cfw||5||0
+2015-11-09 04:56:47.185226||error||visiting||google searchresults||0||1
+2015-11-09 04:56:52.509139||treatment||visit page||http://www.carsense.com/?gclid=CLz84-SJg8kCFdcYgQodr0oJqg||2||1
+2015-11-09 04:56:53.155843||treatment||visit page||http://www.carsense.com/?gclid=CK7h7uOJg8kCFdUvgQodVzINNw||3||1
+2015-11-09 04:56:53.214286||error||visiting||google searchresults||1||0
+2015-11-09 04:56:54.802547||error||visiting||google searchresults||5||0
+2015-11-09 04:56:57.247865||error||visiting||google searchresults||4||0
+2015-11-09 04:57:04.758333||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNiEu-mJg8kCFUkvgQod1qsDVQ||0||1
+2015-11-09 04:57:07.134309||treatment||visit page||http://www.carsense.com/?gclid=CLXPgeyJg8kCFdgLgQodEQEH0g||2||1
+2015-11-09 04:57:08.979184||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLyZquyJg8kCFUkvgQod1qsDVQ||1||0
+2015-11-09 04:57:09.357273||treatment||visit page||http://www.carsense.com/?gclid=CP3Qr-yJg8kCFZUlgQodkSENrQ||3||1
+2015-11-09 04:57:11.082424||treatment||visit page||http://dealers.car.com/dealers/bmw?ukwid=a504797f-59a0-42f3-847d-e88ad8efd72e&udv=c&gclid=CLq-jO2Jg8kCFRc6gQodS7sPmw||5||0
+2015-11-09 04:57:17.261137||error||visiting||google searchresults||4||0
+2015-11-09 04:57:20.450811||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKqi6vGJg8kCFYE2gQodAXcLFQ||0||1
+2015-11-09 04:57:20.687041||treatment||google search||BMW||1||0
+2015-11-09 04:57:21.998029||error||visiting||google searchresults||1||0
+2015-11-09 04:57:23.263538||treatment||google search||BMW||5||0
+2015-11-09 04:57:24.255525||error||visiting||google searchresults||5||0
+2015-11-09 04:57:27.260834||error||visiting||google searchresults||2||1
+2015-11-09 04:57:29.426775||error||visiting||google searchresults||3||1
+2015-11-09 04:57:37.322991||error||visiting||google searchresults||4||0
+2015-11-09 04:57:39.668781||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 04:57:40.271371||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 04:57:40.563722||error||visiting||google searchresults||0||1
+2015-11-09 04:57:40.894390||treatment||visit page||http://www.usautomart.com/?gclid=CIbzyvyJg8kCFYM6gQod_O4HNw||2||1
+2015-11-09 04:57:43.008717||treatment||visit page||http://www.usautomart.com/?gclid=COrZ0P2Jg8kCFdgGgQodtJYOGQ||3||1
+2015-11-09 04:57:54.724632||treatment||google search||BMW||2||1
+2015-11-09 04:57:55.818739||treatment||google search||BMW||3||1
+2015-11-09 04:57:57.346819||error||visiting||google searchresults||4||0
+2015-11-09 04:57:57.402895||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 04:57:59.156040||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 04:58:01.681742||treatment||visit page||http://www.carsense.com/?gclid=CPHW84KKg8kCFUQjgQodq_kAqw||0||1
+2015-11-09 04:58:06.024941||error||visiting||google searchresults||2||1
+2015-11-09 04:58:07.009514||error||visiting||google searchresults||3||1
+2015-11-09 04:58:07.437968||error||visiting||google searchresults||1||0
+2015-11-09 04:58:09.182911||error||visiting||google searchresults||5||0
+2015-11-09 04:58:13.757043||treatment||google search||BMW||0||1
+2015-11-09 04:58:17.381177||error||visiting||google searchresults||4||0
+2015-11-09 04:58:25.226996||error||visiting||google searchresults||0||1
+2015-11-09 04:58:25.991310||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 04:58:29.045733||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 04:58:29.334460||treatment||google search||BMW||4||0
+2015-11-09 04:58:30.223618||error||visiting||google searchresults||4||0
+2015-11-09 04:58:35.993034||event||progress-marker||training-end||1||0
+2015-11-09 04:58:36.481309||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 04:58:36.690655||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 04:58:39.046857||event||progress-marker||training-end||5||0
+2015-11-09 04:58:43.102181||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 04:58:45.473330||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||4||0
+2015-11-09 04:58:51.971823||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 04:58:52.373644||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 04:58:58.375790||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 04:59:00.236230||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||4||0
+2015-11-09 04:59:10.270142||error||visiting||google searchresults||4||0
+2015-11-09 04:59:12.023441||error||visiting||google searchresults||2||1
+2015-11-09 04:59:12.427039||error||visiting||google searchresults||3||1
+2015-11-09 04:59:18.424443||error||visiting||google searchresults||0||1
+2015-11-09 04:59:28.966863||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 04:59:29.292649||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 04:59:29.550052||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 04:59:32.723189||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 04:59:38.968584||event||progress-marker||training-end||4||0
+2015-11-09 04:59:39.294320||event||progress-marker||training-end||3||1
+2015-11-09 04:59:39.551854||event||progress-marker||training-end||2||1
+2015-11-09 04:59:42.724474||event||progress-marker||training-end||0||1
+2015-11-09 04:59:43.996886||event||progress-marker||measurement-start||4||0
+2015-11-09 04:59:44.289286||event||progress-marker||measurement-start||5||0
+2015-11-09 04:59:44.323733||event||progress-marker||measurement-start||3||1
+2015-11-09 04:59:44.579444||event||progress-marker||measurement-start||2||1
+2015-11-09 04:59:46.230179||event||progress-marker||measurement-start||1||0
+2015-11-09 04:59:47.751735||event||progress-marker||measurement-start||0||1
+2015-11-09 05:00:34.129316||measurement||ad||2015-11-09 05:00:32.446061@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||1
+2015-11-09 05:00:34.278220||measurement||ad||2015-11-09 05:00:32.446061@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 05:00:34.306229||measurement||loadtime||0:00:44.980983||3||1
+2015-11-09 05:00:36.172356||measurement||ad||2015-11-09 05:00:34.686142@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 05:00:37.374004||measurement||ad||2015-11-09 05:00:34.686142@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 05:00:37.449336||measurement||loadtime||0:00:47.868861||2||1
+2015-11-09 05:00:40.987738||measurement||ad||2015-11-09 05:00:40.362809@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:00:41.204538||measurement||ad||2015-11-09 05:00:40.362809@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 05:00:41.227482||measurement||loadtime||0:00:48.475173||0||1
+2015-11-09 05:00:46.946391||measurement||ad||2015-11-09 05:00:32.569599@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 05:00:48.202687||measurement||ad||2015-11-09 05:00:32.569599@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||5||0
+2015-11-09 05:00:48.341899||measurement||loadtime||0:00:59.051824||5||0
+2015-11-09 05:00:51.066927||measurement||ad||2015-11-09 05:00:34.189948@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 05:00:52.254692||measurement||ad||2015-11-09 05:00:34.189948@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:00:52.260072||measurement||loadtime||0:01:03.261898||4||0
+2015-11-09 05:01:09.510419||measurement||ad||2015-11-09 05:01:08.662553@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 05:01:09.855118||measurement||ad||2015-11-09 05:01:08.662553@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 05:01:09.866292||measurement||loadtime||0:00:30.558592||3||1
+2015-11-09 05:01:18.506007||measurement||ad||2015-11-09 05:01:16.606852@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 05:01:19.559483||measurement||ad||2015-11-09 05:01:16.606852@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 05:01:19.623339||measurement||loadtime||0:00:37.173229||2||1
+2015-11-09 05:01:24.960930||measurement||ad||2015-11-09 05:00:44.849484@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:01:26.433532||measurement||ad||2015-11-09 05:00:44.849484@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||1||0
+2015-11-09 05:01:26.457307||measurement||loadtime||0:01:35.225834||1||0
+2015-11-09 05:01:26.889362||measurement||ad||2015-11-09 05:01:26.111809@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:01:27.915621||measurement||ad||2015-11-09 05:01:26.111809@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||0||1
+2015-11-09 05:01:27.932912||measurement||loadtime||0:00:41.704235||0||1
+2015-11-09 05:01:42.060659||measurement||ad||2015-11-09 05:01:41.444612@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||3||1
+2015-11-09 05:01:42.581933||measurement||ad||2015-11-09 05:01:41.444612@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 05:01:42.610896||measurement||loadtime||0:00:27.741731||3||1
+2015-11-09 05:01:42.904703||measurement||ad||2015-11-09 05:01:24.290169@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 05:01:44.045947||measurement||ad||2015-11-09 05:01:24.290169@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||5||0
+2015-11-09 05:01:44.253306||measurement||loadtime||0:00:50.906611||5||0
+2015-11-09 05:01:46.484685||measurement||ad||2015-11-09 05:01:31.844572@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 05:01:47.359522||measurement||ad||2015-11-09 05:01:31.844572@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:01:47.364333||measurement||loadtime||0:00:50.103595||4||0
+2015-11-09 05:02:01.203487||measurement||ad||2015-11-09 05:01:56.951254@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 05:02:02.051279||measurement||ad||2015-11-09 05:01:56.951254@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:02:02.069820||measurement||loadtime||0:00:37.445611||2||1
+2015-11-09 05:02:05.910516||measurement||ad||2015-11-09 05:02:05.222984@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:02:06.134321||measurement||ad||2015-11-09 05:02:05.222984@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 05:02:06.146811||measurement||loadtime||0:00:33.213227||0||1
+2015-11-09 05:02:29.032065||measurement||ad||2015-11-09 05:02:13.174415@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:02:29.431020||measurement||ad||2015-11-09 05:02:25.041709@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||3||1
+2015-11-09 05:02:31.291395||measurement||ad||2015-11-09 05:02:25.041709@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 05:02:31.302766||measurement||loadtime||0:00:43.688760||3||1
+2015-11-09 05:02:31.379236||measurement||ad||2015-11-09 05:02:13.174415@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 05:02:31.478705||measurement||loadtime||0:01:00.020721||1||0
+2015-11-09 05:02:31.946685||measurement||ad||2015-11-09 05:02:19.106267@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 05:02:32.986039||measurement||ad||2015-11-09 05:02:19.106267@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 05:02:33.248179||measurement||loadtime||0:00:43.993652||5||0
+2015-11-09 05:02:34.546443||measurement||ad||2015-11-09 05:02:17.253442@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:02:35.812025||measurement||ad||2015-11-09 05:02:17.253442@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:02:36.045780||measurement||loadtime||0:00:43.680148||4||0
+2015-11-09 05:02:42.601624||measurement||ad||2015-11-09 05:02:41.740705@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:02:42.797558||measurement||ad||2015-11-09 05:02:41.740705@|Want Rapid Weight Loss?@|thyroid-weight-loss.com@|Power-Boost Your Metabolism With A A Simple Thyroid Fix! Learn More.||0||1
+2015-11-09 05:02:42.813963||measurement||loadtime||0:00:31.666373||0||1
+2015-11-09 05:03:04.873386||measurement||ad||2015-11-09 05:03:03.688495@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 05:03:05.388400||measurement||ad||2015-11-09 05:03:03.688495@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:03:05.408901||measurement||loadtime||0:00:58.338109||2||1
+2015-11-09 05:03:15.923722||measurement||ad||2015-11-09 05:03:14.836050@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||3||1
+2015-11-09 05:03:16.278091||measurement||ad||2015-11-09 05:03:14.836050@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 05:03:16.430992||measurement||loadtime||0:00:40.127569||3||1
+2015-11-09 05:03:16.725114||measurement||ad||2015-11-09 05:03:03.726661@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:03:17.402935||measurement||ad||2015-11-09 05:03:03.726661@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 05:03:17.409318||measurement||loadtime||0:00:40.929808||1||0
+2015-11-09 05:03:23.504866||measurement||ad||2015-11-09 05:03:13.012119@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 05:03:25.218522||measurement||ad||2015-11-09 05:03:13.012119@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:03:25.251803||measurement||ad||2015-11-09 05:03:24.591577@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:03:25.381900||measurement||ad||2015-11-09 05:03:24.591577@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 05:03:25.401624||measurement||loadtime||0:00:37.586081||0||1
+2015-11-09 05:03:25.548754||measurement||loadtime||0:00:44.501926||4||0
+2015-11-09 05:03:33.595592||measurement||ad||2015-11-09 05:03:23.007832@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 05:03:34.377367||measurement||ad||2015-11-09 05:03:23.007832@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||0
+2015-11-09 05:03:34.382138||measurement||loadtime||0:00:56.133141||5||0
+2015-11-09 05:03:43.093936||measurement||ad||2015-11-09 05:03:42.596334@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 05:03:43.271735||measurement||ad||2015-11-09 05:03:42.596334@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:03:43.299799||measurement||loadtime||0:00:32.890220||2||1
+2015-11-09 05:03:54.945366||measurement||ad||2015-11-09 05:03:54.162649@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 05:03:55.214481||measurement||ad||2015-11-09 05:03:54.162649@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||3||1
+2015-11-09 05:03:55.236471||measurement||loadtime||0:00:33.805002||3||1
+2015-11-09 05:04:04.852400||measurement||ad||2015-11-09 05:03:53.891301@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:04:05.904169||measurement||ad||2015-11-09 05:03:53.891301@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 05:04:05.924293||measurement||loadtime||0:00:43.513774||1||0
+2015-11-09 05:04:06.646626||measurement||ad||2015-11-09 05:04:05.446718@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:04:07.345199||measurement||ad||2015-11-09 05:04:05.446718@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 05:04:07.428783||measurement||loadtime||0:00:37.026098||0||1
+2015-11-09 05:04:09.625765||measurement||ad||2015-11-09 05:03:58.883906@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:04:10.390022||measurement||ad||2015-11-09 05:03:58.883906@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:04:10.406057||measurement||loadtime||0:00:39.856702||4||0
+2015-11-09 05:04:20.670258||measurement||ad||2015-11-09 05:04:08.998348@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||0
+2015-11-09 05:04:21.872500||measurement||ad||2015-11-09 05:04:08.998348@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||5||0
+2015-11-09 05:04:21.886882||measurement||loadtime||0:00:42.503546||5||0
+2015-11-09 05:04:29.159387||measurement||ad||2015-11-09 05:04:28.309764@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 05:04:29.304136||measurement||ad||2015-11-09 05:04:28.309764@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:04:29.532719||measurement||loadtime||0:00:41.231929||2||1
+2015-11-09 05:04:45.376948||measurement||ad||2015-11-09 05:04:42.027802@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:04:45.986058||measurement||ad||2015-11-09 05:04:42.027802@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||1
+2015-11-09 05:04:45.990582||measurement||ad||2015-11-09 05:04:45.211173@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 05:04:46.009810||measurement||loadtime||0:00:33.580224||0||1
+2015-11-09 05:04:46.141629||measurement||ad||2015-11-09 05:04:45.211173@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||3||1
+2015-11-09 05:04:46.436955||measurement||loadtime||0:00:46.199887||3||1
+2015-11-09 05:04:56.000376||measurement||ad||2015-11-09 05:04:42.692051@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:04:57.346832||measurement||ad||2015-11-09 05:04:42.692051@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 05:04:57.421517||measurement||loadtime||0:00:46.496357||1||0
+2015-11-09 05:04:57.572040||measurement||ad||2015-11-09 05:04:44.525781@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:04:58.354634||measurement||ad||2015-11-09 05:04:44.525781@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:04:58.366270||measurement||loadtime||0:00:42.958451||4||0
+2015-11-09 05:05:08.662396||measurement||ad||2015-11-09 05:05:08.272565@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:05:08.899528||measurement||ad||2015-11-09 05:05:08.272565@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||2||1
+2015-11-09 05:05:09.049065||measurement||loadtime||0:00:34.514629||2||1
+2015-11-09 05:05:15.154616||measurement||ad||2015-11-09 05:05:06.759181@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 05:05:16.307657||measurement||ad||2015-11-09 05:05:06.759181@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 05:05:16.398010||measurement||loadtime||0:00:49.510322||5||0
+2015-11-09 05:05:27.852758||measurement||ad||2015-11-09 05:05:27.307794@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:05:28.093823||measurement||ad||2015-11-09 05:05:27.307794@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||0||1
+2015-11-09 05:05:28.109475||measurement||loadtime||0:00:37.098668||0||1
+2015-11-09 05:05:38.765120||measurement||ad||2015-11-09 05:05:32.287216@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 05:05:39.485507||measurement||ad||2015-11-09 05:05:32.287216@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 05:05:39.503632||measurement||loadtime||0:00:48.065844||3||1
+2015-11-09 05:05:40.670336||measurement||ad||2015-11-09 05:05:31.440096@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:05:41.418809||measurement||ad||2015-11-09 05:05:31.440096@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:05:41.440286||measurement||loadtime||0:00:38.072952||4||0
+2015-11-09 05:05:41.783464||measurement||ad||2015-11-09 05:05:32.527815@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:05:42.232598||measurement||ad||2015-11-09 05:05:32.527815@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 05:05:42.327263||measurement||loadtime||0:00:39.905050||1||0
+2015-11-09 05:05:47.654038||measurement||ad||2015-11-09 05:05:46.654015@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:05:47.876780||measurement||ad||2015-11-09 05:05:46.654015@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||2||1
+2015-11-09 05:05:47.891592||measurement||loadtime||0:00:33.841889||2||1
+2015-11-09 05:06:01.384077||measurement||ad||2015-11-09 05:05:51.846805@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 05:06:01.941743||measurement||ad||2015-11-09 05:05:51.846805@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 05:06:01.947048||measurement||loadtime||0:00:40.548563||5||0
+2015-11-09 05:06:08.330580||measurement||ad||2015-11-09 05:06:06.490715@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:06:08.822967||measurement||ad||2015-11-09 05:06:06.490715@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 05:06:08.921171||measurement||loadtime||0:00:35.810567||0||1
+2015-11-09 05:06:19.678710||measurement||ad||2015-11-09 05:06:18.961464@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||3||1
+2015-11-09 05:06:19.897157||measurement||ad||2015-11-09 05:06:18.961464@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||3||1
+2015-11-09 05:06:19.907047||measurement||loadtime||0:00:35.402864||3||1
+2015-11-09 05:06:20.184466||measurement||ad||2015-11-09 05:06:11.848467@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 05:06:20.780239||measurement||ad||2015-11-09 05:06:11.848467@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:06:20.855340||measurement||loadtime||0:00:34.414455||4||0
+2015-11-09 05:06:27.105679||measurement||ad||2015-11-09 05:06:24.795619@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:06:27.342223||measurement||ad||2015-11-09 05:06:24.795619@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||2||1
+2015-11-09 05:06:27.400629||measurement||loadtime||0:00:34.507775||2||1
+2015-11-09 05:06:28.198336||measurement||ad||2015-11-09 05:06:18.184776@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 05:06:29.423103||measurement||ad||2015-11-09 05:06:18.184776@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 05:06:29.461865||measurement||loadtime||0:00:42.133061||1||0
+2015-11-09 05:06:54.467763||measurement||ad||2015-11-09 05:06:51.989193@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:06:54.746060||measurement||ad||2015-11-09 05:06:51.989193@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 05:06:54.767326||measurement||loadtime||0:00:40.845020||0||1
+2015-11-09 05:06:54.770621||event||progress-marker||measurement-end||0||1
+2015-11-09 05:07:02.729857||measurement||ad||2015-11-09 05:07:02.057308@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||3||1
+2015-11-09 05:07:02.873732||measurement||ad||2015-11-09 05:07:02.057308@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 05:07:02.887484||measurement||loadtime||0:00:37.979521||3||1
+2015-11-09 05:07:02.887777||event||progress-marker||measurement-end||3||1
+2015-11-09 05:07:03.916771||measurement||ad||2015-11-09 05:06:42.766118@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 05:07:04.265384||measurement||ad||2015-11-09 05:06:42.766118@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||5||0
+2015-11-09 05:07:04.270972||measurement||loadtime||0:00:57.323464||5||0
+2015-11-09 05:07:15.928916||measurement||ad||2015-11-09 05:07:11.581950@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 05:07:16.057821||measurement||ad||2015-11-09 05:07:11.581950@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 05:07:16.062545||measurement||loadtime||0:00:41.599201||1||0
+2015-11-09 05:07:26.163072||error||collecting ads||Error||4||0
+2015-11-09 05:07:32.497931||error||collecting ads||Error||2||1
+2015-11-09 05:07:32.498316||event||progress-marker||measurement-end||2||1
+2015-11-09 05:07:52.510545||measurement||ad||2015-11-09 05:07:41.716634@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:07:54.054442||measurement||ad||2015-11-09 05:07:41.716634@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 05:07:54.221734||measurement||loadtime||0:00:33.157916||1||0
+2015-11-09 05:07:59.596406||measurement||ad||2015-11-09 05:07:51.863217@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:07:59.854401||measurement||ad||2015-11-09 05:07:51.863217@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:07:59.858517||measurement||loadtime||0:00:28.693445||4||0
+2015-11-09 05:07:59.858771||event||progress-marker||measurement-end||4||0
+2015-11-09 05:08:10.940177||error||collecting ads||Error||5||0
+2015-11-09 05:08:22.555035||measurement||ad||2015-11-09 05:08:19.254900@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||0
+2015-11-09 05:08:22.681307||measurement||ad||2015-11-09 05:08:19.254900@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||1||0
+2015-11-09 05:08:22.684473||measurement||loadtime||0:00:23.462100||1||0
+2015-11-09 05:08:22.684989||event||progress-marker||measurement-end||1||0
+2015-11-09 05:08:41.840046||measurement||ad||2015-11-09 05:08:39.907262@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||0
+2015-11-09 05:08:41.962721||measurement||ad||2015-11-09 05:08:39.907262@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||0
+2015-11-09 05:08:41.965941||measurement||loadtime||0:00:26.025138||5||0
+2015-11-09 05:08:41.966177||event||progress-marker||measurement-end||5||0
+2015-11-09 05:08:42.582965||meta||block_id end||11
+2015-11-09 05:08:42.584900||meta||block_id start||12
+2015-11-09 05:08:42.585004||meta||assignment||2@|4@|3@|0@|5@|1
+2015-11-09 05:08:46.051138||event||progress-marker||training-start||2||0
+2015-11-09 05:08:46.068190||event||progress-marker||training-start||4||0
+2015-11-09 05:08:46.369117||event||progress-marker||training-start||3||0
+2015-11-09 05:08:49.787942||event||progress-marker||training-start||0||1
+2015-11-09 05:08:49.948740||event||progress-marker||training-start||5||1
+2015-11-09 05:08:50.503042||event||progress-marker||training-start||1||1
+2015-11-09 05:08:50.863185||treatment||google search||Buy BMW||2||0
+2015-11-09 05:08:51.841865||treatment||google search||Buy BMW||4||0
+2015-11-09 05:08:52.178606||treatment||google search||Buy BMW||3||0
+2015-11-09 05:08:52.746088||error||visiting||google searchresults||2||0
+2015-11-09 05:08:53.817732||error||visiting||google searchresults||4||0
+2015-11-09 05:08:53.949641||error||visiting||google searchresults||3||0
+2015-11-09 05:08:55.353498||treatment||google search||Buy BMW||0||1
+2015-11-09 05:08:55.396211||treatment||google search||Buy BMW||5||1
+2015-11-09 05:08:55.527089||treatment||google search||Buy BMW||1||1
+2015-11-09 05:09:06.242109||error||visiting||google searchresults||5||1
+2015-11-09 05:09:06.388337||error||visiting||google searchresults||1||1
+2015-11-09 05:09:06.395092||error||visiting||google searchresults||0||1
+2015-11-09 05:09:11.146000||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 05:09:12.262939||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 05:09:13.248964||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 05:09:20.058737||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 05:09:20.833668||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 05:09:22.778453||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 05:09:29.301667||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 05:09:30.019164||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 05:09:32.020289||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 05:09:33.489855||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 05:09:34.693964||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 05:09:36.223607||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 05:09:39.335455||error||visiting||google searchresults||3||0
+2015-11-09 05:09:40.053500||error||visiting||google searchresults||4||0
+2015-11-09 05:09:42.054769||error||visiting||google searchresults||2||0
+2015-11-09 05:09:53.525147||error||visiting||google searchresults||1||1
+2015-11-09 05:09:53.912930||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CK3i09mMg8kCFZI9gQod8jMJsA||3||0
+2015-11-09 05:09:54.376862||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CIr1gNqMg8kCFdgWgQodnTAApA||4||0
+2015-11-09 05:09:54.817168||error||visiting||google searchresults||0||1
+2015-11-09 05:09:56.284437||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJqt-tqMg8kCFdgGgQodtJYOGQ||2||0
+2015-11-09 05:09:56.286321||error||visiting||google searchresults||5||1
+2015-11-09 05:10:06.126209||treatment||google search||BMW dealer||3||0
+2015-11-09 05:10:06.480660||treatment||google search||BMW dealer||4||0
+2015-11-09 05:10:07.022873||error||visiting||google searchresults||3||0
+2015-11-09 05:10:07.407653||error||visiting||google searchresults||4||0
+2015-11-09 05:10:08.085062||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CNiQiOGMg8kCFdgOgQod3CYEoQ||0||1
+2015-11-09 05:10:08.388868||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CIjftuCMg8kCFVQkgQodfgMKbg||1||1
+2015-11-09 05:10:08.528508||treatment||google search||BMW dealer||2||0
+2015-11-09 05:10:09.255017||error||visiting||google searchresults||2||0
+2015-11-09 05:10:09.545240||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CMXi4eGMg8kCFVMvgQodTycJrA||5||1
+2015-11-09 05:10:24.523551||treatment||google search||BMW dealer||0||1
+2015-11-09 05:10:24.599249||treatment||google search||BMW dealer||5||1
+2015-11-09 05:10:24.622863||treatment||google search||BMW dealer||1||1
+2015-11-09 05:10:27.170179||treatment||visit page||http://www.towerautosales.com/index.shtml||2||0
+2015-11-09 05:10:28.713295||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKeqgueMg8kCFUkbgQodcCQMUQ||4||0
+2015-11-09 05:10:35.593359||error||visiting||google searchresults||1||1
+2015-11-09 05:10:35.665354||error||visiting||google searchresults||0||1
+2015-11-09 05:10:35.882746||error||visiting||google searchresults||5||1
+2015-11-09 05:10:41.225792||treatment||visit page||http://www.towerautosales.com/index.shtml||2||0
+2015-11-09 05:10:44.939776||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJuWnPGMg8kCFUo8gQodQ3oJ_A||4||0
+2015-11-09 05:10:49.663562||treatment||visit page||http://www.towerautosales.com/index.shtml||5||1
+2015-11-09 05:10:50.364614||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPXowvSMg8kCFdgYgQody_wFDQ||0||1
+2015-11-09 05:10:51.261918||error||visiting||google searchresults||2||0
+2015-11-09 05:10:54.846033||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPvLu_SMg8kCFdcRgQodXmkCzw||1||1
+2015-11-09 05:10:54.976129||error||visiting||google searchresults||4||0
+2015-11-09 05:10:57.078246||error||visiting||google searchresults||3||0
+2015-11-09 05:11:02.922375||treatment||visit page||http://www.towerautosales.com/index.shtml||5||1
+2015-11-09 05:11:06.163421||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CJ3W-PuMg8kCFdgcgQodPBMC0w||2||0
+2015-11-09 05:11:07.205248||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CK--wvuMg8kCFUQ2gQod3qUJlQ||0||1
+2015-11-09 05:11:12.626677||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP6S1P2Mg8kCFdcYgQodr0oJqg||1||1
+2015-11-09 05:11:13.715005||treatment||visit page||http://www.carsense.com/?gclid=CMXR4P2Mg8kCFVA6gQodiFIFoQ||4||0
+2015-11-09 05:11:17.088753||error||visiting||google searchresults||3||0
+2015-11-09 05:11:17.830133||treatment||google search||BMW||2||0
+2015-11-09 05:11:18.634334||error||visiting||google searchresults||2||0
+2015-11-09 05:11:22.991261||error||visiting||google searchresults||5||1
+2015-11-09 05:11:25.318754||treatment||google search||BMW||4||0
+2015-11-09 05:11:26.291608||error||visiting||google searchresults||4||0
+2015-11-09 05:11:27.328096||error||visiting||google searchresults||0||1
+2015-11-09 05:11:32.666645||error||visiting||google searchresults||1||1
+2015-11-09 05:11:36.545455||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 05:11:37.123409||error||visiting||google searchresults||3||0
+2015-11-09 05:11:37.488857||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CLnsiIuNg8kCFUo8gQodQ3oJ_A||5||1
+2015-11-09 05:11:45.403372||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 05:11:48.043805||treatment||visit page||http://www.carsense.com/?gclid=CPPAkY2Ng8kCFYM6gQod_O4HNw||0||1
+2015-11-09 05:11:48.781556||treatment||visit page||http://www.carsense.com/?gclid=CN3i3I-Ng8kCFdcXgQodQqMC1A||1||1
+2015-11-09 05:11:50.963103||treatment||google search||BMW||5||1
+2015-11-09 05:11:54.292439||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 05:11:57.164558||error||visiting||google searchresults||3||0
+2015-11-09 05:11:59.869242||treatment||google search||BMW||0||1
+2015-11-09 05:12:00.715172||treatment||google search||BMW||1||1
+2015-11-09 05:12:01.929879||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 05:12:02.023654||error||visiting||google searchresults||5||1
+2015-11-09 05:12:04.327315||error||visiting||google searchresults||2||0
+2015-11-09 05:12:11.454561||error||visiting||google searchresults||0||1
+2015-11-09 05:12:11.967662||error||visiting||google searchresults||4||0
+2015-11-09 05:12:12.078784||error||visiting||google searchresults||1||1
+2015-11-09 05:12:17.176772||error||visiting||google searchresults||3||0
+2015-11-09 05:12:24.872308||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 05:12:31.412029||treatment||google search||BMW||3||0
+2015-11-09 05:12:33.018020||error||visiting||google searchresults||3||0
+2015-11-09 05:12:34.874174||event||progress-marker||training-end||2||0
+2015-11-09 05:12:35.028168||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 05:12:37.591507||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 05:12:40.704657||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 05:12:45.029202||event||progress-marker||training-end||4||0
+2015-11-09 05:12:50.633173||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 05:12:51.109466||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:12:54.040695||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 05:12:54.060385||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 05:13:06.477008||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 05:13:07.642942||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:13:14.101590||error||visiting||google searchresults||5||1
+2015-11-09 05:13:14.171120||error||visiting||google searchresults||0||1
+2015-11-09 05:13:17.676782||error||visiting||google searchresults||3||0
+2015-11-09 05:13:26.594646||error||visiting||google searchresults||1||1
+2015-11-09 05:13:31.003771||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 05:13:33.859314||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 05:13:36.714173||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 05:13:40.273722||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 05:13:41.005596||event||progress-marker||training-end||0||1
+2015-11-09 05:13:43.859951||event||progress-marker||training-end||5||1
+2015-11-09 05:13:46.716137||event||progress-marker||training-end||3||0
+2015-11-09 05:13:50.275591||event||progress-marker||training-end||1||1
+2015-11-09 05:13:50.303109||event||progress-marker||measurement-start||4||0
+2015-11-09 05:13:51.050560||event||progress-marker||measurement-start||0||1
+2015-11-09 05:13:51.747508||event||progress-marker||measurement-start||3||0
+2015-11-09 05:13:53.906543||event||progress-marker||measurement-start||5||1
+2015-11-09 05:13:55.178480||event||progress-marker||measurement-start||2||0
+2015-11-09 05:13:55.310930||event||progress-marker||measurement-start||1||1
+2015-11-09 05:14:32.618171||measurement||ad||2015-11-09 05:14:19.710317@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:14:33.150829||measurement||ad||2015-11-09 05:14:19.710317@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 05:14:33.156867||measurement||loadtime||0:00:37.852820||4||0
+2015-11-09 05:14:34.275449||measurement||ad||2015-11-09 05:14:33.008165@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 05:14:34.603218||measurement||ad||2015-11-09 05:14:33.008165@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 05:14:34.666353||measurement||loadtime||0:00:38.615236||0||1
+2015-11-09 05:14:36.532127||measurement||ad||2015-11-09 05:14:35.752335@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 05:14:36.681430||measurement||ad||2015-11-09 05:14:35.752335@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:14:36.722505||measurement||loadtime||0:00:36.410093||1||1
+2015-11-09 05:14:46.310529||measurement||ad||2015-11-09 05:14:25.637750@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 05:14:47.576789||measurement||ad||2015-11-09 05:14:25.637750@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:14:47.726034||measurement||loadtime||0:00:50.978002||3||0
+2015-11-09 05:14:49.637638||measurement||ad||2015-11-09 05:14:49.225426@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||1
+2015-11-09 05:14:49.760374||measurement||ad||2015-11-09 05:14:49.225426@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:14:49.776431||measurement||loadtime||0:00:50.869245||5||1
+2015-11-09 05:15:14.187208||measurement||ad||2015-11-09 05:15:13.189423@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 05:15:14.599472||measurement||ad||2015-11-09 05:15:13.189423@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:15:14.666834||measurement||loadtime||0:00:32.943580||1||1
+2015-11-09 05:15:18.317319||measurement||ad||2015-11-09 05:15:16.866350@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 05:15:18.966941||measurement||ad||2015-11-09 05:15:16.866350@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:15:18.979921||measurement||loadtime||0:00:39.313110||0||1
+2015-11-09 05:15:22.167768||measurement||ad||2015-11-09 05:15:07.059647@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:15:22.168521||measurement||ad||2015-11-09 05:15:07.109551@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:15:22.831249||measurement||ad||2015-11-09 05:15:07.109551@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:15:22.948708||measurement||loadtime||0:01:22.768718||2||0
+2015-11-09 05:15:23.133027||measurement||ad||2015-11-09 05:15:07.059647@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||4||0
+2015-11-09 05:15:23.142076||measurement||loadtime||0:00:44.984620||4||0
+2015-11-09 05:15:30.934108||measurement||ad||2015-11-09 05:15:21.879894@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 05:15:32.195176||measurement||ad||2015-11-09 05:15:21.879894@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:15:32.200435||measurement||loadtime||0:00:39.473037||3||0
+2015-11-09 05:15:32.681324||measurement||ad||2015-11-09 05:15:31.825697@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 05:15:32.905866||measurement||ad||2015-11-09 05:15:31.825697@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:15:32.924366||measurement||loadtime||0:00:38.146922||5||1
+2015-11-09 05:15:44.285632||measurement||ad||2015-11-09 05:15:43.517972@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 05:15:44.462083||measurement||ad||2015-11-09 05:15:43.517972@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:15:44.513142||measurement||loadtime||0:00:24.845376||1||1
+2015-11-09 05:15:56.903368||measurement||ad||2015-11-09 05:15:56.202656@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 05:15:57.113754||measurement||ad||2015-11-09 05:15:56.202656@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:15:57.137148||measurement||loadtime||0:00:33.156429||0||1
+2015-11-09 05:16:06.421468||measurement||ad||2015-11-09 05:15:53.679427@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:16:07.736804||measurement||ad||2015-11-09 05:15:53.679427@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:16:07.770324||measurement||loadtime||0:00:39.627414||4||0
+2015-11-09 05:16:10.781125||measurement||ad||2015-11-09 05:16:09.582954@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 05:16:11.315755||measurement||ad||2015-11-09 05:16:09.582954@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:16:11.329596||measurement||loadtime||0:00:33.404214||5||1
+2015-11-09 05:16:23.077133||measurement||ad||2015-11-09 05:16:22.507785@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:16:23.254768||measurement||ad||2015-11-09 05:16:22.507785@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:16:23.285779||measurement||loadtime||0:00:33.772061||1||1
+2015-11-09 05:16:37.792679||measurement||ad||2015-11-09 05:16:36.918405@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 05:16:38.044354||measurement||ad||2015-11-09 05:16:36.918405@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:16:38.067987||measurement||loadtime||0:00:35.929787||0||1
+2015-11-09 05:16:39.599301||measurement||ad||2015-11-09 05:16:16.639094@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 05:16:41.343488||measurement||ad||2015-11-09 05:16:16.639094@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:16:41.446529||measurement||loadtime||0:01:04.245328||3||0
+2015-11-09 05:16:45.731224||measurement||ad||2015-11-09 05:16:45.283488@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||1
+2015-11-09 05:16:45.966939||measurement||ad||2015-11-09 05:16:45.283488@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:16:45.979844||measurement||loadtime||0:00:29.648997||5||1
+2015-11-09 05:16:47.389060||measurement||ad||2015-11-09 05:16:02.859194@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 05:16:52.104329||measurement||ad||2015-11-09 05:16:02.859194@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:16:52.622459||measurement||loadtime||0:01:24.672467||2||0
+2015-11-09 05:16:55.501292||measurement||ad||2015-11-09 05:16:46.192763@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:16:56.012961||measurement||ad||2015-11-09 05:16:46.192763@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 05:16:56.018858||measurement||loadtime||0:00:43.247798||4||0
+2015-11-09 05:17:00.403942||measurement||ad||2015-11-09 05:16:59.100140@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 05:17:00.771507||measurement||ad||2015-11-09 05:16:59.100140@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:17:00.786306||measurement||loadtime||0:00:32.499909||1||1
+2015-11-09 05:17:20.007132||measurement||ad||2015-11-09 05:17:18.874029@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 05:17:20.100172||measurement||ad||2015-11-09 05:17:18.776219@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 05:17:20.221096||measurement||ad||2015-11-09 05:17:18.776219@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:17:20.255069||measurement||ad||2015-11-09 05:17:18.874029@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:17:20.266813||measurement||loadtime||0:00:29.286357||5||1
+2015-11-09 05:17:20.437281||measurement||loadtime||0:00:37.367788||0||1
+2015-11-09 05:17:24.844093||measurement||ad||2015-11-09 05:17:14.168043@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 05:17:25.442723||measurement||ad||2015-11-09 05:17:14.168043@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:17:25.675939||measurement||loadtime||0:00:39.228823||3||0
+2015-11-09 05:17:33.476329||measurement||ad||2015-11-09 05:17:32.804491@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:17:33.563996||measurement||ad||2015-11-09 05:17:32.804491@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:17:33.574636||measurement||loadtime||0:00:27.787817||1||1
+2015-11-09 05:17:38.858509||measurement||ad||2015-11-09 05:17:29.838155@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 05:17:39.809680||measurement||ad||2015-11-09 05:17:29.838155@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:17:40.001772||measurement||loadtime||0:00:38.981944||4||0
+2015-11-09 05:17:46.674885||measurement||ad||2015-11-09 05:17:28.576285@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||2||0
+2015-11-09 05:17:48.695042||measurement||ad||2015-11-09 05:17:28.576285@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:17:48.999490||measurement||loadtime||0:00:51.376041||2||0
+2015-11-09 05:17:52.693356||measurement||ad||2015-11-09 05:17:51.380812@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||1
+2015-11-09 05:17:53.216294||measurement||ad||2015-11-09 05:17:51.380812@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:17:53.248743||measurement||loadtime||0:00:27.980140||5||1
+2015-11-09 05:18:06.291016||measurement||ad||2015-11-09 05:18:05.272938@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||0||1
+2015-11-09 05:18:06.598524||measurement||ad||2015-11-09 05:18:05.272938@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 05:18:06.616898||measurement||loadtime||0:00:41.179101||0||1
+2015-11-09 05:18:08.267597||measurement||ad||2015-11-09 05:17:58.479509@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 05:18:08.556854||measurement||ad||2015-11-09 05:17:58.479509@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:18:08.565933||measurement||loadtime||0:00:37.888949||3||0
+2015-11-09 05:18:11.475721||measurement||ad||2015-11-09 05:18:11.034876@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:18:11.589731||measurement||ad||2015-11-09 05:18:11.034876@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:18:11.604868||measurement||loadtime||0:00:33.027986||1||1
+2015-11-09 05:18:21.182223||measurement||ad||2015-11-09 05:18:13.421281@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:18:21.447899||measurement||ad||2015-11-09 05:18:13.421281@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:18:21.454692||measurement||loadtime||0:00:36.452444||4||0
+2015-11-09 05:18:24.790843||measurement||ad||2015-11-09 05:18:24.339406@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||5||1
+2015-11-09 05:18:24.957119||measurement||ad||2015-11-09 05:18:24.339406@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:18:24.973007||measurement||loadtime||0:00:26.723260||5||1
+2015-11-09 05:18:32.772508||measurement||ad||2015-11-09 05:18:22.197361@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:18:33.704139||measurement||ad||2015-11-09 05:18:22.197361@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:18:33.711640||measurement||loadtime||0:00:39.710671||2||0
+2015-11-09 05:18:48.999670||measurement||ad||2015-11-09 05:18:48.280029@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||0||1
+2015-11-09 05:18:49.530904||measurement||ad||2015-11-09 05:18:48.280029@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:18:49.580651||measurement||loadtime||0:00:37.963215||0||1
+2015-11-09 05:18:51.965674||measurement||ad||2015-11-09 05:18:42.325625@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 05:18:52.602157||measurement||ad||2015-11-09 05:18:42.325625@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:18:52.623943||measurement||loadtime||0:00:39.056484||3||0
+2015-11-09 05:18:53.830831||measurement||ad||2015-11-09 05:18:52.184476@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 05:18:54.335419||measurement||ad||2015-11-09 05:18:52.184476@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:18:54.481422||measurement||loadtime||0:00:37.875578||1||1
+2015-11-09 05:19:00.911625||measurement||ad||2015-11-09 05:18:52.214697@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 05:19:01.143383||measurement||ad||2015-11-09 05:18:52.214697@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:19:01.149112||measurement||loadtime||0:00:34.693668||4||0
+2015-11-09 05:19:01.210806||measurement||ad||2015-11-09 05:19:00.709682@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||1
+2015-11-09 05:19:01.279948||measurement||ad||2015-11-09 05:19:00.709682@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:19:01.291447||measurement||loadtime||0:00:31.317625||5||1
+2015-11-09 05:19:16.252330||measurement||ad||2015-11-09 05:19:06.269771@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 05:19:16.734429||measurement||ad||2015-11-09 05:19:06.269771@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:19:16.810290||measurement||loadtime||0:00:38.098140||2||0
+2015-11-09 05:19:25.820617||measurement||ad||2015-11-09 05:19:24.823026@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 05:19:25.922143||measurement||ad||2015-11-09 05:19:24.823026@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:19:25.938064||measurement||loadtime||0:00:31.356494||0||1
+2015-11-09 05:19:30.851788||measurement||ad||2015-11-09 05:19:22.010188@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:19:31.217828||measurement||ad||2015-11-09 05:19:22.010188@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:19:31.225514||measurement||loadtime||0:00:33.601009||3||0
+2015-11-09 05:19:32.270228||measurement||ad||2015-11-09 05:19:31.782159@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:19:32.447055||measurement||ad||2015-11-09 05:19:31.782159@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:19:32.507914||measurement||loadtime||0:00:33.025465||1||1
+2015-11-09 05:19:38.811116||measurement||ad||2015-11-09 05:19:37.456358@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 05:19:39.011255||measurement||ad||2015-11-09 05:19:37.456358@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:19:39.035248||measurement||loadtime||0:00:32.743203||5||1
+2015-11-09 05:19:39.142159||measurement||ad||2015-11-09 05:19:32.417181@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 05:19:39.463094||measurement||ad||2015-11-09 05:19:32.417181@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:19:39.515932||measurement||loadtime||0:00:33.366193||4||0
+2015-11-09 05:20:00.269280||measurement||ad||2015-11-09 05:19:50.277185@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:20:00.781968||measurement||ad||2015-11-09 05:19:50.277185@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:20:00.792450||measurement||loadtime||0:00:38.981645||2||0
+2015-11-09 05:20:01.535758||measurement||ad||2015-11-09 05:19:59.836514@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:20:02.124152||measurement||ad||2015-11-09 05:19:59.836514@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||1
+2015-11-09 05:20:02.159457||measurement||loadtime||0:00:31.220937||0||1
+2015-11-09 05:20:09.622852||measurement||ad||2015-11-09 05:20:00.340802@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:20:09.739898||measurement||ad||2015-11-09 05:20:00.340802@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:20:09.744174||measurement||loadtime||0:00:33.518042||3||0
+2015-11-09 05:20:13.836149||measurement||ad||2015-11-09 05:20:13.182199@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 05:20:14.152459||measurement||ad||2015-11-09 05:20:13.182199@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 05:20:14.172726||measurement||loadtime||0:00:36.664168||1||1
+2015-11-09 05:20:14.173765||event||progress-marker||measurement-end||1||1
+2015-11-09 05:20:16.602673||measurement||ad||2015-11-09 05:20:15.308494@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||1
+2015-11-09 05:20:17.718664||measurement||ad||2015-11-09 05:20:15.308494@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||1
+2015-11-09 05:20:17.738701||measurement||loadtime||0:00:33.702753||5||1
+2015-11-09 05:20:17.738972||event||progress-marker||measurement-end||5||1
+2015-11-09 05:20:21.437013||measurement||ad||2015-11-09 05:20:12.232912@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 05:20:21.614455||measurement||ad||2015-11-09 05:20:12.232912@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 05:20:21.665866||measurement||loadtime||0:00:37.148374||4||0
+2015-11-09 05:20:34.926781||measurement||ad||2015-11-09 05:20:34.469889@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||1
+2015-11-09 05:20:35.006629||measurement||ad||2015-11-09 05:20:34.469889@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 05:20:35.018276||measurement||loadtime||0:00:27.858264||0||1
+2015-11-09 05:20:35.018589||event||progress-marker||measurement-end||0||1
+2015-11-09 05:20:36.121876||measurement||ad||2015-11-09 05:20:31.531945@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||2||0
+2015-11-09 05:20:36.258174||measurement||ad||2015-11-09 05:20:31.531945@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:20:36.264350||measurement||loadtime||0:00:30.471104||2||0
+2015-11-09 05:20:40.864602||measurement||ad||2015-11-09 05:20:37.733671@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:20:40.962599||measurement||ad||2015-11-09 05:20:37.733671@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 05:20:40.965839||measurement||loadtime||0:00:26.221217||3||0
+2015-11-09 05:20:50.629565||measurement||ad||2015-11-09 05:20:47.106267@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 05:20:50.747491||measurement||ad||2015-11-09 05:20:47.106267@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||4||0
+2015-11-09 05:20:50.752116||measurement||loadtime||0:00:24.085796||4||0
+2015-11-09 05:20:50.752379||event||progress-marker||measurement-end||4||0
+2015-11-09 05:21:01.044254||measurement||ad||2015-11-09 05:20:58.692328@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:21:01.265937||measurement||ad||2015-11-09 05:20:58.692328@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:21:01.299878||measurement||loadtime||0:00:20.034650||2||0
+2015-11-09 05:21:07.916254||measurement||ad||2015-11-09 05:21:05.078653@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:21:08.006715||measurement||ad||2015-11-09 05:21:05.078653@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||3||0
+2015-11-09 05:21:08.009357||measurement||loadtime||0:00:22.042870||3||0
+2015-11-09 05:21:08.009670||event||progress-marker||measurement-end||3||0
+2015-11-09 05:21:22.785099||measurement||ad||2015-11-09 05:21:21.146953@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 05:21:22.842424||measurement||ad||2015-11-09 05:21:21.146953@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:21:22.845617||measurement||loadtime||0:00:16.544859||2||0
+2015-11-09 05:21:44.971407||measurement||ad||2015-11-09 05:21:43.050879@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:21:45.049899||measurement||ad||2015-11-09 05:21:43.050879@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||0
+2015-11-09 05:21:45.053090||measurement||loadtime||0:00:17.205887||2||0
+2015-11-09 05:21:45.053366||event||progress-marker||measurement-end||2||0
+2015-11-09 05:21:45.556099||meta||block_id end||12
+2015-11-09 05:21:45.558915||meta||block_id start||13
+2015-11-09 05:21:45.559092||meta||assignment||3@|0@|2@|5@|1@|4
+2015-11-09 05:21:49.208711||event||progress-marker||training-start||3||0
+2015-11-09 05:21:49.377764||event||progress-marker||training-start||2||0
+2015-11-09 05:21:49.403497||event||progress-marker||training-start||0||0
+2015-11-09 05:21:52.379199||event||progress-marker||training-start||1||1
+2015-11-09 05:21:52.705697||event||progress-marker||training-start||5||1
+2015-11-09 05:21:52.898691||event||progress-marker||training-start||4||1
+2015-11-09 05:21:54.019103||treatment||google search||Buy BMW||3||0
+2015-11-09 05:21:54.158262||treatment||google search||Buy BMW||0||0
+2015-11-09 05:21:54.168703||treatment||google search||Buy BMW||2||0
+2015-11-09 05:21:55.932153||error||visiting||google searchresults||3||0
+2015-11-09 05:21:56.078419||error||visiting||google searchresults||2||0
+2015-11-09 05:21:56.134764||error||visiting||google searchresults||0||0
+2015-11-09 05:21:57.761822||treatment||google search||Buy BMW||1||1
+2015-11-09 05:21:57.885359||treatment||google search||Buy BMW||5||1
+2015-11-09 05:21:57.932201||treatment||google search||Buy BMW||4||1
+2015-11-09 05:22:08.605275||error||visiting||google searchresults||1||1
+2015-11-09 05:22:08.694124||error||visiting||google searchresults||5||1
+2015-11-09 05:22:08.810666||error||visiting||google searchresults||4||1
+2015-11-09 05:22:14.253585||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 05:22:14.898115||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 05:22:22.713189||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 05:22:26.461868||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 05:22:27.494517||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 05:22:28.822993||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 05:22:29.487045||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 05:22:32.771446||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 05:22:35.985566||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 05:22:38.865658||error||visiting||google searchresults||2||0
+2015-11-09 05:22:39.521076||error||visiting||google searchresults||0||0
+2015-11-09 05:22:39.693831||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 05:22:40.743519||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 05:22:47.212806||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 05:22:54.230785||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||2||0
+2015-11-09 05:22:55.252405||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||0||0
+2015-11-09 05:22:56.086155||error||visiting||google searchresults||4||1
+2015-11-09 05:22:57.247688||error||visiting||google searchresults||3||0
+2015-11-09 05:22:59.733650||error||visiting||google searchresults||5||1
+2015-11-09 05:23:00.832881||error||visiting||google searchresults||1||1
+2015-11-09 05:23:05.907364||treatment||google search||BMW dealer||2||0
+2015-11-09 05:23:06.592324||error||visiting||google searchresults||2||0
+2015-11-09 05:23:06.961445||treatment||google search||BMW dealer||0||0
+2015-11-09 05:23:07.796002||error||visiting||google searchresults||0||0
+2015-11-09 05:23:12.270690||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||4||1
+2015-11-09 05:23:12.589453||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||3||0
+2015-11-09 05:23:14.489545||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||5||1
+2015-11-09 05:23:15.989251||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||1||1
+2015-11-09 05:23:25.345071||treatment||google search||BMW dealer||3||0
+2015-11-09 05:23:25.925568||treatment||google search||BMW dealer||4||1
+2015-11-09 05:23:26.171679||error||visiting||google searchresults||3||0
+2015-11-09 05:23:27.302538||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CILslNuPg8kCFdc2gQodWIsEdg||0||0
+2015-11-09 05:23:28.007145||treatment||google search||BMW dealer||5||1
+2015-11-09 05:23:28.574628||treatment||google search||BMW dealer||1||1
+2015-11-09 05:23:37.469740||error||visiting||google searchresults||4||1
+2015-11-09 05:23:39.012865||error||visiting||google searchresults||5||1
+2015-11-09 05:23:39.318958||error||visiting||google searchresults||1||1
+2015-11-09 05:23:43.678914||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJeeuuSPg8kCFUU7gQodHnMD0w||0||0
+2015-11-09 05:23:44.091713||treatment||visit page||http://www.carsense.com/?gclid=CMTi9eOPg8kCFZM2gQodqtgP5w||3||0
+2015-11-09 05:23:52.746141||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CL2yieqPg8kCFdcYgQodjHIJmg||5||1
+2015-11-09 05:23:53.431129||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIb8m-qPg8kCFZI9gQod8jMJsA||1||1
+2015-11-09 05:23:53.732673||error||visiting||google searchresults||0||0
+2015-11-09 05:23:56.247138||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CN_iqOmPg8kCFRMjgQodg40D8w||4||1
+2015-11-09 05:23:56.655245||error||visiting||google searchresults||2||0
+2015-11-09 05:23:57.790522||treatment||visit page||http://www.carsense.com/?gclid=CMvNvOyPg8kCFYY9gQodPk0Okw||3||0
+2015-11-09 05:24:07.842228||error||visiting||google searchresults||3||0
+2015-11-09 05:24:11.551017||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLLqyvCPg8kCFdgcgQodPBMC0w||5||1
+2015-11-09 05:24:12.176291||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNOapfKPg8kCFVUlgQodJdoD7Q||4||1
+2015-11-09 05:24:12.437805||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNX39PCPg8kCFVIbgQodFFQFtw||1||1
+2015-11-09 05:24:13.482288||treatment||visit page||http://www.carsense.com/?gclid=COmihvGPg8kCFdgVgQodCWoF0w||0||0
+2015-11-09 05:24:16.659932||error||visiting||google searchresults||2||0
+2015-11-09 05:24:22.601466||treatment||visit page||http://www.towerautosales.com/index.shtml||3||0
+2015-11-09 05:24:25.269746||treatment||google search||BMW||0||0
+2015-11-09 05:24:26.157600||error||visiting||google searchresults||0||0
+2015-11-09 05:24:31.607403||error||visiting||google searchresults||5||1
+2015-11-09 05:24:32.255600||error||visiting||google searchresults||4||1
+2015-11-09 05:24:32.536880||error||visiting||google searchresults||1||1
+2015-11-09 05:24:34.257180||treatment||google search||BMW||3||0
+2015-11-09 05:24:35.216851||error||visiting||google searchresults||3||0
+2015-11-09 05:24:36.699219||error||visiting||google searchresults||2||0
+2015-11-09 05:24:44.663944||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 05:24:50.962790||treatment||visit page||http://www.carsense.com/?gclid=COGWuIOQg8kCFdgDgQodN8QD6w||4||1
+2015-11-09 05:24:51.418859||treatment||visit page||http://www.carsense.com/?gclid=CK7dj4OQg8kCFYY9gQodPk0Okw||5||1
+2015-11-09 05:24:52.348565||treatment||visit page||http://www.carsense.com/?gclid=CNPez4OQg8kCFZAkgQodbqcDvw||1||1
+2015-11-09 05:24:54.868543||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:24:56.734736||error||visiting||google searchresults||2||0
+2015-11-09 05:25:00.330345||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 05:25:03.236628||treatment||google search||BMW||4||1
+2015-11-09 05:25:04.092186||treatment||google search||BMW||5||1
+2015-11-09 05:25:04.978408||treatment||google search||BMW||1||1
+2015-11-09 05:25:10.372304||error||visiting||google searchresults||0||0
+2015-11-09 05:25:10.797384||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:25:14.494928||error||visiting||google searchresults||4||1
+2015-11-09 05:25:15.331519||error||visiting||google searchresults||5||1
+2015-11-09 05:25:16.007583||error||visiting||google searchresults||1||1
+2015-11-09 05:25:16.770344||error||visiting||google searchresults||2||0
+2015-11-09 05:25:20.842738||error||visiting||google searchresults||3||0
+2015-11-09 05:25:29.730273||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||0
+2015-11-09 05:25:30.179901||treatment||google search||BMW||2||0
+2015-11-09 05:25:32.439631||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||4||1
+2015-11-09 05:25:33.397239||error||visiting||google searchresults||2||0
+2015-11-09 05:25:35.710082||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 05:25:39.732706||event||progress-marker||training-end||0||0
+2015-11-09 05:25:40.453735||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 05:25:40.775891||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 05:25:47.232762||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||4||1
+2015-11-09 05:25:49.871011||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 05:25:50.454960||event||progress-marker||training-end||3||0
+2015-11-09 05:25:51.265805||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 05:25:56.254590||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 05:26:06.871239||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 05:26:07.355658||error||visiting||google searchresults||4||1
+2015-11-09 05:26:09.924602||error||visiting||google searchresults||5||1
+2015-11-09 05:26:16.320626||error||visiting||google searchresults||1||1
+2015-11-09 05:26:16.904833||error||visiting||google searchresults||2||0
+2015-11-09 05:26:23.757400||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 05:26:26.619862||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||1
+2015-11-09 05:26:33.522982||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 05:26:33.759369||event||progress-marker||training-end||5||1
+2015-11-09 05:26:35.271382||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 05:26:36.621198||event||progress-marker||training-end||4||1
+2015-11-09 05:26:43.524772||event||progress-marker||training-end||2||0
+2015-11-09 05:26:45.273021||event||progress-marker||training-end||1||1
+2015-11-09 05:26:45.670471||event||progress-marker||measurement-start||3||0
+2015-11-09 05:26:46.668452||event||progress-marker||measurement-start||4||1
+2015-11-09 05:26:48.558663||event||progress-marker||measurement-start||2||0
+2015-11-09 05:26:48.828769||event||progress-marker||measurement-start||5||1
+2015-11-09 05:26:50.002925||event||progress-marker||measurement-start||0||0
+2015-11-09 05:26:50.303604||event||progress-marker||measurement-start||1||1
+2015-11-09 05:27:17.210664||measurement||ad||2015-11-09 05:27:15.106213@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||1
+2015-11-09 05:27:17.712279||measurement||ad||2015-11-09 05:27:15.106213@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:27:17.727865||measurement||loadtime||0:00:26.058411||4||1
+2015-11-09 05:27:40.033166||measurement||ad||2015-11-09 05:27:38.837978@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 05:27:41.089857||measurement||ad||2015-11-09 05:27:38.837978@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:27:41.114249||measurement||loadtime||0:00:47.283195||5||1
+2015-11-09 05:27:48.925356||measurement||ad||2015-11-09 05:27:44.823261@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||1||1
+2015-11-09 05:27:49.246853||measurement||ad||2015-11-09 05:27:44.823261@|Get A Free Demonstration@|steton.com/BI_Dashboards@|Business Intelligence Dashboards That Keep Your Brand Consistent.||1||1
+2015-11-09 05:27:49.331062||measurement||loadtime||0:00:54.026882||1||1
+2015-11-09 05:27:51.718649||measurement||ad||2015-11-09 05:27:26.923647@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:27:52.359336||measurement||ad||2015-11-09 05:27:26.923647@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:27:52.363899||measurement||loadtime||0:01:01.691779||3||0
+2015-11-09 05:27:53.248740||measurement||ad||2015-11-09 05:27:41.136516@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||0
+2015-11-09 05:27:53.924547||measurement||ad||2015-11-09 05:27:41.136516@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||0
+2015-11-09 05:27:53.982139||measurement||loadtime||0:00:58.978716||0||0
+2015-11-09 05:27:55.709126||measurement||ad||2015-11-09 05:27:55.074822@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||1
+2015-11-09 05:27:55.778769||measurement||ad||2015-11-09 05:27:55.074822@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:27:55.791800||measurement||loadtime||0:00:33.063268||4||1
+2015-11-09 05:28:01.631682||measurement||ad||2015-11-09 05:27:42.091566@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 05:28:03.116279||measurement||ad||2015-11-09 05:27:42.091566@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:28:03.137158||measurement||loadtime||0:01:09.576794||2||0
+2015-11-09 05:28:17.648007||measurement||ad||2015-11-09 05:28:16.347944@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:28:17.880934||measurement||ad||2015-11-09 05:28:16.347944@|Anal Fissure Cream@|www.amoils.com@|100% Effective Anal Fissure Cream Free Shipping On Best Value Size||5||1
+2015-11-09 05:28:17.931596||measurement||loadtime||0:00:31.815041||5||1
+2015-11-09 05:28:33.140985||measurement||ad||2015-11-09 05:28:32.287377@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||1
+2015-11-09 05:28:33.513560||measurement||ad||2015-11-09 05:28:32.287377@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:28:33.579395||measurement||loadtime||0:00:32.786077||4||1
+2015-11-09 05:28:34.832066||measurement||ad||2015-11-09 05:28:32.580339@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 05:28:35.807131||measurement||ad||2015-11-09 05:28:32.580339@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 05:28:35.822883||measurement||loadtime||0:00:41.491067||1||1
+2015-11-09 05:28:39.875538||measurement||ad||2015-11-09 05:28:28.752455@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:28:40.497265||measurement||ad||2015-11-09 05:28:28.752455@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||0
+2015-11-09 05:28:40.503695||measurement||loadtime||0:00:41.520911||0||0
+2015-11-09 05:28:44.431824||measurement||ad||2015-11-09 05:28:31.396368@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:28:44.685063||measurement||ad||2015-11-09 05:28:31.396368@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:28:44.692743||measurement||loadtime||0:00:47.327792||3||0
+2015-11-09 05:28:57.346838||measurement||ad||2015-11-09 05:28:56.323310@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:28:57.652759||measurement||ad||2015-11-09 05:28:56.323310@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 05:28:57.692712||measurement||loadtime||0:00:34.759555||5||1
+2015-11-09 05:29:10.255939||measurement||ad||2015-11-09 05:29:09.543518@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||1
+2015-11-09 05:29:10.664371||measurement||ad||2015-11-09 05:29:09.543518@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:29:10.701959||measurement||loadtime||0:00:32.121343||4||1
+2015-11-09 05:29:11.934175||measurement||ad||2015-11-09 05:29:06.922321@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:29:12.170193||measurement||ad||2015-11-09 05:29:06.922321@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 05:29:12.187203||measurement||loadtime||0:00:26.682686||0||0
+2015-11-09 05:29:12.234760||measurement||ad||2015-11-09 05:28:49.362081@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 05:29:13.246003||measurement||ad||2015-11-09 05:29:11.211339@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 05:29:13.373406||measurement||ad||2015-11-09 05:28:49.362081@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:29:13.380710||measurement||loadtime||0:01:05.241706||2||0
+2015-11-09 05:29:14.194249||measurement||ad||2015-11-09 05:29:11.211339@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||1||1
+2015-11-09 05:29:14.218786||measurement||loadtime||0:00:33.394455||1||1
+2015-11-09 05:29:26.645975||measurement||ad||2015-11-09 05:29:17.909856@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:29:32.127514||measurement||ad||2015-11-09 05:29:17.909856@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:29:32.198987||measurement||loadtime||0:00:42.505663||3||0
+2015-11-09 05:29:36.823008||measurement||ad||2015-11-09 05:29:33.975258@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 05:29:36.964535||measurement||ad||2015-11-09 05:29:33.975258@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:29:37.181952||measurement||loadtime||0:00:34.488567||5||1
+2015-11-09 05:29:45.715310||measurement||ad||2015-11-09 05:29:45.398957@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||1
+2015-11-09 05:29:45.787568||measurement||ad||2015-11-09 05:29:45.398957@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:29:45.798406||measurement||loadtime||0:00:30.095846||4||1
+2015-11-09 05:29:51.862870||measurement||ad||2015-11-09 05:29:46.811074@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:29:52.088745||measurement||ad||2015-11-09 05:29:46.811074@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||0
+2015-11-09 05:29:52.138976||measurement||loadtime||0:00:34.951136||0||0
+2015-11-09 05:29:54.574961||measurement||ad||2015-11-09 05:29:53.387694@|5 Foods That Hurt Liver@|perfectorigins.com/5Foods.php@|Watch and learn the 5 damaging foods for your liver  weight.||1||1
+2015-11-09 05:29:54.902145||measurement||ad||2015-11-09 05:29:53.387694@|Get A Free Demonstration@|steton.com/BI_Dashboards@|Business Intelligence Dashboards That Keep Your Brand Consistent.||1||1
+2015-11-09 05:29:54.918348||measurement||loadtime||0:00:35.699026||1||1
+2015-11-09 05:30:02.881409||measurement||ad||2015-11-09 05:29:50.050387@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 05:30:03.732361||measurement||ad||2015-11-09 05:29:50.050387@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:30:03.737266||measurement||loadtime||0:00:45.355612||2||0
+2015-11-09 05:30:21.907878||measurement||ad||2015-11-09 05:30:06.562453@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:30:22.362530||measurement||ad||2015-11-09 05:30:21.290347@|Anal Fissure Cream@|www.amoils.com@|100% Effective Anal Fissure Cream Free Shipping On Best Value Size||5||1
+2015-11-09 05:30:22.989324||measurement||ad||2015-11-09 05:30:21.290347@|5 Foods That Hurt Liver@|perfectorigins.com/5Foods.php@|Watch And Learn 5 Damaging Foods For Your Liver  Weight.||5||1
+2015-11-09 05:30:23.184159||measurement||loadtime||0:00:41.000753||5||1
+2015-11-09 05:30:24.296990||measurement||ad||2015-11-09 05:30:06.562453@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:30:24.451967||measurement||loadtime||0:00:47.251847||3||0
+2015-11-09 05:30:36.039685||measurement||ad||2015-11-09 05:30:35.640267@|5 Foods Hurt The Liver@|perfectorigins.com/5Foods.php@|Watch Video That Shows 5 Damaging Foods For Your Liver  Weight.||1||1
+2015-11-09 05:30:36.183697||measurement||ad||2015-11-09 05:30:35.640267@|Get A Free Demonstration@|steton.com/BI_Dashboards@|Business Intelligence Dashboards That Keep Your Brand Consistent.||1||1
+2015-11-09 05:30:36.205996||measurement||loadtime||0:00:36.286170||1||1
+2015-11-09 05:30:49.546571||measurement||ad||2015-11-09 05:30:40.769758@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 05:30:50.415666||measurement||ad||2015-11-09 05:30:40.769758@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:30:50.629113||measurement||loadtime||0:00:41.890745||2||0
+2015-11-09 05:30:50.861159||error||collecting ads||Error||4||1
+2015-11-09 05:30:54.036123||measurement||ad||2015-11-09 05:30:53.610678@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 05:30:54.268323||measurement||ad||2015-11-09 05:30:53.610678@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||5||1
+2015-11-09 05:30:54.321649||measurement||loadtime||0:00:26.136956||5||1
+2015-11-09 05:30:58.507895||error||collecting ads||Error||0||0
+2015-11-09 05:30:59.882179||measurement||ad||2015-11-09 05:30:53.013351@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:31:00.321779||measurement||ad||2015-11-09 05:30:53.013351@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:31:00.347164||measurement||loadtime||0:00:30.893677||3||0
+2015-11-09 05:31:08.734819||measurement||ad||2015-11-09 05:31:07.948350@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 05:31:08.864960||measurement||ad||2015-11-09 05:31:07.948350@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 05:31:08.878879||measurement||loadtime||0:00:27.671655||1||1
+2015-11-09 05:31:11.364224||measurement||ad||2015-11-09 05:31:08.389532@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||1
+2015-11-09 05:31:13.238596||measurement||ad||2015-11-09 05:31:08.389532@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:31:13.291736||measurement||loadtime||0:00:17.429597||4||1
+2015-11-09 05:31:27.585208||measurement||ad||2015-11-09 05:31:20.654315@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:31:27.884384||measurement||ad||2015-11-09 05:31:20.654315@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:31:27.889205||measurement||loadtime||0:00:32.258865||2||0
+2015-11-09 05:31:43.150909||measurement||ad||2015-11-09 05:31:37.265521@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:31:43.290919||measurement||ad||2015-11-09 05:31:37.265521@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:31:43.296733||measurement||loadtime||0:00:37.948919||3||0
+2015-11-09 05:31:45.950728||measurement||ad||2015-11-09 05:31:45.277394@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||4||1
+2015-11-09 05:31:46.375300||measurement||ad||2015-11-09 05:31:45.277394@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:31:46.388427||measurement||loadtime||0:00:28.095425||4||1
+2015-11-09 05:31:47.557646||measurement||ad||2015-11-09 05:31:43.476359@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||0
+2015-11-09 05:31:47.685026||measurement||ad||2015-11-09 05:31:43.476359@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:31:47.704068||measurement||loadtime||0:00:44.195197||0||0
+2015-11-09 05:31:48.601661||measurement||ad||2015-11-09 05:31:47.716765@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 05:31:48.899914||measurement||ad||2015-11-09 05:31:47.716765@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||1||1
+2015-11-09 05:31:48.965025||measurement||loadtime||0:00:35.084507||1||1
+2015-11-09 05:31:49.865834||measurement||ad||2015-11-09 05:31:49.529888@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 05:31:50.017925||measurement||ad||2015-11-09 05:31:49.529888@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:31:50.032794||measurement||loadtime||0:00:50.709959||5||1
+2015-11-09 05:32:01.538943||measurement||ad||2015-11-09 05:31:53.901190@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:32:02.667486||measurement||ad||2015-11-09 05:31:53.901190@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:32:02.678741||measurement||loadtime||0:00:29.788891||2||0
+2015-11-09 05:32:17.814277||measurement||ad||2015-11-09 05:32:17.163666@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||4||1
+2015-11-09 05:32:18.053856||measurement||ad||2015-11-09 05:32:17.163666@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:32:18.300821||measurement||loadtime||0:00:26.911544||4||1
+2015-11-09 05:32:27.990582||measurement||ad||2015-11-09 05:32:27.351840@|Dental Implant Warnings@|symptomfind.com/CosmeticDentalCare@|Critical Info You Need To Know Before Getting Dental Implants.||1||1
+2015-11-09 05:32:28.172761||measurement||ad||2015-11-09 05:32:27.846545@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 05:32:28.443723||measurement||ad||2015-11-09 05:32:27.846545@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:32:28.454273||measurement||loadtime||0:00:33.420338||5||1
+2015-11-09 05:32:28.491263||measurement||ad||2015-11-09 05:32:27.351840@|Get A Free Demonstration@|steton.com/BI_Dashboards@|Business Intelligence Dashboards That Keep Your Brand Consistent.||1||1
+2015-11-09 05:32:28.528988||measurement||loadtime||0:00:34.563319||1||1
+2015-11-09 05:32:51.470524||measurement||ad||2015-11-09 05:32:50.164391@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||1
+2015-11-09 05:32:52.736974||measurement||ad||2015-11-09 05:32:50.164391@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:32:52.756811||measurement||loadtime||0:00:29.454841||4||1
+2015-11-09 05:32:52.774546||event||progress-marker||measurement-end||4||1
+2015-11-09 05:32:53.720127||measurement||ad||2015-11-09 05:32:30.723840@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||0
+2015-11-09 05:32:54.770180||measurement||ad||2015-11-09 05:32:30.723840@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:32:54.909269||measurement||loadtime||0:01:02.204679||0||0
+2015-11-09 05:32:56.562455||measurement||ad||2015-11-09 05:32:29.986956@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:33:01.301209||measurement||ad||2015-11-09 05:32:29.986956@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:33:01.341755||measurement||loadtime||0:01:13.044519||3||0
+2015-11-09 05:33:09.774960||error||collecting ads||Error||2||0
+2015-11-09 05:33:10.655476||measurement||ad||2015-11-09 05:33:10.006030@|Anal Fissure Cream@|www.amoils.com@|100% Effective Anal Fissure Cream Free Shipping On Best Value Size||5||1
+2015-11-09 05:33:10.713374||measurement||ad||2015-11-09 05:33:10.006030@|Understanding Options@|thestockmarketwatch.com/Options@|Learn Options Trading Basics with 11 Free Video Lessons.||5||1
+2015-11-09 05:33:10.724621||measurement||loadtime||0:00:37.269401||5||1
+2015-11-09 05:33:12.981329||measurement||ad||2015-11-09 05:33:12.490043@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 05:33:13.109751||measurement||ad||2015-11-09 05:33:12.490043@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||1
+2015-11-09 05:33:13.142545||measurement||loadtime||0:00:39.612998||1||1
+2015-11-09 05:33:37.985379||measurement||ad||2015-11-09 05:33:37.230044@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||5||1
+2015-11-09 05:33:38.259123||measurement||ad||2015-11-09 05:33:37.230044@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||1
+2015-11-09 05:33:38.285102||measurement||loadtime||0:00:22.558847||5||1
+2015-11-09 05:33:38.287434||event||progress-marker||measurement-end||5||1
+2015-11-09 05:33:41.132266||measurement||ad||2015-11-09 05:33:39.632352@|5 Foods That Hurt Liver@|perfectorigins.com/5Foods.php@|Watch and learn the 5 damaging foods for your liver  weight.||1||1
+2015-11-09 05:33:41.684957||measurement||ad||2015-11-09 05:33:39.632352@|Get A Free Demonstration@|steton.com/BI_Dashboards@|Business Intelligence Dashboards That Keep Your Brand Consistent.||1||1
+2015-11-09 05:33:41.917591||measurement||loadtime||0:00:23.773762||1||1
+2015-11-09 05:33:41.917858||event||progress-marker||measurement-end||1||1
+2015-11-09 05:33:44.335476||measurement||ad||2015-11-09 05:33:34.099547@|My Guardian Angel's Name@|guardian-angel-reading.com/Identity@|Who watches over you? Padre knows the name of your Angel. Find out!||3||0
+2015-11-09 05:33:44.713523||measurement||ad||2015-11-09 05:33:34.099547@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:33:44.754092||measurement||loadtime||0:00:38.409973||3||0
+2015-11-09 05:33:45.077443||measurement||ad||2015-11-09 05:33:23.240279@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:33:45.249537||measurement||ad||2015-11-09 05:33:23.240279@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 05:33:45.256478||measurement||loadtime||0:00:45.346431||0||0
+2015-11-09 05:34:04.678768||measurement||ad||2015-11-09 05:33:56.314600@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:34:05.148754||measurement||ad||2015-11-09 05:33:56.314600@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:34:05.260711||measurement||loadtime||0:00:50.482390||2||0
+2015-11-09 05:34:12.161645||measurement||ad||2015-11-09 05:34:09.228537@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||0||0
+2015-11-09 05:34:12.296943||measurement||ad||2015-11-09 05:34:09.228537@|Want Rapid Weight Loss?@|thyroid-weight-loss.com@|Power-Boost Your Metabolism With A A Simple Thyroid Fix! Learn More.||0||0
+2015-11-09 05:34:12.301312||measurement||loadtime||0:00:22.043826||0||0
+2015-11-09 05:34:29.537932||measurement||ad||2015-11-09 05:34:09.868643@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:34:30.088103||measurement||ad||2015-11-09 05:34:09.868643@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:34:30.096231||measurement||loadtime||0:00:40.341249||3||0
+2015-11-09 05:34:36.555187||measurement||ad||2015-11-09 05:34:33.419724@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||0
+2015-11-09 05:34:36.677249||measurement||ad||2015-11-09 05:34:33.419724@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 05:34:36.682114||measurement||loadtime||0:00:19.379602||0||0
+2015-11-09 05:34:36.687648||event||progress-marker||measurement-end||0||0
+2015-11-09 05:34:38.459556||measurement||ad||2015-11-09 05:34:30.242398@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 05:34:38.899337||measurement||ad||2015-11-09 05:34:30.242398@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:34:38.908179||measurement||loadtime||0:00:28.646949||2||0
+2015-11-09 05:34:57.330999||measurement||ad||2015-11-09 05:34:55.358047@|Watch Movies Online@|www.yidio.com/Movies@|Find any Full Movie available fast and easy.||3||0
+2015-11-09 05:34:57.480426||measurement||ad||2015-11-09 05:34:55.358047@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:34:57.483698||measurement||loadtime||0:00:22.386668||3||0
+2015-11-09 05:34:57.483973||event||progress-marker||measurement-end||3||0
+2015-11-09 05:35:02.875774||measurement||ad||2015-11-09 05:35:00.841482@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||2||0
+2015-11-09 05:35:02.936719||measurement||ad||2015-11-09 05:35:00.841482@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 05:35:02.939853||measurement||loadtime||0:00:19.030919||2||0
+2015-11-09 05:35:02.940150||event||progress-marker||measurement-end||2||0
+2015-11-09 05:35:03.489177||meta||block_id end||13
+2015-11-09 05:35:03.492576||meta||block_id start||14
+2015-11-09 05:35:03.494118||meta||assignment||5@|4@|3@|1@|2@|0
+2015-11-09 05:35:07.055488||event||progress-marker||training-start||4||0
+2015-11-09 05:35:07.336662||event||progress-marker||training-start||3||0
+2015-11-09 05:35:07.351668||event||progress-marker||training-start||5||0
+2015-11-09 05:35:10.736292||event||progress-marker||training-start||2||1
+2015-11-09 05:35:11.002123||event||progress-marker||training-start||0||1
+2015-11-09 05:35:11.087765||event||progress-marker||training-start||1||1
+2015-11-09 05:35:11.775007||treatment||google search||Buy BMW||4||0
+2015-11-09 05:35:11.843347||treatment||google search||Buy BMW||5||0
+2015-11-09 05:35:12.696542||treatment||google search||Buy BMW||3||0
+2015-11-09 05:35:13.301024||error||visiting||google searchresults||4||0
+2015-11-09 05:35:13.611097||error||visiting||google searchresults||5||0
+2015-11-09 05:35:14.425672||error||visiting||google searchresults||3||0
+2015-11-09 05:35:15.708989||treatment||google search||Buy BMW||2||1
+2015-11-09 05:35:15.892483||treatment||google search||Buy BMW||0||1
+2015-11-09 05:35:15.951362||treatment||google search||Buy BMW||1||1
+2015-11-09 05:35:26.693746||error||visiting||google searchresults||2||1
+2015-11-09 05:35:26.703500||error||visiting||google searchresults||0||1
+2015-11-09 05:35:26.881072||error||visiting||google searchresults||1||1
+2015-11-09 05:35:34.154881||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 05:35:34.487501||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 05:35:36.773643||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 05:35:41.552300||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 05:35:41.624885||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 05:35:41.866319||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||1
+2015-11-09 05:35:50.591087||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 05:35:51.777471||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 05:35:55.421624||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||1
+2015-11-09 05:35:55.667776||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 05:35:56.630150||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 05:35:56.886404||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 05:36:00.619569||error||visiting||google searchresults||4||0
+2015-11-09 05:36:01.811172||error||visiting||google searchresults||5||0
+2015-11-09 05:36:05.703428||error||visiting||google searchresults||3||0
+2015-11-09 05:36:14.907145||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CK_h18uSg8kCFUUdgQodBswGAg||4||0
+2015-11-09 05:36:15.480317||error||visiting||google searchresults||2||1
+2015-11-09 05:36:15.995200||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CPfQnsySg8kCFdgLgQodfDYHIg||5||0
+2015-11-09 05:36:16.726307||error||visiting||google searchresults||0||1
+2015-11-09 05:36:16.931922||error||visiting||google searchresults||1||1
+2015-11-09 05:36:19.909177||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CLTkjc6Sg8kCFVUlgQodJdoD7Q||3||0
+2015-11-09 05:36:26.727519||treatment||google search||BMW dealer||4||0
+2015-11-09 05:36:27.752725||error||visiting||google searchresults||4||0
+2015-11-09 05:36:28.169726||treatment||google search||BMW dealer||5||0
+2015-11-09 05:36:28.673899||error||visiting||google searchresults||5||0
+2015-11-09 05:36:29.874122||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJW149KSg8kCFZYkgQod96sHBA||2||1
+2015-11-09 05:36:29.892909||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=CJTgstOSg8kCFdgTgQodJKoCGw||0||1
+2015-11-09 05:36:30.241859||treatment||visit page||http://dealers.autosite.com/ppc/bmw?ukwid=2259101e-390a-4d58-a492-356a62452142&udv=c&gclid=COSTvtOSg8kCFdU6gQodunAK2g||1||1
+2015-11-09 05:36:32.134443||treatment||google search||BMW dealer||3||0
+2015-11-09 05:36:32.651826||error||visiting||google searchresults||3||0
+2015-11-09 05:36:43.411694||treatment||google search||BMW dealer||0||1
+2015-11-09 05:36:44.547282||treatment||google search||BMW dealer||2||1
+2015-11-09 05:36:45.313863||treatment||google search||BMW dealer||1||1
+2015-11-09 05:36:48.568327||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPDxytiSg8kCFUo6gQodotYFog||4||0
+2015-11-09 05:36:49.440738||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP_zhdmSg8kCFdgDgQodN8QD6w||5||0
+2015-11-09 05:36:52.182243||treatment||visit page||http://www.carsense.com/?gclid=CKbh-NqSg8kCFYcbgQodIbkOIw||3||0
+2015-11-09 05:36:54.721353||error||visiting||google searchresults||0||1
+2015-11-09 05:36:56.079389||error||visiting||google searchresults||2||1
+2015-11-09 05:36:56.491293||error||visiting||google searchresults||1||1
+2015-11-09 05:37:04.120427||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPmswuKSg8kCFdgJgQodmYkNDA||4||0
+2015-11-09 05:37:05.177165||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMiX-OKSg8kCFdgBgQodMekJLw||5||0
+2015-11-09 05:37:07.322733||treatment||visit page||http://www.carsense.com/?gclid=CMuxn-SSg8kCFcUkgQod5NkDfg||3||0
+2015-11-09 05:37:12.586084||treatment||visit page||http://www.carsense.com/?gclid=CKf0quaSg8kCFUUlgQodxcoKZQ||1||1
+2015-11-09 05:37:13.840765||treatment||visit page||http://www.carsense.com/?gclid=CJvYuuWSg8kCFdgagQodCK4AMg||0||1
+2015-11-09 05:37:14.155846||error||visiting||google searchresults||4||0
+2015-11-09 05:37:15.108571||treatment||visit page||http://www.carsense.com/?gclid=CJ71jeaSg8kCFdgPgQodEnsOlw||2||1
+2015-11-09 05:37:15.209597||error||visiting||google searchresults||5||0
+2015-11-09 05:37:17.355726||error||visiting||google searchresults||3||0
+2015-11-09 05:37:29.046510||treatment||visit page||http://www.carsense.com/?gclid=CNix_e2Sg8kCFZMvgQodgGcBow||1||1
+2015-11-09 05:37:33.242145||treatment||visit page||http://www.carsense.com/?gclid=CNzxmu-Sg8kCFVI7gQodrjYBDQ||2||1
+2015-11-09 05:37:33.759173||treatment||visit page||http://www.towerautosales.com/index.shtml||3||0
+2015-11-09 05:37:34.484554||treatment||visit page||http://www.carsense.com/?gclid=CObp3e6Sg8kCFUo8gQodQ3oJ_A||4||0
+2015-11-09 05:37:35.360853||treatment||visit page||http://www.carsense.com/?gclid=COzRye6Sg8kCFdgIgQodts4DTw||0||1
+2015-11-09 05:37:35.935081||treatment||visit page||http://www.carsense.com/?gclid=CJKkn--Sg8kCFVMvgQodTycJrA||5||0
+2015-11-09 05:37:45.446544||treatment||google search||BMW||3||0
+2015-11-09 05:37:46.120999||treatment||google search||BMW||4||0
+2015-11-09 05:37:46.327177||error||visiting||google searchresults||3||0
+2015-11-09 05:37:46.937021||error||visiting||google searchresults||4||0
+2015-11-09 05:37:47.736247||treatment||google search||BMW||5||0
+2015-11-09 05:37:48.501425||error||visiting||google searchresults||5||0
+2015-11-09 05:37:49.089854||error||visiting||google searchresults||1||1
+2015-11-09 05:37:53.289401||error||visiting||google searchresults||2||1
+2015-11-09 05:37:55.449117||error||visiting||google searchresults||0||1
+2015-11-09 05:38:03.504883||treatment||visit page||http://www.towerautosales.com/index.shtml||1||1
+2015-11-09 05:38:06.464064||treatment||visit page||http://www.towerautosales.com/index.shtml||2||1
+2015-11-09 05:38:07.746593||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 05:38:07.858351||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:38:08.987253||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 05:38:10.339472||treatment||visit page||http://www.towerautosales.com/index.shtml||0||1
+2015-11-09 05:38:15.269791||treatment||google search||BMW||1||1
+2015-11-09 05:38:18.218105||treatment||google search||BMW||2||1
+2015-11-09 05:38:23.091027||treatment||google search||BMW||0||1
+2015-11-09 05:38:24.645765||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 05:38:24.943356||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:38:25.539684||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 05:38:27.186611||error||visiting||google searchresults||1||1
+2015-11-09 05:38:29.567031||error||visiting||google searchresults||2||1
+2015-11-09 05:38:34.050677||error||visiting||google searchresults||0||1
+2015-11-09 05:38:34.679256||error||visiting||google searchresults||4||0
+2015-11-09 05:38:34.977853||error||visiting||google searchresults||3||0
+2015-11-09 05:38:35.574790||error||visiting||google searchresults||5||0
+2015-11-09 05:38:50.301227||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 05:38:52.869544||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 05:38:58.370698||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 05:39:00.865586||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 05:39:01.043461||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 05:39:03.562943||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 05:39:08.372362||event||progress-marker||training-end||5||0
+2015-11-09 05:39:09.161601||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 05:39:10.867497||event||progress-marker||training-end||4||0
+2015-11-09 05:39:11.044289||event||progress-marker||training-end||3||0
+2015-11-09 05:39:11.111197||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 05:39:23.655333||error||visiting||google searchresults||2||1
+2015-11-09 05:39:26.839366||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 05:39:29.202596||error||visiting||google searchresults||1||1
+2015-11-09 05:39:40.043377||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 05:39:45.798322||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 05:39:46.885987||error||visiting||google searchresults||0||1
+2015-11-09 05:39:50.044880||event||progress-marker||training-end||2||1
+2015-11-09 05:39:55.800002||event||progress-marker||training-end||1||1
+2015-11-09 05:40:03.506846||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 05:40:13.508663||event||progress-marker||training-end||0||1
+2015-11-09 05:40:13.636680||event||progress-marker||measurement-start||5||0
+2015-11-09 05:40:15.155261||event||progress-marker||measurement-start||2||1
+2015-11-09 05:40:15.886138||event||progress-marker||measurement-start||1||1
+2015-11-09 05:40:16.143695||event||progress-marker||measurement-start||4||0
+2015-11-09 05:40:16.306277||event||progress-marker||measurement-start||3||0
+2015-11-09 05:40:18.543281||event||progress-marker||measurement-start||0||1
+2015-11-09 05:40:53.415864||measurement||ad||2015-11-09 05:40:53.210181@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:40:53.493197||measurement||ad||2015-11-09 05:40:53.210181@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 05:40:53.506746||measurement||loadtime||0:00:32.619777||1||1
+2015-11-09 05:40:54.219415||measurement||ad||2015-11-09 05:40:39.140918@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||0
+2015-11-09 05:40:54.502114||measurement||ad||2015-11-09 05:40:39.140918@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:40:54.620305||measurement||loadtime||0:00:35.983124||5||0
+2015-11-09 05:40:57.128264||measurement||ad||2015-11-09 05:40:56.275361@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:40:57.138243||measurement||ad||2015-11-09 05:40:56.647564@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 05:40:57.231757||measurement||ad||2015-11-09 05:40:56.647564@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:40:57.246102||measurement||loadtime||0:00:33.702243||0||1
+2015-11-09 05:40:57.360805||measurement||ad||2015-11-09 05:40:56.275361@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 05:40:57.409236||measurement||loadtime||0:00:37.253457||2||1
+2015-11-09 05:41:18.180095||measurement||ad||2015-11-09 05:40:57.062148@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||4||0
+2015-11-09 05:41:19.853323||measurement||ad||2015-11-09 05:40:57.062148@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||4||0
+2015-11-09 05:41:19.859849||measurement||loadtime||0:00:58.714519||4||0
+2015-11-09 05:41:24.314942||measurement||ad||2015-11-09 05:41:23.592016@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 05:41:24.568867||measurement||ad||2015-11-09 05:41:23.592016@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 05:41:24.697312||measurement||loadtime||0:00:26.190048||1||1
+2015-11-09 05:41:27.693915||measurement||ad||2015-11-09 05:41:04.981590@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:41:28.280718||measurement||ad||2015-11-09 05:41:04.981590@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 05:41:28.504666||measurement||loadtime||0:01:07.197320||3||0
+2015-11-09 05:41:28.601946||measurement||ad||2015-11-09 05:41:28.048375@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:41:28.857199||measurement||ad||2015-11-09 05:41:28.048375@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 05:41:28.881448||measurement||loadtime||0:00:26.634271||0||1
+2015-11-09 05:41:30.475372||measurement||ad||2015-11-09 05:41:29.859944@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||2||1
+2015-11-09 05:41:31.011271||measurement||ad||2015-11-09 05:41:29.859944@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 05:41:31.026837||measurement||loadtime||0:00:28.616149||2||1
+2015-11-09 05:41:32.385258||measurement||ad||2015-11-09 05:41:24.813752@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||0
+2015-11-09 05:41:32.505505||measurement||ad||2015-11-09 05:41:24.813752@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:41:32.528968||measurement||loadtime||0:00:32.907210||5||0
+2015-11-09 05:41:51.616597||measurement||ad||2015-11-09 05:41:51.008628@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 05:41:51.775416||measurement||ad||2015-11-09 05:41:51.008628@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:41:51.797766||measurement||loadtime||0:00:22.099811||1||1
+2015-11-09 05:41:58.449631||measurement||ad||2015-11-09 05:41:57.962537@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 05:41:58.708289||measurement||ad||2015-11-09 05:41:57.962537@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:41:58.743622||measurement||loadtime||0:00:24.861481||0||1
+2015-11-09 05:41:59.559370||measurement||ad||2015-11-09 05:41:47.468408@|Public Arrest Records@|records.instantcheckmate.com@|Enter a Name  Search for Free. View Background Check Instantly.||4||0
+2015-11-09 05:41:59.651801||measurement||ad||2015-11-09 05:41:47.468408@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||4||0
+2015-11-09 05:41:59.655768||measurement||loadtime||0:00:34.795324||4||0
+2015-11-09 05:42:01.328342||measurement||ad||2015-11-09 05:42:00.807638@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:42:01.476079||measurement||ad||2015-11-09 05:42:00.807638@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:42:01.496886||measurement||loadtime||0:00:25.469349||2||1
+2015-11-09 05:42:14.453324||measurement||ad||2015-11-09 05:42:00.952630@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||0
+2015-11-09 05:42:15.682300||measurement||ad||2015-11-09 05:42:00.952630@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:42:15.761799||measurement||loadtime||0:00:38.231356||5||0
+2015-11-09 05:42:19.683389||measurement||ad||2015-11-09 05:42:18.945979@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 05:42:19.861783||measurement||ad||2015-11-09 05:42:18.945979@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 05:42:19.878016||measurement||loadtime||0:00:23.078617||1||1
+2015-11-09 05:42:21.332436||measurement||ad||2015-11-09 05:42:06.082992@|Part-Time Online Work@|surveyjunkie.com@|Make up to $45 per survey in 20 min The #1 Paying Survey Site Today!||3||0
+2015-11-09 05:42:22.813380||measurement||ad||2015-11-09 05:42:06.082992@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 05:42:22.849106||measurement||loadtime||0:00:49.341988||3||0
+2015-11-09 05:42:35.306429||measurement||ad||2015-11-09 05:42:33.984382@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:42:35.374661||measurement||ad||2015-11-09 05:42:33.984382@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:42:35.390548||measurement||loadtime||0:00:28.892137||2||1
+2015-11-09 05:42:35.662688||measurement||ad||2015-11-09 05:42:34.721845@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:42:35.804605||measurement||ad||2015-11-09 05:42:34.721845@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:42:35.846018||measurement||loadtime||0:00:32.101757||0||1
+2015-11-09 05:42:40.042427||measurement||ad||2015-11-09 05:42:31.356355@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||4||0
+2015-11-09 05:42:40.670693||measurement||ad||2015-11-09 05:42:31.356355@|Free Wills@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online and Print.||4||0
+2015-11-09 05:42:40.675116||measurement||loadtime||0:00:36.018491||4||0
+2015-11-09 05:42:48.326517||measurement||ad||2015-11-09 05:42:47.973326@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 05:42:48.390233||measurement||ad||2015-11-09 05:42:47.973326@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:42:48.404988||measurement||loadtime||0:00:23.525560||1||1
+2015-11-09 05:42:53.831991||measurement||ad||2015-11-09 05:42:46.556380@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:42:54.274556||measurement||ad||2015-11-09 05:42:46.556380@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||0
+2015-11-09 05:42:54.298491||measurement||loadtime||0:00:33.535867||5||0
+2015-11-09 05:43:06.170204||measurement||ad||2015-11-09 05:43:05.909775@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:43:06.286615||measurement||ad||2015-11-09 05:43:05.909775@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:43:06.334012||measurement||loadtime||0:00:25.487238||0||1
+2015-11-09 05:43:08.611928||measurement||ad||2015-11-09 05:43:08.179525@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:43:08.716046||measurement||ad||2015-11-09 05:43:08.179525@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:43:08.858174||measurement||loadtime||0:00:28.467051||2||1
+2015-11-09 05:43:10.751537||measurement||ad||2015-11-09 05:42:53.539908@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 05:43:12.259853||measurement||ad||2015-11-09 05:42:53.539908@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:43:12.265601||measurement||loadtime||0:00:44.415514||3||0
+2015-11-09 05:43:14.635923||measurement||ad||2015-11-09 05:43:08.438154@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||4||0
+2015-11-09 05:43:14.942003||measurement||ad||2015-11-09 05:43:08.438154@|Free Online Legal Will@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online  Print.||4||0
+2015-11-09 05:43:14.947579||measurement||loadtime||0:00:29.271679||4||0
+2015-11-09 05:43:22.879865||measurement||ad||2015-11-09 05:43:22.329616@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 05:43:22.970094||measurement||ad||2015-11-09 05:43:22.329616@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 05:43:23.009015||measurement||loadtime||0:00:29.603506||1||1
+2015-11-09 05:43:26.442113||measurement||ad||2015-11-09 05:43:20.219720@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||0
+2015-11-09 05:43:26.673113||measurement||ad||2015-11-09 05:43:20.219720@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:43:26.687813||measurement||loadtime||0:00:27.388161||5||0
+2015-11-09 05:43:34.688552||measurement||ad||2015-11-09 05:43:34.299551@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:43:34.785453||measurement||ad||2015-11-09 05:43:34.299551@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:43:34.817214||measurement||loadtime||0:00:23.481753||0||1
+2015-11-09 05:43:35.604181||measurement||ad||2015-11-09 05:43:35.313720@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:43:35.749093||measurement||ad||2015-11-09 05:43:35.313720@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:43:35.766663||measurement||loadtime||0:00:21.907645||2||1
+2015-11-09 05:43:48.250821||measurement||ad||2015-11-09 05:43:42.241905@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 05:43:48.387089||measurement||ad||2015-11-09 05:43:42.241905@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||4||0
+2015-11-09 05:43:48.392008||measurement||loadtime||0:00:28.443632||4||0
+2015-11-09 05:43:52.037673||measurement||ad||2015-11-09 05:43:41.361527@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:43:52.322593||measurement||ad||2015-11-09 05:43:41.361527@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:43:52.327580||measurement||loadtime||0:00:35.061123||3||0
+2015-11-09 05:43:53.890905||measurement||ad||2015-11-09 05:43:51.872191@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 05:43:55.215950||measurement||ad||2015-11-09 05:43:51.872191@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 05:43:55.593559||measurement||loadtime||0:00:27.583945||1||1
+2015-11-09 05:43:58.331954||measurement||ad||2015-11-09 05:43:50.771191@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:43:58.737426||measurement||ad||2015-11-09 05:43:50.771191@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||0
+2015-11-09 05:43:58.744878||measurement||loadtime||0:00:27.056045||5||0
+2015-11-09 05:44:07.920794||measurement||ad||2015-11-09 05:44:07.095977@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy. Mac Features in Windows. Try Free!||0||1
+2015-11-09 05:44:08.058970||measurement||ad||2015-11-09 05:44:07.095977@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:44:08.081618||measurement||loadtime||0:00:28.262871||0||1
+2015-11-09 05:44:09.961382||measurement||ad||2015-11-09 05:44:09.178133@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||1
+2015-11-09 05:44:10.688301||measurement||ad||2015-11-09 05:44:09.178133@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:44:10.779086||measurement||loadtime||0:00:30.010892||2||1
+2015-11-09 05:44:20.981298||measurement||ad||2015-11-09 05:44:14.830859@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||4||0
+2015-11-09 05:44:21.144247||measurement||ad||2015-11-09 05:44:14.830859@|Free Online Will Forms@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online  Print.||4||0
+2015-11-09 05:44:21.153497||measurement||loadtime||0:00:27.760649||4||0
+2015-11-09 05:44:27.898279||measurement||ad||2015-11-09 05:44:21.160032@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:44:27.924980||measurement||ad||2015-11-09 05:44:27.087076@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 05:44:28.309134||measurement||ad||2015-11-09 05:44:27.087076@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:44:28.327336||measurement||ad||2015-11-09 05:44:21.160032@|Part-Time Online Work@|surveyjunkie.com@|Make up to $45 per survey in 20 min The #1 Paying Survey Site Today!||3||0
+2015-11-09 05:44:28.329422||measurement||loadtime||0:00:27.735339||1||1
+2015-11-09 05:44:28.332884||measurement||loadtime||0:00:31.003989||3||0
+2015-11-09 05:44:31.228866||measurement||ad||2015-11-09 05:44:23.955840@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||0
+2015-11-09 05:44:31.461997||measurement||ad||2015-11-09 05:44:23.955840@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 05:44:31.519118||measurement||loadtime||0:00:27.773557||5||0
+2015-11-09 05:44:40.153736||measurement||ad||2015-11-09 05:44:39.926240@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:44:40.251996||measurement||ad||2015-11-09 05:44:39.926240@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||0||1
+2015-11-09 05:44:40.287772||measurement||loadtime||0:00:27.205186||0||1
+2015-11-09 05:44:43.905837||measurement||ad||2015-11-09 05:44:43.401710@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||2||1
+2015-11-09 05:44:43.966752||measurement||ad||2015-11-09 05:44:43.401710@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:44:43.978165||measurement||loadtime||0:00:28.197682||2||1
+2015-11-09 05:44:55.002203||measurement||ad||2015-11-09 05:44:53.901506@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 05:44:55.399380||measurement||ad||2015-11-09 05:44:53.901506@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 05:44:55.427992||measurement||loadtime||0:00:22.097823||1||1
+2015-11-09 05:44:59.452943||measurement||ad||2015-11-09 05:44:52.069638@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||4||0
+2015-11-09 05:44:59.926996||measurement||ad||2015-11-09 05:44:52.069638@|Free Wills@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online and Print.||4||0
+2015-11-09 05:44:59.951942||measurement||loadtime||0:00:33.796470||4||0
+2015-11-09 05:45:02.769227||measurement||ad||2015-11-09 05:44:55.577485@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:45:03.083874||measurement||ad||2015-11-09 05:44:55.577485@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||0
+2015-11-09 05:45:03.099470||measurement||loadtime||0:00:26.579282||5||0
+2015-11-09 05:45:08.874803||measurement||ad||2015-11-09 05:45:07.861959@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||0||1
+2015-11-09 05:45:09.056670||measurement||ad||2015-11-09 05:45:07.861959@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:45:09.068397||measurement||loadtime||0:00:23.779546||0||1
+2015-11-09 05:45:09.536676||measurement||ad||2015-11-09 05:44:57.334688@|Part-Time Online Work@|surveyjunkie.com@|Make up to $45 per survey in 20 min The #1 Paying Survey Site Today!||3||0
+2015-11-09 05:45:09.938275||measurement||ad||2015-11-09 05:44:57.334688@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 05:45:10.130679||measurement||loadtime||0:00:36.796521||3||0
+2015-11-09 05:45:14.714791||measurement||ad||2015-11-09 05:45:14.193951@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||2||1
+2015-11-09 05:45:14.866517||measurement||ad||2015-11-09 05:45:14.193951@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||2||1
+2015-11-09 05:45:14.882823||measurement||loadtime||0:00:25.904018||2||1
+2015-11-09 05:45:23.735353||measurement||ad||2015-11-09 05:45:23.500128@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 05:45:23.904828||measurement||ad||2015-11-09 05:45:23.500128@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||1||1
+2015-11-09 05:45:23.920100||measurement||loadtime||0:00:23.491444||1||1
+2015-11-09 05:45:23.920368||event||progress-marker||measurement-end||1||1
+2015-11-09 05:45:33.540628||measurement||ad||2015-11-09 05:45:28.229530@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 05:45:33.764105||measurement||ad||2015-11-09 05:45:28.229530@|Free Will Templates@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online  Print.||4||0
+2015-11-09 05:45:33.780257||measurement||loadtime||0:00:28.826974||4||0
+2015-11-09 05:45:37.631739||measurement||ad||2015-11-09 05:45:31.292261@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:45:37.951389||measurement||ad||2015-11-09 05:45:31.292261@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||5||0
+2015-11-09 05:45:37.972444||measurement||loadtime||0:00:29.870817||5||0
+2015-11-09 05:45:40.532655||measurement||ad||2015-11-09 05:45:40.310123@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||1
+2015-11-09 05:45:40.588027||measurement||ad||2015-11-09 05:45:40.310123@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||1
+2015-11-09 05:45:40.597143||measurement||loadtime||0:00:20.713136||2||1
+2015-11-09 05:45:40.597371||event||progress-marker||measurement-end||2||1
+2015-11-09 05:45:41.885039||measurement||ad||2015-11-09 05:45:37.582159@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:45:41.976668||measurement||ad||2015-11-09 05:45:37.582159@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 05:45:41.980088||measurement||loadtime||0:00:26.848049||3||0
+2015-11-09 05:45:42.484791||measurement||ad||2015-11-09 05:45:42.262074@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 05:45:42.545461||measurement||ad||2015-11-09 05:45:42.262074@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||0||1
+2015-11-09 05:45:42.555147||measurement||loadtime||0:00:28.486278||0||1
+2015-11-09 05:45:42.555432||event||progress-marker||measurement-end||0||1
+2015-11-09 05:46:00.300785||measurement||ad||2015-11-09 05:45:57.028418@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 05:46:00.427823||measurement||ad||2015-11-09 05:45:57.028418@|Free Online Legal Will@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online  Print.||4||0
+2015-11-09 05:46:00.431657||measurement||loadtime||0:00:21.650411||4||0
+2015-11-09 05:46:01.423126||measurement||ad||2015-11-09 05:45:58.527416@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||5||0
+2015-11-09 05:46:01.550316||measurement||ad||2015-11-09 05:45:58.527416@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 05:46:01.554186||measurement||loadtime||0:00:18.581048||5||0
+2015-11-09 05:46:01.554473||event||progress-marker||measurement-end||5||0
+2015-11-09 05:46:07.007940||measurement||ad||2015-11-09 05:46:04.159685@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:46:07.105512||measurement||ad||2015-11-09 05:46:04.159685@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 05:46:07.108576||measurement||loadtime||0:00:20.127962||3||0
+2015-11-09 05:46:22.520817||measurement||ad||2015-11-09 05:46:20.397137@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||4||0
+2015-11-09 05:46:22.586962||measurement||ad||2015-11-09 05:46:20.397137@|Free Will Templates@|www.totallegal.com@|Forms for Every State. Simple - Prepare Online  Print.||4||0
+2015-11-09 05:46:22.591497||measurement||loadtime||0:00:17.159014||4||0
+2015-11-09 05:46:22.591842||event||progress-marker||measurement-end||4||0
+2015-11-09 05:46:33.062239||measurement||ad||2015-11-09 05:46:28.866090@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 05:46:33.124701||measurement||ad||2015-11-09 05:46:28.866090@|Part-Time Online Work@|surveyjunkie.com@|Make up to $45 per survey in 20 min The #1 Paying Survey Site Today!||3||0
+2015-11-09 05:46:33.127839||measurement||loadtime||0:00:21.017716||3||0
+2015-11-09 05:47:38.209920||error||collecting ads||Error||3||0
+2015-11-09 05:47:38.210400||event||progress-marker||measurement-end||3||0
+2015-11-09 05:47:38.886730||meta||block_id end||14
+2015-11-09 05:47:38.888418||meta||block_id start||15
+2015-11-09 05:47:38.888544||meta||assignment||5@|3@|1@|4@|0@|2
+2015-11-09 05:47:42.659536||event||progress-marker||training-start||1||0
+2015-11-09 05:47:42.840815||event||progress-marker||training-start||5||0
+2015-11-09 05:47:42.847640||event||progress-marker||training-start||3||0
+2015-11-09 05:47:45.728386||event||progress-marker||training-start||4||1
+2015-11-09 05:47:45.804839||event||progress-marker||training-start||0||1
+2015-11-09 05:47:46.194180||event||progress-marker||training-start||2||1
+2015-11-09 05:47:47.504534||treatment||google search||Buy BMW||5||0
+2015-11-09 05:47:47.516289||treatment||google search||Buy BMW||1||0
+2015-11-09 05:47:48.644685||treatment||google search||Buy BMW||3||0
+2015-11-09 05:47:49.527342||error||visiting||google searchresults||5||0
+2015-11-09 05:47:49.728718||error||visiting||google searchresults||1||0
+2015-11-09 05:47:50.349449||error||visiting||google searchresults||3||0
+2015-11-09 05:47:51.324313||treatment||google search||Buy BMW||4||1
+2015-11-09 05:47:51.337856||treatment||google search||Buy BMW||0||1
+2015-11-09 05:47:51.378187||treatment||google search||Buy BMW||2||1
+2015-11-09 05:48:02.213056||error||visiting||google searchresults||4||1
+2015-11-09 05:48:02.218338||error||visiting||google searchresults||2||1
+2015-11-09 05:48:02.226928||error||visiting||google searchresults||0||1
+2015-11-09 05:48:06.450038||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 05:48:07.482540||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 05:48:16.059407||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 05:48:16.223364||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 05:48:17.696439||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 05:48:21.578530||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 05:48:22.374020||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 05:48:25.275099||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 05:48:30.777413||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 05:48:31.166510||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 05:48:31.173388||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 05:48:31.632637||error||visiting||google searchresults||5||0
+2015-11-09 05:48:32.408721||error||visiting||google searchresults||1||0
+2015-11-09 05:48:39.648987||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 05:48:46.500077||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||5||0
+2015-11-09 05:48:47.600199||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||1||0
+2015-11-09 05:48:49.683489||error||visiting||google searchresults||3||0
+2015-11-09 05:48:50.873554||error||visiting||google searchresults||0||1
+2015-11-09 05:48:51.244427||error||visiting||google searchresults||4||1
+2015-11-09 05:48:51.270627||error||visiting||google searchresults||2||1
+2015-11-09 05:48:58.231247||treatment||google search||BMW dealer||5||0
+2015-11-09 05:48:58.882110||error||visiting||google searchresults||5||0
+2015-11-09 05:48:59.297557||treatment||google search||BMW dealer||1||0
+2015-11-09 05:48:59.883797||error||visiting||google searchresults||1||0
+2015-11-09 05:49:04.622206||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||0||1
+2015-11-09 05:49:04.768370||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||4||1
+2015-11-09 05:49:07.052156||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||2||1
+2015-11-09 05:49:08.087491||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 05:49:17.190579||treatment||google search||BMW dealer||0||1
+2015-11-09 05:49:17.336793||treatment||google search||BMW dealer||4||1
+2015-11-09 05:49:19.854524||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIX-oL-Vg8kCFdgJgQodmYkNDA||1||0
+2015-11-09 05:49:19.993829||treatment||google search||BMW dealer||3||0
+2015-11-09 05:49:20.207969||treatment||google search||BMW dealer||2||1
+2015-11-09 05:49:20.686672||error||visiting||google searchresults||3||0
+2015-11-09 05:49:22.536231||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||5||0
+2015-11-09 05:49:28.396965||error||visiting||google searchresults||0||1
+2015-11-09 05:49:28.516167||error||visiting||google searchresults||4||1
+2015-11-09 05:49:31.038700||error||visiting||google searchresults||2||1
+2015-11-09 05:49:35.418615||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CO--4ciVg8kCFYE2gQodAXcLFQ||1||0
+2015-11-09 05:49:37.993617||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJKElsmVg8kCFdgcgQodPBMC0w||3||0
+2015-11-09 05:49:43.052677||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810||5||0
+2015-11-09 05:49:43.438799||treatment||visit page||http://dealers.autosite.com/dealers/bmw?ukwid=9301ef85-c96c-4ead-beee-bf5234006e9d&udv=c&gclid=COLi9cyVg8kCFdgLgQodEQEH0g||4||1
+2015-11-09 05:49:45.492136||error||visiting||google searchresults||1||0
+2015-11-09 05:49:46.464295||treatment||visit page||http://www.carsense.com/?gclid=CKn17cyVg8kCFUUlgQodxcoKZQ||0||1
+2015-11-09 05:49:49.832138||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP3xjs6Vg8kCFYE8gQodHBICvw||2||1
+2015-11-09 05:49:53.095379||error||visiting||google searchresults||5||0
+2015-11-09 05:49:53.562264||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CI-ctdGVg8kCFdgGgQodtJYOGQ||3||0
+2015-11-09 05:49:56.785826||treatment||visit page||http://dealers.autosite.com/dealers/bmw?ukwid=9301ef85-c96c-4ead-beee-bf5234006e9d&udv=c&gclid=CNGVg9SVg8kCFdgYgQody_wFDQ||4||1
+2015-11-09 05:50:02.731430||treatment||visit page||http://www.carsense.com/?gclid=CIjg_tSVg8kCFdU6gQodunAK2g||1||0
+2015-11-09 05:50:02.995699||treatment||visit page||http://www.carsense.com/?gclid=CO2pu9WVg8kCFU47gQod-GIG7g||0||1
+2015-11-09 05:50:03.607396||error||visiting||google searchresults||3||0
+2015-11-09 05:50:05.512943||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKqCideVg8kCFYc7gQod-Q0MzA||2||1
+2015-11-09 05:50:10.919474||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJDyz9iVg8kCFVMvgQodTycJrA||5||0
+2015-11-09 05:50:14.464377||treatment||google search||BMW||1||0
+2015-11-09 05:50:15.431762||error||visiting||google searchresults||1||0
+2015-11-09 05:50:16.875044||error||visiting||google searchresults||4||1
+2015-11-09 05:50:20.728595||treatment||visit page||http://www.carsense.com/?gclid=CJD4z92Vg8kCFZI9gQod8jMJsA||3||0
+2015-11-09 05:50:22.512102||treatment||google search||BMW||5||0
+2015-11-09 05:50:23.062501||error||visiting||google searchresults||0||1
+2015-11-09 05:50:23.327192||error||visiting||google searchresults||5||0
+2015-11-09 05:50:25.563139||error||visiting||google searchresults||2||1
+2015-11-09 05:50:30.257583||treatment||visit page||http://www.usautomart.com/?gclid=CKDL_OOVg8kCFYc7gQod-Q0MzA||4||1
+2015-11-09 05:50:32.365706||treatment||google search||BMW||3||0
+2015-11-09 05:50:33.389585||error||visiting||google searchresults||3||0
+2015-11-09 05:50:33.596591||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 05:50:36.581514||treatment||visit page||http://www.towerautosales.com/index.shtml||0||1
+2015-11-09 05:50:41.159312||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 05:50:41.694757||treatment||visit page||http://www.carsense.com/?gclid=CInJj-iVg8kCFdgLgQodEQEH0g||2||1
+2015-11-09 05:50:42.713864||treatment||google search||BMW||4||1
+2015-11-09 05:50:48.508348||treatment||google search||BMW||0||1
+2015-11-09 05:50:50.261796||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 05:50:50.758382||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:50:53.827863||treatment||google search||BMW||2||1
+2015-11-09 05:50:57.043066||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 05:50:57.657905||error||visiting||google searchresults||4||1
+2015-11-09 05:50:59.421853||error||visiting||google searchresults||0||1
+2015-11-09 05:51:00.323758||error||visiting||google searchresults||1||0
+2015-11-09 05:51:04.827540||error||visiting||google searchresults||2||1
+2015-11-09 05:51:06.396754||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 05:51:07.078528||error||visiting||google searchresults||5||0
+2015-11-09 05:51:14.085440||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||0||1
+2015-11-09 05:51:16.340881||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 05:51:16.440914||error||visiting||google searchresults||3||0
+2015-11-09 05:51:18.084608||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 05:51:20.678358||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 05:51:26.264861||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 05:51:26.342574||event||progress-marker||training-end||1||0
+2015-11-09 05:51:29.175236||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||0||1
+2015-11-09 05:51:31.432591||treatment||visit page||http://www.bmwusa.com/||4||1
+2015-11-09 05:51:32.318347||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 05:51:36.266405||event||progress-marker||training-end||5||0
+2015-11-09 05:51:36.842306||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 05:51:42.319919||event||progress-marker||training-end||3||0
+2015-11-09 05:51:49.271080||error||visiting||google searchresults||0||1
+2015-11-09 05:51:51.544125||error||visiting||google searchresults||4||1
+2015-11-09 05:51:56.966423||error||visiting||google searchresults||2||1
+2015-11-09 05:52:05.726372||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||1
+2015-11-09 05:52:10.106225||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 05:52:13.549046||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 05:52:15.727522||event||progress-marker||training-end||4||1
+2015-11-09 05:52:20.107705||event||progress-marker||training-end||0||1
+2015-11-09 05:52:23.549716||event||progress-marker||training-end||2||1
+2015-11-09 05:52:25.143837||event||progress-marker||measurement-start||0||1
+2015-11-09 05:52:25.781965||event||progress-marker||measurement-start||4||1
+2015-11-09 05:52:26.480770||event||progress-marker||measurement-start||5||0
+2015-11-09 05:52:26.613263||event||progress-marker||measurement-start||1||0
+2015-11-09 05:52:27.531549||event||progress-marker||measurement-start||3||0
+2015-11-09 05:52:28.589598||event||progress-marker||measurement-start||2||1
+2015-11-09 05:53:17.241605||measurement||ad||2015-11-09 05:53:06.430339@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 05:53:17.373244||measurement||ad||2015-11-09 05:53:06.430339@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 05:53:17.379874||measurement||loadtime||0:00:45.765197||1||0
+2015-11-09 05:53:19.429327||measurement||ad||2015-11-09 05:53:18.177731@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:53:19.679592||measurement||ad||2015-11-09 05:53:18.177731@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:53:19.704912||measurement||loadtime||0:00:49.559527||0||1
+2015-11-09 05:53:23.250092||measurement||ad||2015-11-09 05:53:08.126072@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||0
+2015-11-09 05:53:23.490870||measurement||ad||2015-11-09 05:53:08.126072@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:53:23.497651||measurement||loadtime||0:00:50.965187||3||0
+2015-11-09 05:53:23.729429||measurement||ad||2015-11-09 05:53:23.338967@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:53:23.844297||measurement||ad||2015-11-09 05:53:23.338967@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||1
+2015-11-09 05:53:23.859745||measurement||loadtime||0:00:53.077036||4||1
+2015-11-09 05:53:26.204512||measurement||ad||2015-11-09 05:53:25.136187@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:53:26.527285||measurement||ad||2015-11-09 05:53:25.136187@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 05:53:26.541310||measurement||loadtime||0:00:52.949984||2||1
+2015-11-09 05:53:58.192234||measurement||ad||2015-11-09 05:53:47.831202@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 05:54:02.018333||measurement||ad||2015-11-09 05:53:24.035835@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||0
+2015-11-09 05:54:02.621032||measurement||ad||2015-11-09 05:53:47.831202@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 05:54:02.717353||measurement||loadtime||0:00:40.336839||1||0
+2015-11-09 05:54:03.263084||measurement||ad||2015-11-09 05:53:24.035835@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 05:54:03.267975||measurement||loadtime||0:01:31.786277||5||0
+2015-11-09 05:54:04.939230||measurement||ad||2015-11-09 05:54:04.257590@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:54:05.196379||measurement||ad||2015-11-09 05:54:04.257590@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:54:05.346501||measurement||loadtime||0:00:40.640833||0||1
+2015-11-09 05:54:11.412400||measurement||ad||2015-11-09 05:53:54.400295@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||0
+2015-11-09 05:54:12.400379||measurement||ad||2015-11-09 05:53:54.400295@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:54:12.472848||measurement||loadtime||0:00:43.974684||3||0
+2015-11-09 05:54:12.768449||measurement||ad||2015-11-09 05:54:11.338761@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:54:13.009497||measurement||ad||2015-11-09 05:54:11.338761@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 05:54:13.029426||measurement||loadtime||0:00:41.487438||2||1
+2015-11-09 05:54:14.677955||measurement||ad||2015-11-09 05:54:13.861088@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:54:15.021256||measurement||ad||2015-11-09 05:54:13.861088@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||1
+2015-11-09 05:54:15.096113||measurement||loadtime||0:00:46.234524||4||1
+2015-11-09 05:54:39.497002||measurement||ad||2015-11-09 05:54:38.803258@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:54:39.754918||measurement||ad||2015-11-09 05:54:38.803258@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:54:39.808131||measurement||loadtime||0:00:29.459525||0||1
+2015-11-09 05:54:44.978233||measurement||ad||2015-11-09 05:54:29.384862@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 05:54:45.552852||measurement||ad||2015-11-09 05:54:29.384862@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||1||0
+2015-11-09 05:54:45.587837||measurement||loadtime||0:00:37.869494||1||0
+2015-11-09 05:54:51.250710||measurement||ad||2015-11-09 05:54:50.127784@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:54:51.496120||measurement||ad||2015-11-09 05:54:50.127784@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:54:51.585875||measurement||loadtime||0:00:33.555735||2||1
+2015-11-09 05:54:52.712959||measurement||ad||2015-11-09 05:54:37.356713@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||0
+2015-11-09 05:54:55.545207||measurement||ad||2015-11-09 05:54:37.356713@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:54:55.572581||measurement||loadtime||0:00:38.098443||3||0
+2015-11-09 05:55:02.643835||measurement||ad||2015-11-09 05:55:01.360908@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:55:03.057715||measurement||ad||2015-11-09 05:55:01.360908@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||1
+2015-11-09 05:55:03.172631||measurement||loadtime||0:00:43.075074||4||1
+2015-11-09 05:55:12.877664||measurement||ad||2015-11-09 05:54:48.854266@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 05:55:16.356859||measurement||ad||2015-11-09 05:54:48.854266@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 05:55:16.991822||measurement||loadtime||0:01:08.723096||5||0
+2015-11-09 05:55:22.778604||measurement||ad||2015-11-09 05:55:15.915120@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 05:55:23.099132||measurement||ad||2015-11-09 05:55:15.915120@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 05:55:23.104976||measurement||loadtime||0:00:32.514985||1||0
+2015-11-09 05:55:27.754189||measurement||ad||2015-11-09 05:55:27.224308@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:55:27.984026||measurement||ad||2015-11-09 05:55:27.224308@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:55:28.023293||measurement||loadtime||0:00:43.214657||0||1
+2015-11-09 05:55:31.764162||measurement||ad||2015-11-09 05:55:26.139588@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 05:55:31.962682||measurement||ad||2015-11-09 05:55:31.165080@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:55:32.006343||measurement||ad||2015-11-09 05:55:26.139588@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:55:32.012896||measurement||loadtime||0:00:31.438539||3||0
+2015-11-09 05:55:32.234114||measurement||ad||2015-11-09 05:55:31.165080@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:55:32.257840||measurement||loadtime||0:00:35.671126||2||1
+2015-11-09 05:55:41.229813||measurement||ad||2015-11-09 05:55:40.728640@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:55:41.524626||measurement||ad||2015-11-09 05:55:40.728640@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:55:41.541743||measurement||loadtime||0:00:33.367882||4||1
+2015-11-09 05:55:58.293710||measurement||ad||2015-11-09 05:55:49.930946@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 05:55:58.503476||measurement||ad||2015-11-09 05:55:49.930946@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 05:55:58.519856||measurement||loadtime||0:00:30.414098||1||0
+2015-11-09 05:56:02.671317||measurement||ad||2015-11-09 05:55:56.716267@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||0
+2015-11-09 05:56:02.877572||measurement||ad||2015-11-09 05:55:56.716267@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 05:56:02.883106||measurement||loadtime||0:00:25.869443||3||0
+2015-11-09 05:56:02.897811||measurement||ad||2015-11-09 05:56:01.910389@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:56:03.006944||measurement||ad||2015-11-09 05:56:01.910389@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:56:03.018948||measurement||loadtime||0:00:25.760383||2||1
+2015-11-09 05:56:08.656076||measurement||ad||2015-11-09 05:56:02.887588@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:56:09.656602||measurement||ad||2015-11-09 05:56:02.887588@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:56:09.740422||measurement||loadtime||0:00:36.715503||0||1
+2015-11-09 05:56:12.065777||measurement||ad||2015-11-09 05:55:52.958042@|Design A Room Online@|www.bhg.com/DesignRoom@|Try Our Virtual Room Builder Tool From Better Homes  Gardens®||5||0
+2015-11-09 05:56:12.493414||measurement||ad||2015-11-09 05:55:52.958042@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 05:56:12.500602||measurement||loadtime||0:00:50.507140||5||0
+2015-11-09 05:56:19.480681||measurement||ad||2015-11-09 05:56:18.738471@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:56:19.695056||measurement||ad||2015-11-09 05:56:18.738471@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:56:19.758872||measurement||loadtime||0:00:33.216516||4||1
+2015-11-09 05:56:30.175256||measurement||ad||2015-11-09 05:56:25.976722@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 05:56:30.357833||measurement||ad||2015-11-09 05:56:25.976722@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||0
+2015-11-09 05:56:30.362727||measurement||loadtime||0:00:26.841560||1||0
+2015-11-09 05:56:35.149001||measurement||ad||2015-11-09 05:56:34.543600@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:56:35.204895||measurement||ad||2015-11-09 05:56:34.543600@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:56:35.214911||measurement||loadtime||0:00:27.195370||2||1
+2015-11-09 05:56:35.709410||measurement||ad||2015-11-09 05:56:28.153459@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:56:38.855267||measurement||ad||2015-11-09 05:56:28.153459@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:56:38.917205||measurement||loadtime||0:00:31.033547||3||0
+2015-11-09 05:56:45.968148||measurement||ad||2015-11-09 05:56:45.490234@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:56:46.410479||measurement||ad||2015-11-09 05:56:45.490234@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:56:46.555536||measurement||loadtime||0:00:31.813554||0||1
+2015-11-09 05:56:54.653231||measurement||ad||2015-11-09 05:56:45.577754@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 05:56:56.171093||measurement||ad||2015-11-09 05:56:55.064556@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:56:56.461670||measurement||ad||2015-11-09 05:56:55.064556@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:56:56.484875||measurement||loadtime||0:00:31.724936||4||1
+2015-11-09 05:56:57.929505||measurement||ad||2015-11-09 05:56:45.577754@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 05:56:58.901116||measurement||loadtime||0:00:41.399572||5||0
+2015-11-09 05:57:04.186724||measurement||ad||2015-11-09 05:56:57.466608@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 05:57:04.405719||measurement||ad||2015-11-09 05:56:57.466608@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||1||0
+2015-11-09 05:57:04.411562||measurement||loadtime||0:00:29.047607||1||0
+2015-11-09 05:57:07.688878||measurement||ad||2015-11-09 05:57:07.277036@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:57:07.771845||measurement||ad||2015-11-09 05:57:07.277036@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:57:07.833255||measurement||loadtime||0:00:27.617739||2||1
+2015-11-09 05:57:27.271090||measurement||ad||2015-11-09 05:57:26.574188@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:57:27.482462||measurement||ad||2015-11-09 05:57:26.574188@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:57:27.496350||measurement||loadtime||0:00:35.939721||0||1
+2015-11-09 05:57:30.959485||measurement||ad||2015-11-09 05:57:11.800517@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:57:32.054612||measurement||ad||2015-11-09 05:57:11.800517@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:57:32.059302||measurement||loadtime||0:00:48.141522||3||0
+2015-11-09 05:57:40.297029||measurement||ad||2015-11-09 05:57:38.593730@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:57:40.742938||measurement||ad||2015-11-09 05:57:38.593730@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:57:40.758208||measurement||loadtime||0:00:39.271791||4||1
+2015-11-09 05:57:41.242472||measurement||ad||2015-11-09 05:57:36.653041@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 05:57:41.371909||measurement||ad||2015-11-09 05:57:36.653041@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||1||0
+2015-11-09 05:57:41.379779||measurement||loadtime||0:00:31.966691||1||0
+2015-11-09 05:57:44.793668||measurement||ad||2015-11-09 05:57:43.947048@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:57:44.897722||measurement||ad||2015-11-09 05:57:43.947048@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:57:44.935337||measurement||loadtime||0:00:32.101065||2||1
+2015-11-09 05:57:56.880725||measurement||ad||2015-11-09 05:57:40.647277@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||5||0
+2015-11-09 05:57:57.146058||measurement||ad||2015-11-09 05:57:40.647277@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 05:57:57.152252||measurement||loadtime||0:00:53.250484||5||0
+2015-11-09 05:58:10.295756||measurement||ad||2015-11-09 05:58:09.719252@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:58:10.478776||measurement||ad||2015-11-09 05:58:09.719252@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:58:10.500216||measurement||loadtime||0:00:38.003392||0||1
+2015-11-09 05:58:17.775633||measurement||ad||2015-11-09 05:58:13.187341@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 05:58:18.100608||measurement||ad||2015-11-09 05:58:13.187341@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 05:58:18.108348||measurement||loadtime||0:00:31.727942||1||0
+2015-11-09 05:58:19.408930||measurement||ad||2015-11-09 05:58:18.766240@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:58:19.623070||measurement||ad||2015-11-09 05:58:18.766240@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:58:19.641187||measurement||loadtime||0:00:33.882062||4||1
+2015-11-09 05:58:20.554366||measurement||ad||2015-11-09 05:58:19.865467@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:58:21.102054||measurement||ad||2015-11-09 05:58:19.865467@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:58:21.225932||measurement||loadtime||0:00:31.289844||2||1
+2015-11-09 05:58:22.931960||measurement||ad||2015-11-09 05:58:01.678835@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||3||0
+2015-11-09 05:58:25.286225||measurement||ad||2015-11-09 05:58:01.678835@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:58:25.294846||measurement||loadtime||0:00:48.233185||3||0
+2015-11-09 05:58:42.082364||measurement||ad||2015-11-09 05:58:32.112222@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||0
+2015-11-09 05:58:47.150031||measurement||ad||2015-11-09 05:58:32.112222@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 05:58:47.243847||measurement||loadtime||0:00:45.089676||5||0
+2015-11-09 05:58:55.178738||measurement||ad||2015-11-09 05:58:54.649935@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:58:55.323749||measurement||ad||2015-11-09 05:58:54.649935@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:58:55.334611||measurement||loadtime||0:00:30.692582||4||1
+2015-11-09 05:58:56.237917||measurement||ad||2015-11-09 05:58:48.274065@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:58:56.415277||measurement||ad||2015-11-09 05:58:48.274065@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:58:56.431754||measurement||loadtime||0:00:40.930012||0||1
+2015-11-09 05:59:01.153621||measurement||ad||2015-11-09 05:58:50.185772@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||1||0
+2015-11-09 05:59:01.525634||measurement||ad||2015-11-09 05:58:50.185772@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 05:59:01.533460||measurement||loadtime||0:00:38.424152||1||0
+2015-11-09 05:59:01.539027||event||progress-marker||measurement-end||1||0
+2015-11-09 05:59:04.673441||measurement||ad||2015-11-09 05:59:02.920415@|Earn $10-$40 per Survey@|surveyjunkie.com@|Legitimate Work at Home. Free! Cash Money in Your Spare Time.||2||1
+2015-11-09 05:59:05.059077||measurement||ad||2015-11-09 05:59:02.920415@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 05:59:05.077748||measurement||loadtime||0:00:38.850774||2||1
+2015-11-09 05:59:05.078128||event||progress-marker||measurement-end||2||1
+2015-11-09 05:59:07.107398||measurement||ad||2015-11-09 05:58:59.859195@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:59:07.280572||measurement||ad||2015-11-09 05:58:59.859195@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:59:07.318055||measurement||loadtime||0:00:37.021672||3||0
+2015-11-09 05:59:24.109562||measurement||ad||2015-11-09 05:59:23.870061@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||1
+2015-11-09 05:59:24.195897||measurement||ad||2015-11-09 05:59:23.870061@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||4||1
+2015-11-09 05:59:24.239085||measurement||loadtime||0:00:23.903899||4||1
+2015-11-09 05:59:24.239781||event||progress-marker||measurement-end||4||1
+2015-11-09 05:59:26.819148||measurement||ad||2015-11-09 05:59:26.649346@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||0||1
+2015-11-09 05:59:26.865720||measurement||ad||2015-11-09 05:59:26.649346@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 05:59:26.875228||measurement||loadtime||0:00:25.442784||0||1
+2015-11-09 05:59:26.875470||event||progress-marker||measurement-end||0||1
+2015-11-09 05:59:34.424763||measurement||ad||2015-11-09 05:59:32.236273@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||0
+2015-11-09 05:59:34.504367||measurement||ad||2015-11-09 05:59:32.236273@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||0
+2015-11-09 05:59:34.507449||measurement||loadtime||0:00:22.188462||3||0
+2015-11-09 05:59:34.507680||event||progress-marker||measurement-end||3||0
+2015-11-09 05:59:52.348962||error||collecting ads||Error||5||0
+2015-11-09 06:00:14.365510||measurement||ad||2015-11-09 06:00:12.264038@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 06:00:14.430929||measurement||ad||2015-11-09 06:00:12.264038@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 06:00:14.523701||measurement||loadtime||0:00:17.174056||5||0
+2015-11-09 06:00:48.670638||measurement||ad||2015-11-09 06:00:46.112688@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 06:00:48.757643||measurement||ad||2015-11-09 06:00:46.112688@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 06:00:48.760984||measurement||loadtime||0:00:29.236784||5||0
+2015-11-09 06:01:17.882410||measurement||ad||2015-11-09 06:01:11.153662@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||5||0
+2015-11-09 06:01:18.022761||measurement||ad||2015-11-09 06:01:11.153662@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||5||0
+2015-11-09 06:01:18.627815||measurement||loadtime||0:00:24.865642||5||0
+2015-11-09 06:01:18.628243||event||progress-marker||measurement-end||5||0
+2015-11-09 06:01:19.367027||meta||block_id end||15
+2015-11-09 06:01:19.368880||meta||block_id start||16
+2015-11-09 06:01:19.369197||meta||assignment||4@|5@|3@|2@|1@|0
+2015-11-09 06:01:23.194055||event||progress-marker||training-start||5||0
+2015-11-09 06:01:23.207095||event||progress-marker||training-start||3||0
+2015-11-09 06:01:23.478126||event||progress-marker||training-start||4||0
+2015-11-09 06:01:26.026350||event||progress-marker||training-start||1||1
+2015-11-09 06:01:26.120198||event||progress-marker||training-start||2||1
+2015-11-09 06:01:26.165454||event||progress-marker||training-start||0||1
+2015-11-09 06:01:28.049895||treatment||google search||Buy BMW||4||0
+2015-11-09 06:01:29.102339||treatment||google search||Buy BMW||5||0
+2015-11-09 06:01:29.169791||treatment||google search||Buy BMW||3||0
+2015-11-09 06:01:30.104226||error||visiting||google searchresults||4||0
+2015-11-09 06:01:30.772860||error||visiting||google searchresults||3||0
+2015-11-09 06:01:30.857999||error||visiting||google searchresults||5||0
+2015-11-09 06:01:31.784520||treatment||google search||Buy BMW||0||1
+2015-11-09 06:01:31.800179||treatment||google search||Buy BMW||2||1
+2015-11-09 06:01:31.837659||treatment||google search||Buy BMW||1||1
+2015-11-09 06:01:42.743733||error||visiting||google searchresults||1||1
+2015-11-09 06:01:42.750146||error||visiting||google searchresults||2||1
+2015-11-09 06:01:42.772230||error||visiting||google searchresults||0||1
+2015-11-09 06:01:51.334145||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 06:01:51.690306||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 06:01:59.416975||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 06:01:59.569635||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 06:02:01.911851||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||1
+2015-11-09 06:02:07.856574||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||0
+2015-11-09 06:02:09.369272||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||0
+2015-11-09 06:02:13.401884||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||1
+2015-11-09 06:02:14.918599||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 06:02:16.875518||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||1
+2015-11-09 06:02:17.892985||error||visiting||google searchresults||5||0
+2015-11-09 06:02:19.401996||error||visiting||google searchresults||3||0
+2015-11-09 06:02:20.278674||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 06:02:32.065225||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CI6y5LuYg8kCFdgDgQodN8QD6w||5||0
+2015-11-09 06:02:33.239086||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CJXpv7yYg8kCFUo6gQodotYFog||3||0
+2015-11-09 06:02:33.501756||error||visiting||google searchresults||1||1
+2015-11-09 06:02:34.960101||error||visiting||google searchresults||0||1
+2015-11-09 06:02:36.959397||error||visiting||google searchresults||2||1
+2015-11-09 06:02:37.309235||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 06:02:43.873106||treatment||google search||BMW dealer||5||0
+2015-11-09 06:02:44.657677||error||visiting||google searchresults||5||0
+2015-11-09 06:02:45.165542||treatment||google search||BMW dealer||3||0
+2015-11-09 06:02:45.760255||error||visiting||google searchresults||3||0
+2015-11-09 06:02:46.734920||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CKSIoMOYg8kCFZYkgQod96sHBA||1||1
+2015-11-09 06:02:47.364284||error||visiting||google searchresults||4||0
+2015-11-09 06:02:48.207018||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CMfF-MOYg8kCFZM2gQodqtgP5w||0||1
+2015-11-09 06:02:50.211128||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CMDd88SYg8kCFdgNgQodcuEFZg||2||1
+2015-11-09 06:02:59.231474||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t1&physloc=9005925&intloc=&gclid=CPLkwsiYg8kCFdcSgQodbsAAfg||5||0
+2015-11-09 06:02:59.696607||treatment||google search||BMW dealer||1||1
+2015-11-09 06:03:00.780750||treatment||google search||BMW dealer||0||1
+2015-11-09 06:03:01.658178||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CJDf7MmYg8kCFYI8gQodSNAOFA||4||0
+2015-11-09 06:03:03.011392||treatment||google search||BMW dealer||2||1
+2015-11-09 06:03:05.320917||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CICehsmYg8kCFcUlgQodKCwN8A||3||0
+2015-11-09 06:03:11.237785||error||visiting||google searchresults||1||1
+2015-11-09 06:03:11.883600||error||visiting||google searchresults||0||1
+2015-11-09 06:03:13.279525||treatment||google search||BMW dealer||4||0
+2015-11-09 06:03:13.605131||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t1&physloc=9005925&intloc=&gclid=CN6Lvc-Yg8kCFUEvgQodvQgC1w||5||0
+2015-11-09 06:03:13.915673||error||visiting||google searchresults||2||1
+2015-11-09 06:03:13.981492||error||visiting||google searchresults||4||0
+2015-11-09 06:03:20.708980||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLzCsNKYg8kCFdgBgQodMekJLw||3||0
+2015-11-09 06:03:23.658482||error||visiting||google searchresults||5||0
+2015-11-09 06:03:25.918620||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t1&physloc=9005925&intloc=&gclid=CJ-Ww9WYg8kCFdcZgQod5yUGlQ||0||1
+2015-11-09 06:03:30.034443||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJvsmdWYg8kCFdgagQodCK4AMg||1||1
+2015-11-09 06:03:30.758175||error||visiting||google searchresults||3||0
+2015-11-09 06:03:31.969596||treatment||visit page||http://www.carsense.com/?gclid=CNmlwdaYg8kCFYc7gQod-Q0MzA||2||1
+2015-11-09 06:03:33.292230||treatment||visit page||http://www.carsense.com/?gclid=CNmIydaYg8kCFYE8gQodHBICvw||4||0
+2015-11-09 06:03:38.090256||treatment||visit page||http://www.towerautosales.com/index.shtml||5||0
+2015-11-09 06:03:40.148916||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t1&physloc=9005925&intloc=&gclid=CLrfmtyYg8kCFdcYgQodr0oJqg||0||1
+2015-11-09 06:03:47.472521||treatment||visit page||http://www.carsense.com/?gclid=COLHkd-Yg8kCFdgUgQod7XIEQg||2||1
+2015-11-09 06:03:47.670025||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIqRlt6Yg8kCFVY9gQodhJwOrg||1||1
+2015-11-09 06:03:50.130184||treatment||google search||BMW||5||0
+2015-11-09 06:03:50.489731||treatment||visit page||http://www.carsense.com/?gclid=CODK3d-Yg8kCFYkjgQodPiQO3A||4||0
+2015-11-09 06:03:51.010547||error||visiting||google searchresults||5||0
+2015-11-09 06:04:00.204588||error||visiting||google searchresults||0||1
+2015-11-09 06:04:00.526612||error||visiting||google searchresults||4||0
+2015-11-09 06:04:07.536388||error||visiting||google searchresults||2||1
+2015-11-09 06:04:07.770238||error||visiting||google searchresults||1||1
+2015-11-09 06:04:08.769196||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 06:04:15.968338||treatment||visit page||http://www.usautomart.com/?gclid=CKXQ2-yYg8kCFdgUgQod7XIEQg||4||0
+2015-11-09 06:04:16.111815||treatment||visit page||http://www.towerautosales.com/index.shtml||0||1
+2015-11-09 06:04:20.828514||error||visiting||google searchresults||3||0
+2015-11-09 06:04:21.775427||treatment||visit page||http://dealershipperformancecrm.com/||1||1
+2015-11-09 06:04:22.203476||treatment||visit page||http://www.towerautosales.com/index.shtml||2||1
+2015-11-09 06:04:25.362950||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 06:04:27.855058||treatment||google search||BMW||4||0
+2015-11-09 06:04:28.267066||treatment||google search||BMW||0||1
+2015-11-09 06:04:28.774643||error||visiting||google searchresults||4||0
+2015-11-09 06:04:33.577591||treatment||google search||BMW||1||1
+2015-11-09 06:04:34.450462||treatment||google search||BMW||2||1
+2015-11-09 06:04:35.398374||error||visiting||google searchresults||5||0
+2015-11-09 06:04:40.288639||error||visiting||google searchresults||0||1
+2015-11-09 06:04:40.884721||error||visiting||google searchresults||3||0
+2015-11-09 06:04:44.940567||error||visiting||google searchresults||1||1
+2015-11-09 06:04:45.353396||error||visiting||google searchresults||2||1
+2015-11-09 06:04:46.592450||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 06:04:51.036599||treatment||visit page||http://www.bmwusa.com/Standard/Content/SalesandPrograms/Offers.aspx||5||0
+2015-11-09 06:05:00.951247||error||visiting||google searchresults||3||0
+2015-11-09 06:05:01.037624||event||progress-marker||training-end||5||0
+2015-11-09 06:05:04.865906||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 06:05:05.091157||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 06:05:06.900421||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 06:05:07.369086||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 06:05:14.900200||error||visiting||google searchresults||4||0
+2015-11-09 06:05:20.984811||error||visiting||google searchresults||3||0
+2015-11-09 06:05:21.412162||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 06:05:21.545825||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 06:05:21.769613||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 06:05:32.143576||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 06:05:40.995622||error||visiting||google searchresults||3||0
+2015-11-09 06:05:41.468017||error||visiting||google searchresults||1||1
+2015-11-09 06:05:41.608035||error||visiting||google searchresults||2||1
+2015-11-09 06:05:41.834690||error||visiting||google searchresults||0||1
+2015-11-09 06:05:42.145373||event||progress-marker||training-end||4||0
+2015-11-09 06:05:52.794417||treatment||google search||BMW||3||0
+2015-11-09 06:05:54.080847||error||visiting||google searchresults||3||0
+2015-11-09 06:06:00.944250||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 06:06:01.183567||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 06:06:03.293942||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 06:06:10.945949||event||progress-marker||training-end||0||1
+2015-11-09 06:06:11.184363||event||progress-marker||training-end||2||1
+2015-11-09 06:06:11.972971||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 06:06:13.295651||event||progress-marker||training-end||1||1
+2015-11-09 06:06:27.696746||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 06:06:37.732012||error||visiting||google searchresults||3||0
+2015-11-09 06:06:54.836238||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 06:07:04.838220||event||progress-marker||training-end||3||0
+2015-11-09 06:07:06.177009||event||progress-marker||measurement-start||0||1
+2015-11-09 06:07:06.419396||event||progress-marker||measurement-start||2||1
+2015-11-09 06:07:06.653921||event||progress-marker||measurement-start||5||0
+2015-11-09 06:07:07.530237||event||progress-marker||measurement-start||4||0
+2015-11-09 06:07:08.539198||event||progress-marker||measurement-start||1||1
+2015-11-09 06:07:09.876290||event||progress-marker||measurement-start||3||0
+2015-11-09 06:07:47.239426||measurement||ad||2015-11-09 06:07:46.788488@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:07:47.372163||measurement||ad||2015-11-09 06:07:46.788488@|Dashboard Analytics@|steton.com/BI_Dashboards@|Improve Compliance  Operational Quality With Steton's Dashboards.||1||1
+2015-11-09 06:07:47.393211||measurement||loadtime||0:00:33.853438||1||1
+2015-11-09 06:07:47.623926||measurement||ad||2015-11-09 06:07:47.169396@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 06:07:47.797934||measurement||ad||2015-11-09 06:07:47.169396@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||2||1
+2015-11-09 06:07:47.811632||measurement||loadtime||0:00:36.390662||2||1
+2015-11-09 06:07:48.895080||measurement||ad||2015-11-09 06:07:48.463655@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:07:49.033612||measurement||ad||2015-11-09 06:07:48.463655@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:07:49.049394||measurement||loadtime||0:00:37.870798||0||1
+2015-11-09 06:07:53.263571||measurement||ad||2015-11-09 06:07:44.108662@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:07:57.301135||measurement||ad||2015-11-09 06:07:44.108662@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:07:57.458038||measurement||loadtime||0:00:44.926803||4||0
+2015-11-09 06:07:59.068176||measurement||ad||2015-11-09 06:07:37.247625@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:08:00.517422||measurement||ad||2015-11-09 06:07:37.247625@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 06:08:00.542986||measurement||loadtime||0:00:48.887867||5||0
+2015-11-09 06:08:19.815859||measurement||ad||2015-11-09 06:07:50.321310@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 06:08:21.438003||measurement||ad||2015-11-09 06:07:50.321310@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:08:21.638241||measurement||loadtime||0:01:06.760445||3||0
+2015-11-09 06:08:24.706915||measurement||ad||2015-11-09 06:08:24.072632@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:08:24.965720||measurement||ad||2015-11-09 06:08:24.072632@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:08:25.002733||measurement||loadtime||0:00:30.952622||0||1
+2015-11-09 06:08:25.325203||measurement||ad||2015-11-09 06:08:23.621528@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:08:25.477808||measurement||ad||2015-11-09 06:08:23.621528@|Dashboard Analytics@|steton.com/BI_Dashboards@|Improve Compliance  Operational Quality With Steton's Dashboards.||1||1
+2015-11-09 06:08:25.551631||measurement||loadtime||0:00:33.157459||1||1
+2015-11-09 06:08:28.357628||measurement||ad||2015-11-09 06:08:27.793920@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 06:08:28.455715||measurement||ad||2015-11-09 06:08:27.793920@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:08:28.469388||measurement||loadtime||0:00:35.657240||2||1
+2015-11-09 06:08:36.221667||measurement||ad||2015-11-09 06:08:29.099673@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:08:36.694385||measurement||ad||2015-11-09 06:08:29.099673@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:08:36.699894||measurement||loadtime||0:00:34.241211||4||0
+2015-11-09 06:08:48.226075||measurement||ad||2015-11-09 06:08:31.781562@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:08:49.794859||measurement||ad||2015-11-09 06:08:31.781562@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 06:08:52.222454||measurement||loadtime||0:00:46.678933||5||0
+2015-11-09 06:08:59.083060||measurement||ad||2015-11-09 06:08:58.678249@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:08:59.230052||measurement||ad||2015-11-09 06:08:58.678249@|Dashboard Analytics@|steton.com/BI_Dashboards@|Improve Compliance  Operational Quality With Steton's Dashboards.||1||1
+2015-11-09 06:08:59.272853||measurement||loadtime||0:00:28.720451||1||1
+2015-11-09 06:09:02.277753||measurement||ad||2015-11-09 06:09:01.678754@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:09:02.498995||measurement||ad||2015-11-09 06:09:01.678754@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:09:02.519975||measurement||loadtime||0:00:32.515760||0||1
+2015-11-09 06:09:04.258111||measurement||ad||2015-11-09 06:08:48.671822@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 06:09:06.953528||measurement||ad||2015-11-09 06:08:48.671822@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:09:07.226286||measurement||loadtime||0:00:40.587386||3||0
+2015-11-09 06:09:09.951121||measurement||ad||2015-11-09 06:09:08.913219@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 06:09:10.030238||measurement||ad||2015-11-09 06:09:08.913219@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:09:10.041972||measurement||loadtime||0:00:36.572127||2||1
+2015-11-09 06:09:21.396399||measurement||ad||2015-11-09 06:09:10.698036@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:09:27.096138||measurement||ad||2015-11-09 06:09:10.698036@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:09:27.215632||measurement||loadtime||0:00:45.515072||4||0
+2015-11-09 06:09:31.368186||measurement||ad||2015-11-09 06:09:30.332704@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:09:31.559731||measurement||ad||2015-11-09 06:09:30.332704@|Dashboard Analytics@|steton.com/BI_Dashboards@|Improve Compliance  Operational Quality With Steton's Dashboards.||1||1
+2015-11-09 06:09:31.572265||measurement||loadtime||0:00:27.298445||1||1
+2015-11-09 06:09:34.001091||measurement||ad||2015-11-09 06:09:19.991238@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:09:34.236139||measurement||ad||2015-11-09 06:09:19.991238@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 06:09:34.241190||measurement||loadtime||0:00:37.018258||5||0
+2015-11-09 06:09:37.979886||measurement||ad||2015-11-09 06:09:37.738135@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:09:38.287012||measurement||ad||2015-11-09 06:09:37.738135@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:09:38.300951||measurement||loadtime||0:00:30.779889||0||1
+2015-11-09 06:09:44.286936||measurement||ad||2015-11-09 06:09:43.918444@|VA Loans- $0 Down@|veteransunited.com@|Dedicated to Military Home Owners. PreQualify Today on Up to $417K!||2||1
+2015-11-09 06:09:44.347520||measurement||ad||2015-11-09 06:09:43.918444@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:09:44.357494||measurement||loadtime||0:00:29.314941||2||1
+2015-11-09 06:09:45.673958||measurement||ad||2015-11-09 06:09:39.453166@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:09:45.964850||measurement||ad||2015-11-09 06:09:39.453166@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:09:45.969767||measurement||loadtime||0:00:33.742844||3||0
+2015-11-09 06:09:59.444633||measurement||ad||2015-11-09 06:09:52.957718@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:09:59.824243||measurement||ad||2015-11-09 06:09:52.957718@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:09:59.828676||measurement||loadtime||0:00:27.612447||4||0
+2015-11-09 06:10:02.463074||measurement||ad||2015-11-09 06:10:01.956047@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:10:02.660018||measurement||ad||2015-11-09 06:10:01.956047@|Dashboard Analytics@|steton.com/BI_Dashboards@|Improve Compliance  Operational Quality With Steton's Dashboards.||1||1
+2015-11-09 06:10:02.707990||measurement||loadtime||0:00:26.135008||1||1
+2015-11-09 06:10:07.353195||measurement||ad||2015-11-09 06:10:07.016693@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:10:07.626551||measurement||ad||2015-11-09 06:10:07.016693@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:10:07.658043||measurement||loadtime||0:00:24.355590||0||1
+2015-11-09 06:10:09.394974||measurement||ad||2015-11-09 06:10:02.173699@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:10:09.497709||measurement||ad||2015-11-09 06:10:02.173699@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 06:10:09.502226||measurement||loadtime||0:00:30.260438||5||0
+2015-11-09 06:10:14.041043||measurement||ad||2015-11-09 06:10:13.554887@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||2||1
+2015-11-09 06:10:14.103877||measurement||ad||2015-11-09 06:10:13.554887@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:10:14.115411||measurement||loadtime||0:00:24.756363||2||1
+2015-11-09 06:10:19.411867||measurement||ad||2015-11-09 06:10:13.002128@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||0
+2015-11-09 06:10:19.643506||measurement||ad||2015-11-09 06:10:13.002128@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:10:19.653794||measurement||loadtime||0:00:28.683118||3||0
+2015-11-09 06:10:32.505213||measurement||ad||2015-11-09 06:10:31.901251@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:10:32.715288||measurement||ad||2015-11-09 06:10:31.901251@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||1
+2015-11-09 06:10:32.729358||measurement||loadtime||0:00:25.020214||1||1
+2015-11-09 06:10:34.709821||measurement||ad||2015-11-09 06:10:34.379151@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:10:34.860393||measurement||ad||2015-11-09 06:10:34.379151@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:10:34.873479||measurement||loadtime||0:00:22.214898||0||1
+2015-11-09 06:10:35.161228||measurement||ad||2015-11-09 06:10:27.992008@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:10:35.286421||measurement||ad||2015-11-09 06:10:27.992008@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:10:35.290937||measurement||loadtime||0:00:30.461211||4||0
+2015-11-09 06:10:44.276210||measurement||ad||2015-11-09 06:10:38.052514@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:10:44.456452||measurement||ad||2015-11-09 06:10:38.052514@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 06:10:44.461836||measurement||loadtime||0:00:29.959050||5||0
+2015-11-09 06:10:45.464457||measurement||ad||2015-11-09 06:10:45.262746@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 06:10:45.521148||measurement||ad||2015-11-09 06:10:45.262746@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:10:45.532113||measurement||loadtime||0:00:26.415512||2||1
+2015-11-09 06:10:51.988164||measurement||ad||2015-11-09 06:10:45.714721@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:10:52.230098||measurement||ad||2015-11-09 06:10:45.714721@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:10:52.235334||measurement||loadtime||0:00:27.580875||3||0
+2015-11-09 06:11:02.471393||measurement||ad||2015-11-09 06:11:02.090630@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:11:02.631032||measurement||ad||2015-11-09 06:11:02.090630@|Get Rid of Your Timeshare@|www.donateforacause.org@|No upfront cost! Call us today to end your Maintenance Fee bills.||1||1
+2015-11-09 06:11:02.643785||measurement||loadtime||0:00:24.913811||1||1
+2015-11-09 06:11:02.725289||measurement||ad||2015-11-09 06:11:02.304206@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:11:02.963821||measurement||ad||2015-11-09 06:11:02.304206@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:11:02.973976||measurement||loadtime||0:00:23.099950||0||1
+2015-11-09 06:11:11.290753||measurement||ad||2015-11-09 06:11:01.039490@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:11:11.587463||measurement||ad||2015-11-09 06:11:01.039490@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:11:11.593987||measurement||loadtime||0:00:31.301996||4||0
+2015-11-09 06:11:14.568430||measurement||ad||2015-11-09 06:11:14.271853@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 06:11:14.682589||measurement||ad||2015-11-09 06:11:14.271853@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:11:14.702882||measurement||loadtime||0:00:24.169667||2||1
+2015-11-09 06:11:19.096590||measurement||ad||2015-11-09 06:11:11.720100@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:11:19.415735||measurement||ad||2015-11-09 06:11:11.720100@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 06:11:19.425614||measurement||loadtime||0:00:29.962299||5||0
+2015-11-09 06:11:29.969129||measurement||ad||2015-11-09 06:11:21.791076@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:11:30.626740||measurement||ad||2015-11-09 06:11:30.184685@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:11:30.706429||measurement||ad||2015-11-09 06:11:21.791076@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:11:30.711425||measurement||loadtime||0:00:33.475601||3||0
+2015-11-09 06:11:30.723770||measurement||ad||2015-11-09 06:11:30.184685@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:11:30.732375||measurement||loadtime||0:00:22.757646||0||1
+2015-11-09 06:11:32.147602||measurement||ad||2015-11-09 06:11:31.701695@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:11:32.260152||measurement||ad||2015-11-09 06:11:31.701695@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||1
+2015-11-09 06:11:32.305948||measurement||loadtime||0:00:24.661255||1||1
+2015-11-09 06:11:44.758177||measurement||ad||2015-11-09 06:11:44.291920@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||2||1
+2015-11-09 06:11:44.830330||measurement||ad||2015-11-09 06:11:44.291920@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:11:44.843488||measurement||loadtime||0:00:25.139665||2||1
+2015-11-09 06:11:45.174564||measurement||ad||2015-11-09 06:11:38.740562@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:11:45.459017||measurement||ad||2015-11-09 06:11:38.740562@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:11:45.463921||measurement||loadtime||0:00:28.869343||4||0
+2015-11-09 06:11:55.184298||measurement||ad||2015-11-09 06:11:47.638712@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:11:55.462298||measurement||ad||2015-11-09 06:11:47.638712@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 06:11:55.468144||measurement||loadtime||0:00:31.041778||5||0
+2015-11-09 06:11:58.855916||measurement||ad||2015-11-09 06:11:58.342387@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:11:59.012430||measurement||ad||2015-11-09 06:11:58.342387@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:11:59.049469||measurement||loadtime||0:00:23.316578||0||1
+2015-11-09 06:12:03.305803||measurement||ad||2015-11-09 06:11:57.971390@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 06:12:03.425057||measurement||ad||2015-11-09 06:11:57.971390@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:12:03.432204||measurement||loadtime||0:00:27.719355||3||0
+2015-11-09 06:12:08.337848||measurement||ad||2015-11-09 06:12:07.419780@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||1||1
+2015-11-09 06:12:09.323239||measurement||ad||2015-11-09 06:12:07.419780@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 06:12:09.369017||measurement||loadtime||0:00:32.061583||1||1
+2015-11-09 06:12:17.862368||measurement||ad||2015-11-09 06:12:17.274202@|Top 10 Home Insurance®@|top10homeinsurance.com@|Free Quotes. See Rates That The Smartest Homeowners Are Paying!||2||1
+2015-11-09 06:12:17.909798||measurement||ad||2015-11-09 06:12:12.730918@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:12:17.935030||measurement||ad||2015-11-09 06:12:17.274202@|Get Rid of Your Timeshare@|www.donateforacause.org@|No upfront cost! Call us today to end your Maintenance Fee bills.||2||1
+2015-11-09 06:12:17.952295||measurement||loadtime||0:00:28.107328||2||1
+2015-11-09 06:12:18.066928||measurement||ad||2015-11-09 06:12:12.730918@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:12:18.073299||measurement||loadtime||0:00:27.607831||4||0
+2015-11-09 06:12:25.640257||measurement||ad||2015-11-09 06:12:25.282619@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 06:12:25.707485||measurement||ad||2015-11-09 06:12:25.282619@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Talk with your doctor now.||0||1
+2015-11-09 06:12:25.726183||measurement||loadtime||0:00:21.675295||0||1
+2015-11-09 06:12:25.726480||event||progress-marker||measurement-end||0||1
+2015-11-09 06:12:25.814392||measurement||ad||2015-11-09 06:12:20.546749@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:12:26.065388||measurement||ad||2015-11-09 06:12:20.546749@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 06:12:26.094102||measurement||loadtime||0:00:25.625111||5||0
+2015-11-09 06:12:32.388807||measurement||ad||2015-11-09 06:12:28.841097@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:12:32.482880||measurement||ad||2015-11-09 06:12:28.841097@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:12:32.487992||measurement||loadtime||0:00:24.055005||3||0
+2015-11-09 06:12:43.025923||measurement||ad||2015-11-09 06:12:42.803979@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||2||1
+2015-11-09 06:12:43.080178||measurement||ad||2015-11-09 06:12:42.803979@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 06:12:43.093253||measurement||loadtime||0:00:20.140442||2||1
+2015-11-09 06:12:43.093525||event||progress-marker||measurement-end||2||1
+2015-11-09 06:12:56.583147||measurement||ad||2015-11-09 06:12:54.506970@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:12:56.661724||measurement||ad||2015-11-09 06:12:54.506970@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:12:56.665856||measurement||loadtime||0:00:19.176427||3||0
+2015-11-09 06:13:14.440562||error||collecting ads||Error||1||1
+2015-11-09 06:13:14.440921||event||progress-marker||measurement-end||1||1
+2015-11-09 06:13:20.475979||measurement||ad||2015-11-09 06:13:18.528763@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||3||0
+2015-11-09 06:13:20.607405||measurement||ad||2015-11-09 06:13:18.528763@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 06:13:20.613602||measurement||loadtime||0:00:18.946181||3||0
+2015-11-09 06:13:20.613882||event||progress-marker||measurement-end||3||0
+2015-11-09 06:13:23.185811||error||collecting ads||Error||4||0
+2015-11-09 06:13:31.150818||error||collecting ads||Error||5||0
+2015-11-09 06:13:51.913277||measurement||ad||2015-11-09 06:13:49.764481@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 06:13:52.025081||measurement||ad||2015-11-09 06:13:49.764481@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 06:13:52.028421||measurement||loadtime||0:00:15.876441||5||0
+2015-11-09 06:13:52.028897||event||progress-marker||measurement-end||5||0
+2015-11-09 06:13:53.633924||measurement||ad||2015-11-09 06:13:51.039893@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 06:13:53.697470||measurement||ad||2015-11-09 06:13:51.039893@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||4||0
+2015-11-09 06:13:53.702432||measurement||loadtime||0:00:25.515166||4||0
+2015-11-09 06:13:53.702702||event||progress-marker||measurement-end||4||0
+2015-11-09 06:13:54.251684||meta||block_id end||16
+2015-11-09 06:13:54.253746||meta||block_id start||17
+2015-11-09 06:13:54.253899||meta||assignment||1@|5@|0@|2@|4@|3
+2015-11-09 06:13:56.039008||event||progress-marker||training-start||1||0
+2015-11-09 06:13:57.562517||event||progress-marker||training-start||5||0
+2015-11-09 06:13:57.797077||event||progress-marker||training-start||0||0
+2015-11-09 06:14:01.982180||event||progress-marker||training-start||3||1
+2015-11-09 06:14:01.996784||event||progress-marker||training-start||2||1
+2015-11-09 06:14:02.047846||treatment||google search||Buy BMW||1||0
+2015-11-09 06:14:02.182758||treatment||google search||Buy BMW||5||0
+2015-11-09 06:14:02.299326||treatment||google search||Buy BMW||0||0
+2015-11-09 06:14:02.399639||event||progress-marker||training-start||4||1
+2015-11-09 06:14:03.260350||error||visiting||google searchresults||1||0
+2015-11-09 06:14:03.526656||error||visiting||google searchresults||5||0
+2015-11-09 06:14:03.552824||error||visiting||google searchresults||0||0
+2015-11-09 06:14:06.635920||treatment||google search||Buy BMW||3||1
+2015-11-09 06:14:06.680712||treatment||google search||Buy BMW||2||1
+2015-11-09 06:14:06.782897||treatment||google search||Buy BMW||4||1
+2015-11-09 06:14:17.409262||error||visiting||google searchresults||3||1
+2015-11-09 06:14:17.594276||error||visiting||google searchresults||4||1
+2015-11-09 06:14:17.633817||error||visiting||google searchresults||2||1
+2015-11-09 06:14:19.926379||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 06:14:20.340152||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 06:14:20.821667||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 06:14:34.098253||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 06:14:34.344833||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 06:14:34.354324||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 06:14:35.687452||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 06:14:35.914176||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 06:14:36.194207||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 06:14:44.133270||error||visiting||google searchresults||0||0
+2015-11-09 06:14:45.804879||error||visiting||google searchresults||1||0
+2015-11-09 06:14:45.957305||error||visiting||google searchresults||5||0
+2015-11-09 06:14:47.631168||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||1
+2015-11-09 06:14:49.224418||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 06:14:50.700594||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 06:14:59.602998||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||0||0
+2015-11-09 06:15:00.833393||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||1||0
+2015-11-09 06:15:05.606584||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 06:15:07.730627||error||visiting||google searchresults||4||1
+2015-11-09 06:15:09.362511||error||visiting||google searchresults||2||1
+2015-11-09 06:15:10.793023||error||visiting||google searchresults||3||1
+2015-11-09 06:15:11.278621||treatment||google search||BMW dealer||0||0
+2015-11-09 06:15:12.089472||error||visiting||google searchresults||0||0
+2015-11-09 06:15:12.581581||treatment||google search||BMW dealer||1||0
+2015-11-09 06:15:13.168138||error||visiting||google searchresults||1||0
+2015-11-09 06:15:17.217913||treatment||google search||BMW dealer||5||0
+2015-11-09 06:15:17.732182||error||visiting||google searchresults||5||0
+2015-11-09 06:15:21.033672||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||4||1
+2015-11-09 06:15:24.127719||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||3||1
+2015-11-09 06:15:25.159267||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||2||1
+2015-11-09 06:15:30.320513||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNX3-qybg8kCFYkjgQodPiQO3A||0||0
+2015-11-09 06:15:32.048647||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNzJu62bg8kCFUg9gQodzgsGsg||1||0
+2015-11-09 06:15:33.567409||treatment||google search||BMW dealer||4||1
+2015-11-09 06:15:33.583752||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJuu0a-bg8kCFdcRgQodXmkCzw||5||0
+2015-11-09 06:15:36.069723||treatment||google search||BMW dealer||3||1
+2015-11-09 06:15:37.099440||treatment||google search||BMW dealer||2||1
+2015-11-09 06:15:44.503861||error||visiting||google searchresults||4||1
+2015-11-09 06:15:45.823362||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKrwz7Wbg8kCFVIbgQodFFQFtw||0||0
+2015-11-09 06:15:46.964914||error||visiting||google searchresults||3||1
+2015-11-09 06:15:47.737392||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COOxubabg8kCFdgIgQodts4DTw||1||0
+2015-11-09 06:15:47.817982||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMWMmLebg8kCFUo6gQodotYFog||5||0
+2015-11-09 06:15:48.071510||error||visiting||google searchresults||2||1
+2015-11-09 06:15:55.873247||error||visiting||google searchresults||0||0
+2015-11-09 06:15:57.761572||error||visiting||google searchresults||1||0
+2015-11-09 06:15:57.865514||error||visiting||google searchresults||5||0
+2015-11-09 06:16:00.984033||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CN3Fzr2bg8kCFYc7gQod-Q0MzA||3||1
+2015-11-09 06:16:01.211072||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIyetLybg8kCFdgUgQod7XIEQg||4||1
+2015-11-09 06:16:06.850288||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLS1jb6bg8kCFdcSgQodbsAAfg||2||1
+2015-11-09 06:16:15.084935||treatment||visit page||http://www.carsense.com/?gclid=CIzY5sGbg8kCFUUdgQodBswGAg||0||0
+2015-11-09 06:16:16.379489||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CN-qscSbg8kCFYY9gQodPk0Okw||4||1
+2015-11-09 06:16:16.580201||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKu5psSbg8kCFUkvgQod1qsDVQ||3||1
+2015-11-09 06:16:18.639554||treatment||visit page||http://www.carsense.com/?gclid=CJGT4cKbg8kCFYcbgQodIbkOIw||5||0
+2015-11-09 06:16:20.711657||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJubjcebg8kCFY49gQodmmkLMA||2||1
+2015-11-09 06:16:26.778371||treatment||google search||BMW||0||0
+2015-11-09 06:16:27.516236||error||visiting||google searchresults||0||0
+2015-11-09 06:16:30.431773||treatment||google search||BMW||5||0
+2015-11-09 06:16:31.170407||error||visiting||google searchresults||5||0
+2015-11-09 06:16:36.433099||error||visiting||google searchresults||4||1
+2015-11-09 06:16:36.687143||error||visiting||google searchresults||3||1
+2015-11-09 06:16:40.824005||error||visiting||google searchresults||2||1
+2015-11-09 06:16:45.261769||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 06:16:46.593640||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||5||0
+2015-11-09 06:16:47.809505||error||visiting||google searchresults||1||0
+2015-11-09 06:16:53.616867||treatment||visit page||http://www.carsense.com/?gclid=CLuVldWbg8kCFUgvgQod-r4Cfw||4||1
+2015-11-09 06:16:53.663055||treatment||visit page||http://www.carsense.com/?gclid=CLHnqNWbg8kCFRMjgQodg40D8w||3||1
+2015-11-09 06:16:57.430843||treatment||visit page||http://www.carsense.com/?gclid=CMicptebg8kCFYw7gQodfJMA8Q||2||1
+2015-11-09 06:17:01.992260||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 06:17:02.131463||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||5||0
+2015-11-09 06:17:05.706625||treatment||google search||BMW||3||1
+2015-11-09 06:17:05.838953||treatment||google search||BMW||4||1
+2015-11-09 06:17:07.830304||error||visiting||google searchresults||1||0
+2015-11-09 06:17:09.096081||treatment||google search||BMW||2||1
+2015-11-09 06:17:12.038827||error||visiting||google searchresults||0||0
+2015-11-09 06:17:12.180011||error||visiting||google searchresults||5||0
+2015-11-09 06:17:16.638024||error||visiting||google searchresults||3||1
+2015-11-09 06:17:16.964741||error||visiting||google searchresults||4||1
+2015-11-09 06:17:20.065058||error||visiting||google searchresults||2||1
+2015-11-09 06:17:27.861955||error||visiting||google searchresults||1||0
+2015-11-09 06:17:29.672945||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 06:17:31.418054||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||0
+2015-11-09 06:17:39.674809||event||progress-marker||training-end||5||0
+2015-11-09 06:17:41.418856||event||progress-marker||training-end||0||0
+2015-11-09 06:17:45.629081||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 06:17:47.915783||error||visiting||google searchresults||1||0
+2015-11-09 06:17:48.122453||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 06:18:01.114707||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 06:18:03.483220||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 06:18:06.999922||error||visiting||google searchresults||4||1
+2015-11-09 06:18:07.960320||error||visiting||google searchresults||1||0
+2015-11-09 06:18:19.746434||treatment||google search||BMW||1||0
+2015-11-09 06:18:20.610311||error||visiting||google searchresults||1||0
+2015-11-09 06:18:21.210882||error||visiting||google searchresults||2||1
+2015-11-09 06:18:23.608184||error||visiting||google searchresults||3||1
+2015-11-09 06:18:40.511904||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 06:18:40.791697||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 06:18:43.717361||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 06:18:50.792825||event||progress-marker||training-end||3||1
+2015-11-09 06:18:53.718712||event||progress-marker||training-end||2||1
+2015-11-09 06:18:56.479904||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 06:19:06.520144||error||visiting||google searchresults||1||0
+2015-11-09 06:19:23.962549||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 06:19:33.963855||event||progress-marker||training-end||1||0
+2015-11-09 06:47:14.324911||error||block timeout||Error||0||5
+2015-11-09 06:47:14.324989||error||block timeout||Error||1||3
+2015-11-09 06:47:14.324941||error||block timeout||Error||0||0
+2015-11-09 06:47:14.324911||error||block timeout||Error||1||2
+2015-11-09 06:47:14.324911||error||block timeout||Error||0||1
+2015-11-09 06:47:14.326923||error||block timeout||Error||1||4
+2015-11-09 06:47:15.972530||meta||block_id end||17
+2015-11-09 06:47:15.973384||meta||block_id start||18
+2015-11-09 06:47:15.973463||meta||assignment||2@|4@|3@|5@|0@|1
+2015-11-09 06:47:19.940776||event||progress-marker||training-start||4||0
+2015-11-09 06:47:20.371950||event||progress-marker||training-start||2||0
+2015-11-09 06:47:20.421880||event||progress-marker||training-start||3||0
+2015-11-09 06:47:24.127630||event||progress-marker||training-start||5||1
+2015-11-09 06:47:24.248170||event||progress-marker||training-start||0||1
+2015-11-09 06:47:24.665946||event||progress-marker||training-start||1||1
+2015-11-09 06:47:25.293846||treatment||google search||Buy BMW||2||0
+2015-11-09 06:47:25.528865||treatment||google search||Buy BMW||4||0
+2015-11-09 06:47:25.679044||treatment||google search||Buy BMW||3||0
+2015-11-09 06:47:27.781943||error||visiting||google searchresults||2||0
+2015-11-09 06:47:27.816682||error||visiting||google searchresults||3||0
+2015-11-09 06:47:27.837148||error||visiting||google searchresults||4||0
+2015-11-09 06:47:30.115449||treatment||google search||Buy BMW||1||1
+2015-11-09 06:47:30.606206||treatment||google search||Buy BMW||5||1
+2015-11-09 06:47:30.624924||treatment||google search||Buy BMW||0||1
+2015-11-09 06:47:41.047474||error||visiting||google searchresults||1||1
+2015-11-09 06:47:41.479751||error||visiting||google searchresults||5||1
+2015-11-09 06:47:41.585480||error||visiting||google searchresults||0||1
+2015-11-09 06:47:44.257551||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 06:47:45.608013||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 06:47:46.235786||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 06:47:55.843273||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 06:47:56.011343||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 06:47:59.848482||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 06:48:00.036077||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 06:48:01.155823||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 06:48:01.636528||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 06:48:10.078620||error||visiting||google searchresults||2||0
+2015-11-09 06:48:11.198684||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 06:48:11.223387||error||visiting||google searchresults||4||0
+2015-11-09 06:48:11.518255||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 06:48:11.685624||error||visiting||google searchresults||3||0
+2015-11-09 06:48:14.508847||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 06:48:24.501754||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||2||0
+2015-11-09 06:48:26.901564||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||4||0
+2015-11-09 06:48:27.064390||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||3||0
+2015-11-09 06:48:31.312588||error||visiting||google searchresults||5||1
+2015-11-09 06:48:31.636914||error||visiting||google searchresults||0||1
+2015-11-09 06:48:34.638401||error||visiting||google searchresults||1||1
+2015-11-09 06:48:36.188935||treatment||google search||BMW dealer||2||0
+2015-11-09 06:48:36.840011||error||visiting||google searchresults||2||0
+2015-11-09 06:48:38.858378||treatment||google search||BMW dealer||4||0
+2015-11-09 06:48:39.067398||treatment||google search||BMW dealer||3||0
+2015-11-09 06:48:39.566527||error||visiting||google searchresults||4||0
+2015-11-09 06:48:39.816770||error||visiting||google searchresults||3||0
+2015-11-09 06:48:44.903438||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||0||1
+2015-11-09 06:48:46.471492||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||5||1
+2015-11-09 06:48:50.692055||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||1||1
+2015-11-09 06:48:59.174675||treatment||google search||BMW dealer||0||1
+2015-11-09 06:48:59.818841||treatment||google search||BMW dealer||5||1
+2015-11-09 06:49:02.098818||treatment||visit page||http://www.carsense.com/?gclid=CPq3mOqig8kCFdUvgQodVzINNw||4||0
+2015-11-09 06:49:02.352625||treatment||visit page||http://www.carsense.com/?gclid=CMHoqOqig8kCFU82gQodctkLuw||3||0
+2015-11-09 06:49:03.721190||treatment||google search||BMW dealer||1||1
+2015-11-09 06:49:10.126456||error||visiting||google searchresults||0||1
+2015-11-09 06:49:11.260448||error||visiting||google searchresults||5||1
+2015-11-09 06:49:14.647378||error||visiting||google searchresults||1||1
+2015-11-09 06:49:18.430415||treatment||visit page||http://www.carsense.com/?gclid=CPaz9vSig8kCFdUvgQodVzINNw||4||0
+2015-11-09 06:49:18.870860||treatment||visit page||http://www.carsense.com/?gclid=CJSFh_Wig8kCFUgvgQod-r4Cfw||3||0
+2015-11-09 06:49:25.849409||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKTjqPmig8kCFdgIgQodts4DTw||5||1
+2015-11-09 06:49:26.976144||error||visiting||google searchresults||2||0
+2015-11-09 06:49:28.243614||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIab-Pqig8kCFZQjgQodp6QJLQ||1||1
+2015-11-09 06:49:28.461565||error||visiting||google searchresults||4||0
+2015-11-09 06:49:28.930122||error||visiting||google searchresults||3||0
+2015-11-09 06:49:29.022768||treatment||visit page||http://www.carsense.com/?gclid=CJfl4_iig8kCFdc2gQodWIsEdg||0||1
+2015-11-09 06:49:43.788677||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP-WoICjg8kCFZQjgQodp6QJLQ||5||1
+2015-11-09 06:49:45.223982||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPvntIGjg8kCFYkjgQodPiQO3A||1||1
+2015-11-09 06:49:45.799831||treatment||visit page||http://dealers.car.com/dealers/bmw?ukwid=a504797f-59a0-42f3-847d-e88ad8efd72e&udv=c&gclid=CPWk3YGjg8kCFdgcgQodPBMC0w||3||0
+2015-11-09 06:49:46.279533||treatment||visit page||http://www.towerautosales.com/index.shtml||4||0
+2015-11-09 06:49:46.990045||error||visiting||google searchresults||2||0
+2015-11-09 06:49:47.505509||treatment||visit page||http://www.carsense.com/?gclid=COGdgYKjg8kCFZQdgQod_WgHpw||0||1
+2015-11-09 06:49:57.571620||treatment||google search||BMW||3||0
+2015-11-09 06:49:57.812763||treatment||google search||BMW||4||0
+2015-11-09 06:49:59.089051||error||visiting||google searchresults||3||0
+2015-11-09 06:49:59.330127||error||visiting||google searchresults||4||0
+2015-11-09 06:50:03.867992||error||visiting||google searchresults||5||1
+2015-11-09 06:50:05.340468||error||visiting||google searchresults||1||1
+2015-11-09 06:50:07.003247||error||visiting||google searchresults||2||0
+2015-11-09 06:50:07.597852||error||visiting||google searchresults||0||1
+2015-11-09 06:50:15.440875||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||3||0
+2015-11-09 06:50:19.022533||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 06:50:20.902446||treatment||visit page||http://www.carsense.com/?gclid=CKe5spKjg8kCFdcXgQodQqMC1A||5||1
+2015-11-09 06:50:21.002349||treatment||visit page||http://www.towerautosales.com/index.shtml||0||1
+2015-11-09 06:50:23.486428||treatment||visit page||http://www.carsense.com/?gclid=CP-vj5Ojg8kCFdcRgQodXmkCzw||1||1
+2015-11-09 06:50:27.013710||error||visiting||google searchresults||2||0
+2015-11-09 06:50:31.189222||treatment||visit page||http://www.bmwpittsburgh.com/default.aspx||3||0
+2015-11-09 06:50:35.169288||treatment||google search||BMW||0||1
+2015-11-09 06:50:35.753493||treatment||google search||BMW||5||1
+2015-11-09 06:50:36.273522||treatment||google search||BMW||1||1
+2015-11-09 06:50:41.225989||error||visiting||google searchresults||3||0
+2015-11-09 06:50:43.507598||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 06:50:47.065201||error||visiting||google searchresults||2||0
+2015-11-09 06:50:47.226151||error||visiting||google searchresults||0||1
+2015-11-09 06:50:47.281880||error||visiting||google searchresults||5||1
+2015-11-09 06:50:47.340419||error||visiting||google searchresults||1||1
+2015-11-09 06:50:53.556981||error||visiting||google searchresults||4||0
+2015-11-09 06:50:59.733537||treatment||google search||BMW||2||0
+2015-11-09 06:51:01.101460||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 06:51:02.440200||error||visiting||google searchresults||2||0
+2015-11-09 06:51:07.912864||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 06:51:08.704500||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 06:51:10.219711||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 06:51:11.103390||event||progress-marker||training-end||3||0
+2015-11-09 06:51:15.655361||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 06:51:21.173089||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 06:51:22.990903||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 06:51:23.639636||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 06:51:24.296441||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 06:51:25.657310||event||progress-marker||training-end||4||0
+2015-11-09 06:51:36.840501||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 06:51:43.030814||error||visiting||google searchresults||1||1
+2015-11-09 06:51:43.735481||error||visiting||google searchresults||0||1
+2015-11-09 06:51:44.355588||error||visiting||google searchresults||5||1
+2015-11-09 06:51:46.878636||error||visiting||google searchresults||2||0
+2015-11-09 06:52:02.488481||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 06:52:03.415562||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 06:52:04.591879||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 06:52:08.481197||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 06:52:12.490374||event||progress-marker||training-end||0||1
+2015-11-09 06:52:13.417400||event||progress-marker||training-end||1||1
+2015-11-09 06:52:14.592887||event||progress-marker||training-end||5||1
+2015-11-09 06:52:18.483294||event||progress-marker||training-end||2||0
+2015-11-09 06:52:19.633693||event||progress-marker||measurement-start||5||1
+2015-11-09 06:52:20.951280||event||progress-marker||measurement-start||4||0
+2015-11-09 06:52:21.505453||event||progress-marker||measurement-start||3||0
+2015-11-09 06:52:22.556013||event||progress-marker||measurement-start||0||1
+2015-11-09 06:52:23.483633||event||progress-marker||measurement-start||1||1
+2015-11-09 06:52:23.526093||event||progress-marker||measurement-start||2||0
+2015-11-09 06:52:54.552388||measurement||ad||2015-11-09 06:52:51.219549@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 06:52:55.462914||measurement||ad||2015-11-09 06:52:51.219549@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:52:55.797652||measurement||loadtime||0:00:31.162359||5||1
+2015-11-09 06:53:11.488630||measurement||ad||2015-11-09 06:53:10.292469@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||1
+2015-11-09 06:53:12.677922||measurement||ad||2015-11-09 06:53:10.292469@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:53:13.352779||measurement||loadtime||0:00:45.795569||0||1
+2015-11-09 06:53:22.551400||measurement||ad||2015-11-09 06:53:16.631754@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:53:23.476029||measurement||ad||2015-11-09 06:53:16.631754@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 06:53:23.716339||measurement||loadtime||0:00:55.231695||1||1
+2015-11-09 06:53:53.226481||measurement||ad||2015-11-09 06:53:47.245006@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 06:53:56.373915||measurement||ad||2015-11-09 06:53:47.245006@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:53:56.506172||measurement||ad||2015-11-09 06:53:16.776833@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||0
+2015-11-09 06:53:57.539566||measurement||loadtime||0:00:56.741356||5||1
+2015-11-09 06:54:03.372581||measurement||ad||2015-11-09 06:53:25.394217@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 06:54:06.440827||measurement||ad||2015-11-09 06:53:25.394217@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 06:54:06.537645||measurement||loadtime||0:01:38.010868||2||0
+2015-11-09 06:54:10.770799||measurement||ad||2015-11-09 06:54:09.231218@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 06:54:11.250103||measurement||ad||2015-11-09 06:53:26.698209@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 06:54:11.749721||measurement||ad||2015-11-09 06:54:09.231218@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:54:11.910360||measurement||loadtime||0:00:53.556813||0||1
+2015-11-09 06:54:14.836161||measurement||ad||2015-11-09 06:53:16.776833@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 06:54:14.981861||measurement||ad||2015-11-09 06:53:26.698209@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 06:54:15.379344||measurement||loadtime||0:01:48.872202||3||0
+2015-11-09 06:54:17.132420||measurement||loadtime||0:01:51.179315||4||0
+2015-11-09 06:54:23.163716||measurement||ad||2015-11-09 06:54:21.374161@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||1||1
+2015-11-09 06:54:23.677188||measurement||ad||2015-11-09 06:54:21.374161@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:54:23.806098||measurement||loadtime||0:00:55.089302||1||1
+2015-11-09 06:54:55.899162||measurement||ad||2015-11-09 06:54:54.507991@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:54:56.431619||measurement||ad||2015-11-09 06:54:54.507991@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 06:54:56.749852||measurement||loadtime||0:00:54.208738||5||1
+2015-11-09 06:55:01.445161||measurement||ad||2015-11-09 06:55:00.452225@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 06:55:01.941113||measurement||ad||2015-11-09 06:55:00.452225@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:55:01.987284||measurement||loadtime||0:00:45.076324||0||1
+2015-11-09 06:55:16.968878||measurement||ad||2015-11-09 06:55:15.992581@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:55:17.083990||measurement||ad||2015-11-09 06:55:15.992581@|VA Loans- $0 Down@|veteransunited.com@|Dedicated to Military Home Owners. PreQualify Today on Up to $417K!||1||1
+2015-11-09 06:55:17.392699||measurement||loadtime||0:00:48.585073||1||1
+2015-11-09 06:55:19.958566||measurement||ad||2015-11-09 06:54:57.626309@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 06:55:21.879280||measurement||ad||2015-11-09 06:55:05.858616@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 06:55:24.895727||measurement||ad||2015-11-09 06:55:05.858616@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 06:55:25.033483||measurement||loadtime||0:01:04.653330||3||0
+2015-11-09 06:55:33.885472||measurement||ad||2015-11-09 06:54:57.626309@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 06:55:34.693115||measurement||loadtime||0:01:23.154357||2||0
+2015-11-09 06:55:38.567479||measurement||ad||2015-11-09 06:55:36.810960@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:55:39.213842||measurement||ad||2015-11-09 06:55:36.810960@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 06:55:39.228283||measurement||loadtime||0:00:37.477541||5||1
+2015-11-09 06:55:48.962871||measurement||ad||2015-11-09 06:55:48.229070@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:55:49.309752||measurement||ad||2015-11-09 06:55:48.229070@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:55:49.336345||measurement||loadtime||0:00:42.348545||0||1
+2015-11-09 06:56:07.432839||measurement||ad||2015-11-09 06:55:16.307344@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 06:56:10.010281||measurement||ad||2015-11-09 06:56:05.764368@|Top 10 Home Insurance®@|top10homeinsurance.com@|Get Rates From Top Carriers! Save up to $263/Year in just 5 min.||1||1
+2015-11-09 06:56:10.748749||measurement||ad||2015-11-09 06:56:05.764368@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:56:11.305348||measurement||loadtime||0:00:48.910735||1||1
+2015-11-09 06:56:14.237238||measurement||ad||2015-11-09 06:55:56.793218@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:56:20.160194||measurement||ad||2015-11-09 06:55:56.793218@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 06:56:20.264508||measurement||loadtime||0:00:50.230346||3||0
+2015-11-09 06:56:24.737581||measurement||ad||2015-11-09 06:55:16.307344@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||4||0
+2015-11-09 06:56:27.321623||measurement||loadtime||0:02:05.188203||4||0
+2015-11-09 06:56:32.641615||measurement||ad||2015-11-09 06:56:17.194723@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 06:56:35.228525||measurement||ad||2015-11-09 06:56:17.194723@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 06:56:35.386104||measurement||loadtime||0:00:55.692427||2||0
+2015-11-09 06:56:36.765157||measurement||ad||2015-11-09 06:56:32.033697@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:56:36.933404||measurement||ad||2015-11-09 06:56:32.033697@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 06:56:37.029612||measurement||loadtime||0:00:52.799847||5||1
+2015-11-09 06:56:37.389616||measurement||ad||2015-11-09 06:56:36.333472@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 06:56:37.592602||measurement||ad||2015-11-09 06:56:36.333472@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:56:37.642768||measurement||loadtime||0:00:43.304902||0||1
+2015-11-09 06:56:59.684647||measurement||ad||2015-11-09 06:56:57.673049@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:57:00.693686||measurement||ad||2015-11-09 06:56:57.673049@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||1||1
+2015-11-09 06:57:00.711495||measurement||loadtime||0:00:44.403438||1||1
+2015-11-09 06:57:22.434929||measurement||ad||2015-11-09 06:57:21.688760@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 06:57:22.574298||measurement||ad||2015-11-09 06:57:21.688760@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:57:22.590972||measurement||loadtime||0:00:39.947257||0||1
+2015-11-09 06:57:23.598637||measurement||ad||2015-11-09 06:57:22.206315@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:57:23.770321||measurement||ad||2015-11-09 06:57:22.206315@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 06:57:23.807027||measurement||loadtime||0:00:41.776834||5||1
+2015-11-09 06:57:25.458711||error||collecting ads||Error||3||0
+2015-11-09 06:57:35.308930||measurement||ad||2015-11-09 06:57:16.241207@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 06:57:39.164830||measurement||ad||2015-11-09 06:57:16.241207@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||4||0
+2015-11-09 06:57:39.202629||measurement||loadtime||0:01:06.880240||4||0
+2015-11-09 06:57:43.931299||measurement||ad||2015-11-09 06:57:18.845442@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 06:57:51.177732||measurement||ad||2015-11-09 06:57:18.845442@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 06:57:51.679055||measurement||loadtime||0:01:11.291389||2||0
+2015-11-09 06:57:57.485740||measurement||ad||2015-11-09 06:57:56.367784@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:57:57.696038||measurement||ad||2015-11-09 06:57:56.367784@|Enroll in Obamacare@|healthplansamerica.org/Obamacare@|Find  Compare Healthcare for Free. Get Covered in 3 Steps (or Less)||1||1
+2015-11-09 06:57:57.749262||measurement||loadtime||0:00:52.036295||1||1
+2015-11-09 06:58:03.277075||measurement||ad||2015-11-09 06:58:02.686898@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:58:03.483575||measurement||ad||2015-11-09 06:58:02.686898@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:58:03.544788||measurement||loadtime||0:00:35.953364||0||1
+2015-11-09 06:58:07.228899||measurement||ad||2015-11-09 06:58:05.766055@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:58:07.433152||measurement||ad||2015-11-09 06:58:05.766055@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 06:58:07.472310||measurement||loadtime||0:00:38.664360||5||1
+2015-11-09 06:58:35.050241||measurement||ad||2015-11-09 06:58:11.814337@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 06:58:41.046374||measurement||ad||2015-11-09 06:58:11.814337@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 06:58:41.063531||measurement||loadtime||0:01:10.603006||3||0
+2015-11-09 06:58:44.799513||measurement||ad||2015-11-09 06:58:43.415410@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:58:45.176994||measurement||ad||2015-11-09 06:58:43.383044@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 06:58:45.268289||measurement||ad||2015-11-09 06:58:43.415410@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:58:45.882814||measurement||loadtime||0:00:37.336704||0||1
+2015-11-09 06:58:46.096765||measurement||ad||2015-11-09 06:58:43.383044@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||1||1
+2015-11-09 06:58:46.108601||measurement||loadtime||0:00:43.358059||1||1
+2015-11-09 06:58:59.180144||measurement||ad||2015-11-09 06:58:58.414904@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 06:58:59.702254||measurement||ad||2015-11-09 06:58:58.414904@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 06:58:59.843391||measurement||loadtime||0:00:47.370536||5||1
+2015-11-09 06:59:00.310019||measurement||ad||2015-11-09 06:58:28.746302@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 06:59:01.682289||measurement||ad||2015-11-09 06:58:23.645400@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 06:59:04.955878||measurement||ad||2015-11-09 06:58:28.746302@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 06:59:05.270444||measurement||loadtime||0:01:08.590598||2||0
+2015-11-09 06:59:06.255633||measurement||ad||2015-11-09 06:58:23.645400@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||4||0
+2015-11-09 06:59:06.837090||measurement||loadtime||0:01:22.633326||4||0
+2015-11-09 06:59:29.560485||measurement||ad||2015-11-09 06:59:28.257832@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 06:59:30.103096||measurement||ad||2015-11-09 06:59:28.257832@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 06:59:31.086000||measurement||loadtime||0:00:40.201464||0||1
+2015-11-09 06:59:52.670615||error||collecting ads||Error||1||1
+2015-11-09 06:59:57.996659||measurement||ad||2015-11-09 06:59:24.678080@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 06:59:59.455333||measurement||ad||2015-11-09 06:59:24.678080@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 06:59:59.479704||measurement||loadtime||0:01:13.415551||3||0
+2015-11-09 07:00:06.005054||measurement||ad||2015-11-09 06:59:57.894837@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 07:00:08.422323||measurement||ad||2015-11-09 06:59:57.894837@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 07:00:09.288955||measurement||loadtime||0:01:04.444276||5||1
+2015-11-09 07:00:14.284983||measurement||ad||2015-11-09 06:59:45.977295@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 07:00:14.536463||measurement||ad||2015-11-09 06:59:54.570646@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 07:00:15.725431||measurement||ad||2015-11-09 07:00:15.056759@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 07:00:15.990999||measurement||ad||2015-11-09 07:00:15.056759@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 07:00:16.016758||measurement||loadtime||0:00:39.929867||0||1
+2015-11-09 07:00:16.023634||event||progress-marker||measurement-end||0||1
+2015-11-09 07:00:20.668360||measurement||ad||2015-11-09 06:59:45.977295@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:00:20.888491||measurement||loadtime||0:01:10.616624||2||0
+2015-11-09 07:00:25.923360||measurement||ad||2015-11-09 06:59:54.570646@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||4||0
+2015-11-09 07:00:26.298274||measurement||loadtime||0:01:14.460640||4||0
+2015-11-09 07:00:45.999272||measurement||ad||2015-11-09 07:00:43.840333@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 07:00:46.774409||measurement||ad||2015-11-09 07:00:43.840333@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 07:00:46.847364||measurement||loadtime||0:00:49.175267||1||1
+2015-11-09 07:00:50.003725||measurement||ad||2015-11-09 07:00:38.556769@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||3||0
+2015-11-09 07:00:52.152334||measurement||ad||2015-11-09 07:00:51.548915@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||5||1
+2015-11-09 07:00:52.608512||measurement||ad||2015-11-09 07:00:51.548915@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||5||1
+2015-11-09 07:00:52.665151||measurement||loadtime||0:00:38.373602||5||1
+2015-11-09 07:00:52.665453||event||progress-marker||measurement-end||5||1
+2015-11-09 07:00:54.731657||measurement||ad||2015-11-09 07:00:38.556769@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 07:00:55.047753||measurement||loadtime||0:00:50.566124||3||0
+2015-11-09 07:01:17.342168||measurement||ad||2015-11-09 07:01:06.114320@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 07:01:23.229586||measurement||ad||2015-11-09 07:01:06.114320@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 07:01:23.385514||measurement||loadtime||0:00:52.086433||4||0
+2015-11-09 07:01:25.984828||measurement||ad||2015-11-09 07:01:25.501913@|Top 10 Home Insurance®@|top10homeinsurance.com@|Get Rates From Top Carriers! Save up to $263/Year in just 5 min.||1||1
+2015-11-09 07:01:26.443934||measurement||ad||2015-11-09 07:01:25.501913@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||1||1
+2015-11-09 07:01:26.471519||measurement||loadtime||0:00:34.623379||1||1
+2015-11-09 07:01:26.475419||event||progress-marker||measurement-end||1||1
+2015-11-09 07:01:32.144612||measurement||ad||2015-11-09 07:01:25.639593@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 07:01:32.307944||measurement||ad||2015-11-09 07:01:25.639593@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 07:01:32.320197||measurement||loadtime||0:00:32.270426||3||0
+2015-11-09 07:01:54.258440||measurement||ad||2015-11-09 07:01:49.022953@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||4||0
+2015-11-09 07:01:54.433789||measurement||ad||2015-11-09 07:01:49.022953@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 07:01:54.442946||measurement||loadtime||0:00:26.056676||4||0
+2015-11-09 07:01:54.583527||measurement||ad||2015-11-09 07:01:14.353334@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 07:01:55.595802||measurement||ad||2015-11-09 07:01:14.353334@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:01:55.628972||measurement||loadtime||0:01:29.739438||2||0
+2015-11-09 07:02:21.895118||measurement||ad||2015-11-09 07:02:17.784193@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 07:02:22.030850||measurement||ad||2015-11-09 07:02:17.784193@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||4||0
+2015-11-09 07:02:22.042943||measurement||loadtime||0:00:22.599080||4||0
+2015-11-09 07:02:27.493058||measurement||ad||2015-11-09 07:02:05.905993@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 07:02:28.406572||measurement||ad||2015-11-09 07:02:22.394715@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 07:02:28.439919||measurement||ad||2015-11-09 07:02:05.905993@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 07:02:28.450869||measurement||loadtime||0:00:51.129854||3||0
+2015-11-09 07:02:28.617328||measurement||ad||2015-11-09 07:02:22.394715@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:02:28.633327||measurement||loadtime||0:00:28.003817||2||0
+2015-11-09 07:02:51.314091||measurement||ad||2015-11-09 07:02:46.590869@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||4||0
+2015-11-09 07:02:51.544556||measurement||ad||2015-11-09 07:02:46.590869@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||4||0
+2015-11-09 07:02:51.558815||measurement||loadtime||0:00:24.515265||4||0
+2015-11-09 07:02:58.874486||measurement||ad||2015-11-09 07:02:55.018797@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||0
+2015-11-09 07:02:59.032080||measurement||ad||2015-11-09 07:02:55.018797@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:02:59.041860||measurement||loadtime||0:00:25.407088||2||0
+2015-11-09 07:03:05.151684||measurement||ad||2015-11-09 07:03:00.460637@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||0
+2015-11-09 07:03:05.396075||measurement||ad||2015-11-09 07:03:00.460637@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||3||0
+2015-11-09 07:03:05.403961||measurement||loadtime||0:00:31.951324||3||0
+2015-11-09 07:03:05.405153||event||progress-marker||measurement-end||3||0
+2015-11-09 07:03:24.749697||measurement||ad||2015-11-09 07:03:21.442422@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:03:24.875530||measurement||ad||2015-11-09 07:03:21.442422@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||0
+2015-11-09 07:03:24.878993||measurement||loadtime||0:00:20.836139||2||0
+2015-11-09 07:03:24.879849||event||progress-marker||measurement-end||2||0
+2015-11-09 07:03:56.630598||error||collecting ads||Error||4||0
+2015-11-09 07:03:56.631105||event||progress-marker||measurement-end||4||0
+2015-11-09 07:03:57.235900||meta||block_id end||18
+2015-11-09 07:03:57.237983||meta||block_id start||19
+2015-11-09 07:03:57.238140||meta||assignment||1@|2@|4@|0@|3@|5
+2015-11-09 07:04:01.049335||event||progress-marker||training-start||2||0
+2015-11-09 07:04:01.439006||event||progress-marker||training-start||4||0
+2015-11-09 07:04:01.603631||event||progress-marker||training-start||1||0
+2015-11-09 07:04:05.818934||event||progress-marker||training-start||5||1
+2015-11-09 07:04:06.055541||event||progress-marker||training-start||0||1
+2015-11-09 07:04:06.314188||treatment||google search||Buy BMW||2||0
+2015-11-09 07:04:06.504024||treatment||google search||Buy BMW||4||0
+2015-11-09 07:04:06.567899||event||progress-marker||training-start||3||1
+2015-11-09 07:04:06.767435||treatment||google search||Buy BMW||1||0
+2015-11-09 07:04:08.214944||error||visiting||google searchresults||2||0
+2015-11-09 07:04:08.491149||error||visiting||google searchresults||4||0
+2015-11-09 07:04:08.730264||error||visiting||google searchresults||1||0
+2015-11-09 07:04:11.161329||treatment||google search||Buy BMW||0||1
+2015-11-09 07:04:11.289670||treatment||google search||Buy BMW||3||1
+2015-11-09 07:04:11.336417||treatment||google search||Buy BMW||5||1
+2015-11-09 07:04:22.097179||error||visiting||google searchresults||0||1
+2015-11-09 07:04:22.147635||error||visiting||google searchresults||3||1
+2015-11-09 07:04:22.327380||error||visiting||google searchresults||5||1
+2015-11-09 07:04:30.045692||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 07:04:30.908760||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 07:04:31.087058||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 07:04:38.849216||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||1
+2015-11-09 07:04:38.948122||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 07:04:41.647885||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 07:04:50.494691||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||4||0
+2015-11-09 07:04:50.537266||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||1||0
+2015-11-09 07:04:52.292538||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||2||0
+2015-11-09 07:04:53.690197||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||5||1
+2015-11-09 07:04:54.324448||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||3||1
+2015-11-09 07:04:56.017502||treatment||visit page||http://www.cargurus.com/Cars/l-Used-BMW-m3?sourceContext=usedPaidSearchNoZip||0||1
+2015-11-09 07:05:00.532563||error||visiting||google searchresults||4||0
+2015-11-09 07:05:00.572106||error||visiting||google searchresults||1||0
+2015-11-09 07:05:02.327207||error||visiting||google searchresults||2||0
+2015-11-09 07:05:13.747283||error||visiting||google searchresults||5||1
+2015-11-09 07:05:14.419613||error||visiting||google searchresults||3||1
+2015-11-09 07:05:15.093216||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CJP5-r2mg8kCFVI7gQodrjYBDQ||4||0
+2015-11-09 07:05:15.156125||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CJrw_b2mg8kCFdgLgQodEQEH0g||1||0
+2015-11-09 07:05:16.124326||error||visiting||google searchresults||0||1
+2015-11-09 07:05:16.617855||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CPSw6L6mg8kCFUU7gQodHnMD0w||2||0
+2015-11-09 07:05:27.456120||treatment||google search||BMW dealer||1||0
+2015-11-09 07:05:27.562055||treatment||google search||BMW dealer||4||0
+2015-11-09 07:05:27.995553||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CIu9osSmg8kCFYc7gQod-Q0MzA||5||1
+2015-11-09 07:05:28.007391||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CJa5zsSmg8kCFZAkgQodbqcDvw||3||1
+2015-11-09 07:05:28.691942||error||visiting||google searchresults||1||0
+2015-11-09 07:05:28.778303||error||visiting||google searchresults||4||0
+2015-11-09 07:05:29.574040||treatment||google search||BMW dealer||2||0
+2015-11-09 07:05:30.216023||error||visiting||google searchresults||2||0
+2015-11-09 07:05:30.864652||treatment||visit page||http://dealers.car.com/ppc/bmw?ukwid=6e269906-6d92-4ca9-bed2-d3562e003ea9&udv=c&gclid=CK6OtMWmg8kCFZYkgQod96sHBA||0||1
+2015-11-09 07:05:46.134954||treatment||google search||BMW dealer||3||1
+2015-11-09 07:05:46.316777||treatment||google search||BMW dealer||5||1
+2015-11-09 07:05:46.830871||treatment||google search||BMW dealer||0||1
+2015-11-09 07:05:51.926655||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLfKuMumg8kCFcUkgQod5NkDfg||4||0
+2015-11-09 07:05:52.280338||treatment||visit page||http://www.carsense.com/?gclid=CLLkjcymg8kCFZQdgQod_WgHpw||2||0
+2015-11-09 07:05:56.321464||error||visiting||google searchresults||3||1
+2015-11-09 07:05:56.673614||error||visiting||google searchresults||5||1
+2015-11-09 07:05:57.897158||error||visiting||google searchresults||0||1
+2015-11-09 07:06:09.610772||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKzNudamg8kCFdgLgQodfDYHIg||4||0
+2015-11-09 07:06:09.684390||treatment||visit page||http://www.carsense.com/?gclid=CPSKztamg8kCFYE2gQodAXcLFQ||2||0
+2015-11-09 07:06:10.374947||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP3r3Nimg8kCFUg9gQodzgsGsg||5||1
+2015-11-09 07:06:12.249092||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COT5r9mmg8kCFdgUgQod7XIEQg||0||1
+2015-11-09 07:06:12.551474||treatment||visit page||http://dealershipperformancecrm.com/||3||1
+2015-11-09 07:06:19.648447||error||visiting||google searchresults||4||0
+2015-11-09 07:06:19.709321||error||visiting||google searchresults||2||0
+2015-11-09 07:06:21.792614||error||visiting||google searchresults||1||0
+2015-11-09 07:06:26.156795||treatment||visit page||http://dealershipperformancecrm.com/||3||1
+2015-11-09 07:06:26.703424||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKSSleCmg8kCFZQ6gQodgPIGrA||0||1
+2015-11-09 07:06:30.587377||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJqOoN-mg8kCFUQ2gQod3qUJlQ||5||1
+2015-11-09 07:06:38.354393||treatment||visit page||http://www.carsense.com/?gclid=COy21eOmg8kCFdcYgQodjHIJmg||4||0
+2015-11-09 07:06:41.827221||error||visiting||google searchresults||1||0
+2015-11-09 07:06:46.237993||error||visiting||google searchresults||3||1
+2015-11-09 07:06:46.774792||error||visiting||google searchresults||0||1
+2015-11-09 07:06:49.984936||treatment||google search||BMW||4||0
+2015-11-09 07:06:50.689144||error||visiting||google searchresults||5||1
+2015-11-09 07:06:51.045945||error||visiting||google searchresults||4||0
+2015-11-09 07:07:01.744307||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CKTNrPCmg8kCFUM2gQodwkkDeA||3||1
+2015-11-09 07:07:01.878755||error||visiting||google searchresults||1||0
+2015-11-09 07:07:04.462785||treatment||visit page||https://www.cargurus.com/Cars/dealer/signup-p2_a5807559?sourceContext=$source_context&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&type=GoogleAdWordsSearch&kw=car%2520dealer%2520websites&matchtype=b&ad=67389137944&placement=&networktype=g&device=c&devicemodel=&adposition=1t2&physloc=9005925&intloc=&gclid=CMSqv_Kmg8kCFRc6gQodS7sPmw||5||1
+2015-11-09 07:07:09.776486||error||visiting||google searchresults||2||0
+2015-11-09 07:07:10.872211||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 07:07:14.054988||treatment||google search||BMW||3||1
+2015-11-09 07:07:17.131627||treatment||google search||BMW||5||1
+2015-11-09 07:07:19.796839||error||visiting||google searchresults||2||0
+2015-11-09 07:07:21.939194||error||visiting||google searchresults||1||0
+2015-11-09 07:07:25.856754||error||visiting||google searchresults||3||1
+2015-11-09 07:07:27.363418||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 07:07:28.347490||error||visiting||google searchresults||5||1
+2015-11-09 07:07:29.817339||error||visiting||google searchresults||2||0
+2015-11-09 07:07:37.452515||error||visiting||google searchresults||4||0
+2015-11-09 07:07:39.837827||error||visiting||google searchresults||2||0
+2015-11-09 07:07:41.987030||error||visiting||google searchresults||1||0
+2015-11-09 07:07:49.853779||error||visiting||google searchresults||2||0
+2015-11-09 07:07:53.809648||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 07:07:55.460448||treatment||google search||BMW||1||0
+2015-11-09 07:07:55.918677||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 07:07:56.472097||error||visiting||google searchresults||1||0
+2015-11-09 07:07:57.805977||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 07:08:01.751040||treatment||google search||BMW||2||0
+2015-11-09 07:08:02.674464||error||visiting||google searchresults||2||0
+2015-11-09 07:08:07.807853||event||progress-marker||training-end||4||0
+2015-11-09 07:08:11.755273||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 07:08:12.344063||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 07:08:16.447918||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 07:08:21.119342||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 07:08:21.600594||treatment||visit page||http://www.fredmartinfiat.com/?gclid=CMXG0fCmg8kCFdgNgQodcuEFZg||0||1
+2015-11-09 07:08:31.833878||error||visiting||google searchresults||3||1
+2015-11-09 07:08:32.393866||error||visiting||google searchresults||5||1
+2015-11-09 07:08:33.163358||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 07:08:34.121309||treatment||google search||BMW||0||1
+2015-11-09 07:08:37.625537||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 07:08:43.220569||error||visiting||google searchresults||1||0
+2015-11-09 07:08:45.063278||error||visiting||google searchresults||0||1
+2015-11-09 07:08:47.683161||error||visiting||google searchresults||2||0
+2015-11-09 07:08:48.349467||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 07:08:50.483638||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 07:08:58.128214||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 07:08:58.350269||event||progress-marker||training-end||5||1
+2015-11-09 07:09:00.484624||event||progress-marker||training-end||3||1
+2015-11-09 07:09:06.481095||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 07:09:06.707709||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 07:09:08.129505||event||progress-marker||training-end||1||0
+2015-11-09 07:09:16.709443||event||progress-marker||training-end||2||0
+2015-11-09 07:09:22.022150||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 07:09:42.120962||error||visiting||google searchresults||0||1
+2015-11-09 07:09:58.693656||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 07:10:08.695406||event||progress-marker||training-end||0||1
+2015-11-09 07:10:08.730238||event||progress-marker||measurement-start||5||1
+2015-11-09 07:10:10.839383||event||progress-marker||measurement-start||3||1
+2015-11-09 07:10:11.985432||event||progress-marker||measurement-start||2||0
+2015-11-09 07:10:13.473715||event||progress-marker||measurement-start||1||0
+2015-11-09 07:10:13.531524||event||progress-marker||measurement-start||4||0
+2015-11-09 07:10:13.738978||event||progress-marker||measurement-start||0||1
+2015-11-09 07:10:48.417089||measurement||ad||2015-11-09 07:10:47.174310@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:10:48.713567||measurement||ad||2015-11-09 07:10:47.174310@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 07:10:48.727916||measurement||loadtime||0:00:32.886931||3||1
+2015-11-09 07:10:55.174835||measurement||ad||2015-11-09 07:10:53.430553@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:10:55.499992||measurement||ad||2015-11-09 07:10:53.430553@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 07:10:55.695481||measurement||loadtime||0:00:41.964509||5||1
+2015-11-09 07:11:01.670770||measurement||ad||2015-11-09 07:11:00.631691@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:11:01.734555||measurement||loadtime||0:00:42.994031||0||1
+2015-11-09 07:11:06.785499||measurement||ad||2015-11-09 07:10:57.344781@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 07:11:07.108046||measurement||ad||2015-11-09 07:10:57.344781@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 07:11:07.118399||measurement||loadtime||0:00:48.644039||1||0
+2015-11-09 07:11:24.116331||measurement||ad||2015-11-09 07:10:56.215507@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||0
+2015-11-09 07:11:35.191151||measurement||ad||2015-11-09 07:10:56.215507@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:11:35.325638||measurement||ad||2015-11-09 07:11:05.544388@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 07:11:35.474047||measurement||loadtime||0:01:18.486560||2||0
+2015-11-09 07:11:36.797711||measurement||ad||2015-11-09 07:11:05.544388@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:11:36.847740||measurement||loadtime||0:01:18.313910||4||0
+2015-11-09 07:11:46.213631||measurement||ad||2015-11-09 07:11:43.671872@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:11:46.663619||measurement||ad||2015-11-09 07:11:43.671872@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:11:46.680064||measurement||loadtime||0:00:52.951482||3||1
+2015-11-09 07:11:53.371400||measurement||ad||2015-11-09 07:11:39.551446@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 07:11:55.247906||measurement||ad||2015-11-09 07:11:39.551446@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||1||0
+2015-11-09 07:11:55.329016||measurement||loadtime||0:00:43.210005||1||0
+2015-11-09 07:11:55.503241||measurement||ad||2015-11-09 07:11:51.667146@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:11:56.265224||measurement||ad||2015-11-09 07:11:51.667146@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 07:11:56.287482||measurement||loadtime||0:00:55.591062||5||1
+2015-11-09 07:11:58.045814||measurement||ad||2015-11-09 07:11:56.312493@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:11:58.670814||measurement||loadtime||0:00:51.935763||0||1
+2015-11-09 07:12:16.581416||measurement||ad||2015-11-09 07:12:07.936271@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 07:12:21.130866||measurement||ad||2015-11-09 07:12:07.936271@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:12:21.373485||measurement||loadtime||0:00:39.524899||4||0
+2015-11-09 07:12:33.779789||measurement||ad||2015-11-09 07:12:32.920560@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:12:33.969932||measurement||ad||2015-11-09 07:12:32.920560@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:12:33.984307||measurement||loadtime||0:00:42.303393||3||1
+2015-11-09 07:12:49.747477||measurement||ad||2015-11-09 07:12:47.235362@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:12:50.179008||measurement||ad||2015-11-09 07:12:47.235362@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:12:50.312726||measurement||loadtime||0:00:49.024130||5||1
+2015-11-09 07:12:50.431574||measurement||ad||2015-11-09 07:12:25.424486@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||0
+2015-11-09 07:12:51.830158||measurement||ad||2015-11-09 07:12:25.424486@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||1||0
+2015-11-09 07:12:51.877522||measurement||loadtime||0:00:51.547718||1||0
+2015-11-09 07:12:52.631980||measurement||ad||2015-11-09 07:12:47.741787@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:12:52.777117||measurement||loadtime||0:00:49.105077||0||1
+2015-11-09 07:13:00.304659||measurement||ad||2015-11-09 07:12:19.382565@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||2||0
+2015-11-09 07:13:00.923648||measurement||ad||2015-11-09 07:12:19.382565@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:13:00.928768||measurement||loadtime||0:01:20.454071||2||0
+2015-11-09 07:13:08.584553||measurement||ad||2015-11-09 07:12:54.405265@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 07:13:09.666189||measurement||ad||2015-11-09 07:12:54.405265@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:13:09.676933||measurement||loadtime||0:00:43.302123||4||0
+2015-11-09 07:13:23.359729||measurement||ad||2015-11-09 07:13:19.990184@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:13:23.955501||measurement||ad||2015-11-09 07:13:18.726714@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 07:13:24.245610||measurement||ad||2015-11-09 07:13:18.726714@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||0
+2015-11-09 07:13:24.252122||measurement||loadtime||0:00:27.373261||1||0
+2015-11-09 07:13:24.370975||measurement||ad||2015-11-09 07:13:19.990184@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:13:24.625899||measurement||loadtime||0:00:45.640245||3||1
+2015-11-09 07:13:37.138503||measurement||ad||2015-11-09 07:13:35.822347@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:13:37.557385||measurement||ad||2015-11-09 07:13:35.822347@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:13:37.968529||measurement||loadtime||0:00:42.654177||5||1
+2015-11-09 07:13:38.655772||measurement||ad||2015-11-09 07:13:37.041885@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:13:38.798434||measurement||loadtime||0:00:41.019881||0||1
+2015-11-09 07:13:55.336999||measurement||ad||2015-11-09 07:13:50.243877@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||1||0
+2015-11-09 07:13:55.450445||measurement||ad||2015-11-09 07:13:50.243877@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||1||0
+2015-11-09 07:13:55.464704||measurement||loadtime||0:00:26.212090||1||0
+2015-11-09 07:13:57.694614||measurement||ad||2015-11-09 07:13:41.351426@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 07:13:59.417244||measurement||ad||2015-11-09 07:13:41.351426@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:13:59.548091||measurement||loadtime||0:00:44.870087||4||0
+2015-11-09 07:14:10.509613||measurement||ad||2015-11-09 07:14:05.955305@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:14:10.822716||measurement||ad||2015-11-09 07:14:05.955305@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:14:10.848849||measurement||loadtime||0:00:41.222304||3||1
+2015-11-09 07:14:21.524398||measurement||ad||2015-11-09 07:14:20.228924@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:14:21.683872||measurement||loadtime||0:00:37.883486||0||1
+2015-11-09 07:14:24.766591||measurement||ad||2015-11-09 07:14:23.184531@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:14:25.132570||measurement||ad||2015-11-09 07:14:23.184531@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:14:25.142587||measurement||loadtime||0:00:42.173413||5||1
+2015-11-09 07:14:30.256299||measurement||ad||2015-11-09 07:14:25.341462@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||1||0
+2015-11-09 07:14:30.583186||measurement||ad||2015-11-09 07:14:25.341462@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 07:14:30.588925||measurement||loadtime||0:00:30.122760||1||0
+2015-11-09 07:14:40.523303||measurement||ad||2015-11-09 07:14:30.993693@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 07:14:40.865649||measurement||ad||2015-11-09 07:14:30.993693@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:14:40.871179||measurement||loadtime||0:00:36.321741||4||0
+2015-11-09 07:14:54.483152||measurement||ad||2015-11-09 07:14:53.192452@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:14:55.139345||measurement||ad||2015-11-09 07:14:53.192452@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:14:55.296387||measurement||loadtime||0:00:39.444825||3||1
+2015-11-09 07:14:59.774172||measurement||ad||2015-11-09 07:13:47.756734@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||2||0
+2015-11-09 07:15:01.653737||measurement||ad||2015-11-09 07:13:47.756734@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:15:01.935668||measurement||loadtime||0:01:56.006249||2||0
+2015-11-09 07:15:04.357152||measurement||ad||2015-11-09 07:14:58.644697@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 07:15:04.580772||measurement||ad||2015-11-09 07:14:58.644697@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 07:15:04.589208||measurement||loadtime||0:00:28.999667||1||0
+2015-11-09 07:15:05.296957||measurement||ad||2015-11-09 07:15:04.236558@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:15:05.528724||measurement||ad||2015-11-09 07:15:04.236558@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:15:05.804612||measurement||loadtime||0:00:35.659379||5||1
+2015-11-09 07:15:06.476802||measurement||ad||2015-11-09 07:15:03.994474@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:15:06.497207||measurement||loadtime||0:00:39.812548||0||1
+2015-11-09 07:15:17.500212||measurement||ad||2015-11-09 07:15:10.522759@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 07:15:17.834289||measurement||ad||2015-11-09 07:15:10.522759@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:15:17.859087||measurement||loadtime||0:00:31.987289||4||0
+2015-11-09 07:15:31.974005||measurement||ad||2015-11-09 07:15:30.602282@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:15:32.351598||measurement||ad||2015-11-09 07:15:30.602282@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:15:32.372667||measurement||loadtime||0:00:32.074226||3||1
+2015-11-09 07:15:36.765694||measurement||ad||2015-11-09 07:15:30.344055@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||1||0
+2015-11-09 07:15:36.973490||measurement||ad||2015-11-09 07:15:30.344055@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 07:15:36.977646||measurement||loadtime||0:00:27.387668||1||0
+2015-11-09 07:15:44.322084||measurement||ad||2015-11-09 07:15:43.830651@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:15:44.586249||measurement||ad||2015-11-09 07:15:43.830651@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:15:44.612899||measurement||loadtime||0:00:33.807529||5||1
+2015-11-09 07:15:53.140960||measurement||ad||2015-11-09 07:15:51.742849@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:15:53.191967||measurement||loadtime||0:00:41.694110||0||1
+2015-11-09 07:15:56.458465||measurement||ad||2015-11-09 07:15:49.983719@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 07:15:56.532827||measurement||ad||2015-11-09 07:15:45.381109@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||2||0
+2015-11-09 07:15:56.616082||measurement||ad||2015-11-09 07:15:49.983719@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:15:56.621328||measurement||loadtime||0:00:33.760381||4||0
+2015-11-09 07:15:57.236181||measurement||ad||2015-11-09 07:15:45.381109@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:15:57.297753||measurement||loadtime||0:00:50.361308||2||0
+2015-11-09 07:16:08.905402||measurement||ad||2015-11-09 07:16:03.281283@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 07:16:09.158496||measurement||ad||2015-11-09 07:16:03.281283@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||1||0
+2015-11-09 07:16:09.168194||measurement||loadtime||0:00:27.189203||1||0
+2015-11-09 07:16:09.320565||measurement||ad||2015-11-09 07:16:08.708671@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:16:09.620687||measurement||ad||2015-11-09 07:16:08.708671@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:16:09.633135||measurement||loadtime||0:00:32.259695||3||1
+2015-11-09 07:16:21.228121||measurement||ad||2015-11-09 07:16:19.961518@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:16:21.479397||measurement||ad||2015-11-09 07:16:19.961518@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:16:21.492114||measurement||loadtime||0:00:31.878376||5||1
+2015-11-09 07:16:36.794568||measurement||ad||2015-11-09 07:16:30.137763@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||4||0
+2015-11-09 07:16:37.232616||measurement||ad||2015-11-09 07:16:30.137763@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:16:37.240554||measurement||loadtime||0:00:35.617720||4||0
+2015-11-09 07:16:44.516440||measurement||ad||2015-11-09 07:16:38.400659@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Compare 2016 Plans  Prices.||1||0
+2015-11-09 07:16:44.718985||measurement||ad||2015-11-09 07:16:38.400659@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||0
+2015-11-09 07:16:44.724844||measurement||loadtime||0:00:30.555952||1||0
+2015-11-09 07:16:44.726031||event||progress-marker||measurement-end||1||0
+2015-11-09 07:16:46.365760||measurement||ad||2015-11-09 07:16:43.407858@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:16:46.513448||measurement||loadtime||0:00:48.320339||0||1
+2015-11-09 07:16:47.446730||measurement||ad||2015-11-09 07:16:46.766855@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 07:16:47.520443||measurement||ad||2015-11-09 07:16:46.766855@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:16:47.636092||measurement||loadtime||0:00:33.002399||3||1
+2015-11-09 07:16:47.683242||measurement||ad||2015-11-09 07:16:35.052021@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||2||0
+2015-11-09 07:16:48.311235||measurement||ad||2015-11-09 07:16:35.052021@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:16:48.352701||measurement||loadtime||0:00:46.053939||2||0
+2015-11-09 07:17:05.764900||measurement||ad||2015-11-09 07:17:05.129485@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:17:06.004574||measurement||ad||2015-11-09 07:17:05.129485@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:17:06.085415||measurement||loadtime||0:00:39.591474||5||1
+2015-11-09 07:17:25.529438||measurement||ad||2015-11-09 07:17:24.747554@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:17:25.742916||measurement||ad||2015-11-09 07:17:24.747554@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 07:17:25.754086||measurement||loadtime||0:00:33.116936||3||1
+2015-11-09 07:17:25.754442||event||progress-marker||measurement-end||3||1
+2015-11-09 07:17:28.162930||measurement||ad||2015-11-09 07:17:19.307599@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:17:28.421176||measurement||ad||2015-11-09 07:17:19.307599@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:17:28.425672||measurement||loadtime||0:00:35.071902||2||0
+2015-11-09 07:17:29.325457||measurement||ad||2015-11-09 07:17:24.017469@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:17:29.391217||measurement||loadtime||0:00:37.877243||0||1
+2015-11-09 07:17:38.023888||measurement||ad||2015-11-09 07:17:17.665064@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||4||0
+2015-11-09 07:17:38.555381||measurement||ad||2015-11-09 07:17:17.665064@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:17:38.561323||measurement||loadtime||0:00:56.320018||4||0
+2015-11-09 07:17:40.608027||measurement||ad||2015-11-09 07:17:40.388407@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||5||1
+2015-11-09 07:17:40.740517||measurement||ad||2015-11-09 07:17:40.388407@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||5||1
+2015-11-09 07:17:40.753886||measurement||loadtime||0:00:29.667768||5||1
+2015-11-09 07:17:40.754194||event||progress-marker||measurement-end||5||1
+2015-11-09 07:18:00.016976||measurement||ad||2015-11-09 07:17:55.346915@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:18:00.104027||measurement||ad||2015-11-09 07:17:55.346915@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||2||0
+2015-11-09 07:18:00.108893||measurement||loadtime||0:00:26.682556||2||0
+2015-11-09 07:18:02.047971||measurement||ad||2015-11-09 07:18:01.699151@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||0||1
+2015-11-09 07:18:02.070827||measurement||loadtime||0:00:27.678344||0||1
+2015-11-09 07:18:02.071248||event||progress-marker||measurement-end||0||1
+2015-11-09 07:18:14.697742||measurement||ad||2015-11-09 07:18:08.444051@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 07:18:15.055779||measurement||ad||2015-11-09 07:18:08.444051@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 07:18:15.060069||measurement||loadtime||0:00:31.497558||4||0
+2015-11-09 07:18:15.060316||event||progress-marker||measurement-end||4||0
+2015-11-09 07:18:25.293770||measurement||ad||2015-11-09 07:18:22.865335@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||2||0
+2015-11-09 07:18:25.362673||measurement||ad||2015-11-09 07:18:22.865335@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:18:25.369694||measurement||loadtime||0:00:20.259602||2||0
+2015-11-09 07:18:48.750814||measurement||ad||2015-11-09 07:18:46.545002@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:18:48.962815||measurement||ad||2015-11-09 07:18:46.545002@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:18:48.966469||measurement||loadtime||0:00:18.595991||2||0
+2015-11-09 07:19:12.118849||measurement||ad||2015-11-09 07:19:09.999638@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:19:12.213906||measurement||ad||2015-11-09 07:19:09.999638@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||0
+2015-11-09 07:19:12.217303||measurement||loadtime||0:00:18.249374||2||0
+2015-11-09 07:19:12.217632||event||progress-marker||measurement-end||2||0
+2015-11-09 07:19:12.876048||meta||block_id end||19
+2015-11-09 07:19:12.900570||meta||block_id start||20
+2015-11-09 07:19:12.901107||meta||assignment||2@|0@|4@|1@|3@|5
+2015-11-09 07:19:16.897787||event||progress-marker||training-start||4||0
+2015-11-09 07:19:16.970768||event||progress-marker||training-start||2||0
+2015-11-09 07:19:17.182487||event||progress-marker||training-start||0||0
+2015-11-09 07:19:21.223126||event||progress-marker||training-start||1||1
+2015-11-09 07:19:21.310952||event||progress-marker||training-start||5||1
+2015-11-09 07:19:21.755191||event||progress-marker||training-start||3||1
+2015-11-09 07:19:22.233496||treatment||google search||Buy BMW||2||0
+2015-11-09 07:19:22.347564||treatment||google search||Buy BMW||0||0
+2015-11-09 07:19:23.308541||treatment||google search||Buy BMW||4||0
+2015-11-09 07:19:24.477917||error||visiting||google searchresults||2||0
+2015-11-09 07:19:24.480101||error||visiting||google searchresults||0||0
+2015-11-09 07:19:24.946659||error||visiting||google searchresults||4||0
+2015-11-09 07:19:26.991572||treatment||google search||Buy BMW||5||1
+2015-11-09 07:19:27.435171||treatment||google search||Buy BMW||1||1
+2015-11-09 07:19:27.554631||treatment||google search||Buy BMW||3||1
+2015-11-09 07:19:38.292422||error||visiting||google searchresults||5||1
+2015-11-09 07:19:38.408130||error||visiting||google searchresults||1||1
+2015-11-09 07:19:38.425458||error||visiting||google searchresults||3||1
+2015-11-09 07:19:38.618157||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 07:19:39.729741||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 07:19:43.204456||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 07:19:52.872965||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 07:19:53.098302||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||0
+2015-11-09 07:19:53.196124||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 07:19:54.144583||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 07:19:58.611078||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 07:19:59.189668||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 07:20:03.137747||error||visiting||google searchresults||2||0
+2015-11-09 07:20:04.179814||error||visiting||google searchresults||0||0
+2015-11-09 07:20:06.464276||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 07:20:08.160566||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 07:20:08.664718||error||visiting||google searchresults||4||0
+2015-11-09 07:20:13.849389||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||1
+2015-11-09 07:20:18.338745||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||2||0
+2015-11-09 07:20:19.570459||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||0||0
+2015-11-09 07:20:23.452467||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||4||0
+2015-11-09 07:20:26.523490||error||visiting||google searchresults||1||1
+2015-11-09 07:20:28.244026||error||visiting||google searchresults||3||1
+2015-11-09 07:20:30.119269||treatment||google search||BMW dealer||2||0
+2015-11-09 07:20:30.911696||error||visiting||google searchresults||2||0
+2015-11-09 07:20:31.430379||treatment||google search||BMW dealer||0||0
+2015-11-09 07:20:32.078448||error||visiting||google searchresults||0||0
+2015-11-09 07:20:33.967015||error||visiting||google searchresults||5||1
+2015-11-09 07:20:35.260354||treatment||google search||BMW dealer||4||0
+2015-11-09 07:20:35.968295||error||visiting||google searchresults||4||0
+2015-11-09 07:20:41.517257||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||3||1
+2015-11-09 07:20:41.532042||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||1||1
+2015-11-09 07:20:46.948343||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||0||0
+2015-11-09 07:20:47.328715||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||5||1
+2015-11-09 07:20:51.408699||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CPnky_mpg8kCFVI7gQodrjYBDQ||2||0
+2015-11-09 07:20:54.467993||treatment||google search||BMW dealer||3||1
+2015-11-09 07:20:54.532533||treatment||google search||BMW dealer||1||1
+2015-11-09 07:20:54.661199||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLSggvypg8kCFUU7gQodHnMD0w||4||0
+2015-11-09 07:20:59.632875||treatment||google search||BMW dealer||5||1
+2015-11-09 07:21:02.716481||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810||0||0
+2015-11-09 07:21:05.641580||error||visiting||google searchresults||1||1
+2015-11-09 07:21:05.644226||error||visiting||google searchresults||3||1
+2015-11-09 07:21:07.147520||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMnxrYOqg8kCFdgVgQodCWoF0w||2||0
+2015-11-09 07:21:10.000589||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMXg9ISqg8kCFZM2gQodqtgP5w||4||0
+2015-11-09 07:21:10.787143||error||visiting||google searchresults||5||1
+2015-11-09 07:21:12.752677||error||visiting||google searchresults||0||0
+2015-11-09 07:21:17.216862||error||visiting||google searchresults||2||0
+2015-11-09 07:21:19.803399||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||1||1
+2015-11-09 07:21:20.034983||error||visiting||google searchresults||4||0
+2015-11-09 07:21:21.266332||treatment||visit page||http://www.usautomart.com/?gclid=CPPPlYqqg8kCFY8dgQodTO8A2Q||3||1
+2015-11-09 07:21:24.994175||treatment||visit page||http://dealers.autosite.com/dealers/bmw?ukwid=9301ef85-c96c-4ead-beee-bf5234006e9d&udv=c&gclid=CI3Iz4yqg8kCFdgYgQody_wFDQ||5||1
+2015-11-09 07:21:35.569830||treatment||visit page||http://www.carsense.com/?gclid=CJWs1I-qg8kCFdgcgQodPBMC0w||2||0
+2015-11-09 07:21:35.673795||treatment||visit page||http://www.usautomart.com/?gclid=CNOJ1JGqg8kCFUQ2gQod3qUJlQ||3||1
+2015-11-09 07:21:36.257670||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CJzQxY2qg8kCFZYkgQod96sHBA||0||0
+2015-11-09 07:21:37.326550||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||4||0
+2015-11-09 07:21:38.346129||treatment||visit page||http://dealers.autosite.com/dealers/bmw?ukwid=9301ef85-c96c-4ead-beee-bf5234006e9d&udv=c&gclid=CIG-t5Oqg8kCFdU6gQodunAK2g||5||1
+2015-11-09 07:21:39.827715||error||visiting||google searchresults||1||1
+2015-11-09 07:21:47.227323||treatment||google search||BMW||2||0
+2015-11-09 07:21:48.164331||treatment||google search||BMW||0||0
+2015-11-09 07:21:48.744058||error||visiting||google searchresults||2||0
+2015-11-09 07:21:49.164132||error||visiting||google searchresults||0||0
+2015-11-09 07:21:49.415717||treatment||google search||BMW||4||0
+2015-11-09 07:21:50.340489||error||visiting||google searchresults||4||0
+2015-11-09 07:21:55.743476||error||visiting||google searchresults||3||1
+2015-11-09 07:21:58.400069||error||visiting||google searchresults||5||1
+2015-11-09 07:22:05.371284||error||visiting||google searchresults||1||1
+2015-11-09 07:22:07.689349||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 07:22:09.058516||treatment||visit page||http://www.towerautosales.com/index.shtml||3||1
+2015-11-09 07:22:10.715278||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 07:22:10.833496||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 07:22:12.749955||treatment||visit page||http://dealers.car.com/dealers/bmw?ukwid=a504797f-59a0-42f3-847d-e88ad8efd72e&udv=c&gclid=CKP9p6Oqg8kCFUgvgQod-r4Cfw||5||1
+2015-11-09 07:22:21.203438||treatment||google search||BMW||3||1
+2015-11-09 07:22:24.545283||treatment||visit page||http://www.bmwusa.com/||2||0
+2015-11-09 07:22:25.641397||treatment||google search||BMW||5||1
+2015-11-09 07:22:27.733797||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 07:22:28.065146||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 07:22:29.359296||error||visiting||google searchresults||1||1
+2015-11-09 07:22:32.800306||error||visiting||google searchresults||3||1
+2015-11-09 07:22:34.581609||error||visiting||google searchresults||2||0
+2015-11-09 07:22:37.214791||error||visiting||google searchresults||5||1
+2015-11-09 07:22:37.761209||error||visiting||google searchresults||4||0
+2015-11-09 07:22:38.100700||error||visiting||google searchresults||0||0
+2015-11-09 07:22:51.478333||error||visiting||google searchresults||1||1
+2015-11-09 07:22:58.088527||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||0
+2015-11-09 07:22:59.020044||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 07:23:01.616203||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 07:23:01.854278||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 07:23:02.365220||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||0
+2015-11-09 07:23:08.090719||event||progress-marker||training-end||2||0
+2015-11-09 07:23:11.653229||error||visiting||google searchresults||1||1
+2015-11-09 07:23:11.855478||event||progress-marker||training-end||4||0
+2015-11-09 07:23:12.368205||event||progress-marker||training-end||0||0
+2015-11-09 07:23:14.474564||treatment||visit page||http://www.bmwusa.com/||5||1
+2015-11-09 07:23:14.991002||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 07:23:31.730053||error||visiting||google searchresults||1||1
+2015-11-09 07:23:34.563116||error||visiting||google searchresults||5||1
+2015-11-09 07:23:35.079277||error||visiting||google searchresults||3||1
+2015-11-09 07:23:43.708139||treatment||google search||BMW||1||1
+2015-11-09 07:23:51.288354||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||1
+2015-11-09 07:23:54.175552||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 07:23:54.767283||error||visiting||google searchresults||1||1
+2015-11-09 07:24:01.290135||event||progress-marker||training-end||5||1
+2015-11-09 07:24:04.177190||event||progress-marker||training-end||3||1
+2015-11-09 07:24:13.405954||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 07:24:28.841433||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 07:24:48.905082||error||visiting||google searchresults||1||1
+2015-11-09 07:25:05.806757||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 07:25:15.809720||event||progress-marker||training-end||1||1
+2015-11-09 07:25:16.675944||event||progress-marker||measurement-start||5||1
+2015-11-09 07:25:17.505043||event||progress-marker||measurement-start||4||0
+2015-11-09 07:25:18.040120||event||progress-marker||measurement-start||0||0
+2015-11-09 07:25:18.780902||event||progress-marker||measurement-start||2||0
+2015-11-09 07:25:19.569448||event||progress-marker||measurement-start||3||1
+2015-11-09 07:25:20.860321||event||progress-marker||measurement-start||1||1
+2015-11-09 07:26:07.415927||measurement||ad||2015-11-09 07:26:06.923968@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:26:07.759727||measurement||ad||2015-11-09 07:26:06.923968@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||1||1
+2015-11-09 07:26:07.803726||measurement||loadtime||0:00:41.942358||1||1
+2015-11-09 07:26:13.542094||measurement||ad||2015-11-09 07:26:12.828632@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 07:26:13.715577||measurement||ad||2015-11-09 07:26:12.828632@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 07:26:13.739223||measurement||loadtime||0:00:49.168577||3||1
+2015-11-09 07:26:14.598047||measurement||ad||2015-11-09 07:26:13.890414@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:26:14.788633||measurement||ad||2015-11-09 07:26:13.890414@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 07:26:14.806650||measurement||loadtime||0:00:53.129551||5||1
+2015-11-09 07:26:42.797872||measurement||ad||2015-11-09 07:26:12.014232@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||0
+2015-11-09 07:26:42.868876||measurement||ad||2015-11-09 07:26:41.696805@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:26:43.356686||measurement||ad||2015-11-09 07:26:41.696805@|Public Arrest Records@|records.instantcheckmate.com@|Enter a Name  Search for Free. View Background Check Instantly.||1||1
+2015-11-09 07:26:43.403580||measurement||loadtime||0:00:30.598367||1||1
+2015-11-09 07:26:44.535429||measurement||ad||2015-11-09 07:26:12.014232@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:26:44.699755||measurement||loadtime||0:01:22.193961||4||0
+2015-11-09 07:26:51.864243||measurement||ad||2015-11-09 07:26:20.037207@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:26:52.641908||measurement||ad||2015-11-09 07:26:20.037207@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:26:52.839980||measurement||loadtime||0:01:29.799113||0||0
+2015-11-09 07:26:54.208095||measurement||ad||2015-11-09 07:26:26.170467@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||2||0
+2015-11-09 07:27:01.240521||measurement||ad||2015-11-09 07:26:26.170467@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:27:01.260509||measurement||loadtime||0:01:37.478589||2||0
+2015-11-09 07:27:03.703095||measurement||ad||2015-11-09 07:27:02.840956@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:27:03.934283||measurement||ad||2015-11-09 07:27:02.840956@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||1
+2015-11-09 07:27:04.190567||measurement||loadtime||0:00:44.381622||5||1
+2015-11-09 07:27:06.726763||measurement||ad||2015-11-09 07:27:04.457843@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 07:27:07.160435||measurement||ad||2015-11-09 07:27:04.457843@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 07:27:07.367519||measurement||loadtime||0:00:48.627103||3||1
+2015-11-09 07:27:22.590888||measurement||ad||2015-11-09 07:27:19.021127@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:27:25.156105||measurement||ad||2015-11-09 07:27:19.021127@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||1||1
+2015-11-09 07:27:26.001934||measurement||loadtime||0:00:37.594138||1||1
+2015-11-09 07:28:01.078985||measurement||ad||2015-11-09 07:27:55.232015@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 07:28:02.783433||measurement||ad||2015-11-09 07:27:55.232015@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 07:28:04.546654||measurement||loadtime||0:00:52.177445||3||1
+2015-11-09 07:28:05.459558||measurement||ad||2015-11-09 07:27:58.379591@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:28:07.460317||measurement||ad||2015-11-09 07:27:58.379591@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:28:07.712442||measurement||loadtime||0:00:58.520576||5||1
+2015-11-09 07:28:13.330635||measurement||ad||2015-11-09 07:27:34.163450@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||0
+2015-11-09 07:28:15.432511||measurement||ad||2015-11-09 07:27:34.163450@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:28:15.793546||measurement||loadtime||0:01:26.092518||4||0
+2015-11-09 07:28:17.542900||measurement||ad||2015-11-09 07:27:38.912987@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:28:18.235919||measurement||ad||2015-11-09 07:28:14.581522@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:28:18.908301||measurement||ad||2015-11-09 07:27:38.912987@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:28:19.079993||measurement||loadtime||0:01:21.239485||0||0
+2015-11-09 07:28:19.342293||measurement||ad||2015-11-09 07:28:14.581522@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||1||1
+2015-11-09 07:28:19.498476||measurement||loadtime||0:00:48.495101||1||1
+2015-11-09 07:28:27.690818||measurement||ad||2015-11-09 07:27:52.796777@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||2||0
+2015-11-09 07:28:30.083371||measurement||ad||2015-11-09 07:27:52.796777@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||2||0
+2015-11-09 07:28:30.551238||measurement||loadtime||0:01:24.289651||2||0
+2015-11-09 07:29:04.617139||measurement||ad||2015-11-09 07:28:56.367039@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 07:29:06.127719||measurement||ad||2015-11-09 07:29:02.726175@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:29:07.792667||measurement||ad||2015-11-09 07:28:56.367039@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 07:29:07.803463||measurement||loadtime||0:00:58.256215||3||1
+2015-11-09 07:29:08.237166||measurement||ad||2015-11-09 07:29:02.726175@|Public Arrest Records@|records.instantcheckmate.com@|Enter a Name  Search for Free. View Background Check Instantly.||1||1
+2015-11-09 07:29:08.257590||measurement||loadtime||0:00:43.758048||1||1
+2015-11-09 07:29:10.257241||measurement||ad||2015-11-09 07:29:00.871621@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:29:12.672456||measurement||ad||2015-11-09 07:29:00.871621@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:29:12.689879||measurement||loadtime||0:00:59.974016||5||1
+2015-11-09 07:29:18.649790||measurement||ad||2015-11-09 07:28:58.232251@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||4||0
+2015-11-09 07:29:20.783263||measurement||ad||2015-11-09 07:28:58.232251@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:29:21.208742||measurement||loadtime||0:01:00.414330||4||0
+2015-11-09 07:29:21.803163||measurement||ad||2015-11-09 07:29:02.545958@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:29:23.155153||measurement||ad||2015-11-09 07:29:02.545958@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:29:23.176265||measurement||loadtime||0:00:59.095404||0||0
+2015-11-09 07:29:40.944860||measurement||ad||2015-11-09 07:29:18.031169@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||2||0
+2015-11-09 07:29:44.575211||measurement||ad||2015-11-09 07:29:18.031169@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:29:44.964820||measurement||loadtime||0:01:09.411940||2||0
+2015-11-09 07:30:10.416255||measurement||ad||2015-11-09 07:30:04.131189@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:30:12.597263||measurement||ad||2015-11-09 07:30:04.131189@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:30:13.448923||measurement||loadtime||0:00:55.758272||5||1
+2015-11-09 07:30:14.106705||error||collecting ads||Error||1||1
+2015-11-09 07:30:16.789441||measurement||ad||2015-11-09 07:30:08.528070@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 07:30:18.045240||measurement||ad||2015-11-09 07:30:08.528070@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 07:30:19.180374||measurement||loadtime||0:01:06.376264||3||1
+2015-11-09 07:30:28.611193||measurement||ad||2015-11-09 07:30:04.569956@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:30:29.865285||measurement||ad||2015-11-09 07:30:04.569956@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:30:29.890006||measurement||loadtime||0:01:01.712728||0||0
+2015-11-09 07:30:36.415895||measurement||ad||2015-11-09 07:30:33.655662@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:30:36.703690||measurement||ad||2015-11-09 07:30:33.655662@|Public Arrest Records@|records.instantcheckmate.com@|Enter a Name  Search for Free. View Background Check Instantly.||1||1
+2015-11-09 07:30:36.892980||measurement||loadtime||0:00:17.785277||1||1
+2015-11-09 07:30:45.856589||measurement||ad||2015-11-09 07:30:06.539814@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||0
+2015-11-09 07:30:47.085049||measurement||ad||2015-11-09 07:30:06.539814@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:30:47.296535||measurement||loadtime||0:01:21.086362||4||0
+2015-11-09 07:31:07.919737||measurement||ad||2015-11-09 07:31:02.905923@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||1
+2015-11-09 07:31:10.826618||measurement||ad||2015-11-09 07:31:02.905923@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 07:31:11.405049||measurement||loadtime||0:00:47.223860||3||1
+2015-11-09 07:31:11.589125||measurement||ad||2015-11-09 07:31:05.679485@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:31:11.882733||measurement||ad||2015-11-09 07:30:30.917194@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:31:13.186091||measurement||ad||2015-11-09 07:30:30.917194@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||2||0
+2015-11-09 07:31:13.192738||measurement||loadtime||0:01:23.226438||2||0
+2015-11-09 07:31:13.356656||measurement||ad||2015-11-09 07:31:05.679485@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:31:13.604666||measurement||loadtime||0:00:55.154036||5||1
+2015-11-09 07:31:28.534768||measurement||ad||2015-11-09 07:31:25.327981@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||1||1
+2015-11-09 07:31:30.752538||measurement||ad||2015-11-09 07:31:25.327981@|Free Diabetic Cookbook@|www.diabetes-cooking.com@|Limited Time offer for a 100% Free Cookbook full of Diabetic Recipes!||1||1
+2015-11-09 07:31:31.674210||measurement||loadtime||0:00:49.779666||1||1
+2015-11-09 07:31:54.424183||error||collecting ads||Error||4||0
+2015-11-09 07:32:01.032672||measurement||ad||2015-11-09 07:31:25.302614@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:32:04.897493||measurement||ad||2015-11-09 07:31:25.302614@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:32:05.485710||measurement||loadtime||0:01:30.594540||0||0
+2015-11-09 07:32:08.791168||measurement||ad||2015-11-09 07:32:03.296966@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||1
+2015-11-09 07:32:10.287854||measurement||ad||2015-11-09 07:32:03.296966@|VA Loans- $0 Down@|veteransunited.com@|Dedicated to Military Home Owners. PreQualify Today on Up to $417K!||3||1
+2015-11-09 07:32:10.657093||measurement||loadtime||0:00:54.251172||3||1
+2015-11-09 07:32:15.908056||measurement||ad||2015-11-09 07:32:10.003899@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:32:16.033375||measurement||ad||2015-11-09 07:32:13.253271@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||1||1
+2015-11-09 07:32:16.896423||measurement||ad||2015-11-09 07:32:10.003899@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:32:16.914920||measurement||loadtime||0:00:58.308550||5||1
+2015-11-09 07:32:17.004781||measurement||ad||2015-11-09 07:32:13.253271@|Free Diabetic Cookbook@|www.diabetes-cooking.com@|Limited Time offer for a 100% Free Cookbook full of Diabetic Recipes!||1||1
+2015-11-09 07:32:17.261232||measurement||loadtime||0:00:40.586274||1||1
+2015-11-09 07:32:34.492482||measurement||ad||2015-11-09 07:32:04.125752@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||2||0
+2015-11-09 07:32:37.442173||measurement||ad||2015-11-09 07:32:04.125752@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:32:37.633422||measurement||loadtime||0:01:19.440022||2||0
+2015-11-09 07:32:56.806190||measurement||ad||2015-11-09 07:32:41.798019@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:33:02.472594||measurement||ad||2015-11-09 07:32:36.870434@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||0
+2015-11-09 07:33:02.872681||measurement||ad||2015-11-09 07:32:58.094701@|16% Annuity Return 2014@|advisorworld.com/CompareAnnuities@|True Investor Returns with no Risk. Find out how with our Free Report.||1||1
+2015-11-09 07:33:04.431413||measurement||ad||2015-11-09 07:32:41.798019@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:33:04.678751||measurement||loadtime||0:00:54.192359||0||0
+2015-11-09 07:33:05.685527||measurement||ad||2015-11-09 07:32:58.094701@|Dividend ETFs to Buy Now@|www.investmentu.com/ETFs@|Investor's Guide: The Top 10 High Dividend Paying ETFs for 2015.||1||1
+2015-11-09 07:33:06.022791||measurement||ad||2015-11-09 07:32:36.870434@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:33:06.195779||measurement||loadtime||0:00:43.933779||1||1
+2015-11-09 07:33:06.198520||event||progress-marker||measurement-end||1||1
+2015-11-09 07:33:06.522674||measurement||loadtime||0:01:07.096456||4||0
+2015-11-09 07:33:14.111406||measurement||ad||2015-11-09 07:33:05.388054@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:33:14.959566||measurement||ad||2015-11-09 07:33:05.388054@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:33:15.000650||measurement||loadtime||0:00:53.084103||5||1
+2015-11-09 07:33:15.655321||measurement||ad||2015-11-09 07:33:02.576997@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||1
+2015-11-09 07:33:18.791890||measurement||ad||2015-11-09 07:33:02.576997@|VA Loans- $0 Down@|veteransunited.com@|Dedicated to Military Home Owners. PreQualify Today on Up to $417K!||3||1
+2015-11-09 07:33:19.259072||measurement||loadtime||0:01:03.601224||3||1
+2015-11-09 07:33:44.024351||measurement||ad||2015-11-09 07:33:32.565713@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||2||0
+2015-11-09 07:33:50.142645||measurement||ad||2015-11-09 07:33:32.565713@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||2||0
+2015-11-09 07:33:50.658647||measurement||loadtime||0:01:08.024243||2||0
+2015-11-09 07:34:00.141361||measurement||ad||2015-11-09 07:33:54.495830@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:34:01.224464||measurement||ad||2015-11-09 07:33:54.495830@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:34:01.270921||measurement||loadtime||0:00:41.267926||5||1
+2015-11-09 07:34:07.816331||measurement||ad||2015-11-09 07:33:49.226253@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:34:14.479859||measurement||ad||2015-11-09 07:33:49.226253@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:34:14.727349||measurement||loadtime||0:01:05.047771||0||0
+2015-11-09 07:34:21.887168||measurement||ad||2015-11-09 07:34:13.640316@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||1
+2015-11-09 07:34:26.118565||measurement||ad||2015-11-09 07:34:13.640316@|VA Loans- $0 Down@|veteransunited.com@|Dedicated to Military Home Owners. PreQualify Today on Up to $417K!||3||1
+2015-11-09 07:34:26.246561||measurement||loadtime||0:01:01.986527||3||1
+2015-11-09 07:34:33.661724||measurement||ad||2015-11-09 07:33:52.169973@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||4||0
+2015-11-09 07:34:35.256673||measurement||ad||2015-11-09 07:33:52.169973@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:34:35.270584||measurement||loadtime||0:01:23.746046||4||0
+2015-11-09 07:34:56.266857||measurement||ad||2015-11-09 07:34:50.857271@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||1
+2015-11-09 07:34:57.434240||measurement||ad||2015-11-09 07:34:50.857271@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||1
+2015-11-09 07:34:57.766525||measurement||loadtime||0:00:51.494940||5||1
+2015-11-09 07:34:57.770155||event||progress-marker||measurement-end||5||1
+2015-11-09 07:35:27.858855||measurement||ad||2015-11-09 07:35:23.379259@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||3||1
+2015-11-09 07:35:30.877223||measurement||ad||2015-11-09 07:35:23.379259@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||3||1
+2015-11-09 07:35:31.160645||measurement||loadtime||0:00:59.913106||3||1
+2015-11-09 07:35:31.164052||event||progress-marker||measurement-end||3||1
+2015-11-09 07:35:32.435515||measurement||ad||2015-11-09 07:35:20.494008@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||4||0
+2015-11-09 07:35:35.516736||measurement||ad||2015-11-09 07:35:20.494008@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:35:35.756177||measurement||loadtime||0:00:55.484459||4||0
+2015-11-09 07:35:35.932678||measurement||ad||2015-11-09 07:35:25.082759@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||0||0
+2015-11-09 07:35:37.109785||measurement||ad||2015-11-09 07:35:25.082759@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||0
+2015-11-09 07:35:37.156841||measurement||loadtime||0:01:17.427991||0||0
+2015-11-09 07:35:39.147582||measurement||ad||2015-11-09 07:34:53.422199@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:35:44.856891||measurement||ad||2015-11-09 07:34:53.422199@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||2||0
+2015-11-09 07:35:46.741432||measurement||loadtime||0:01:51.081340||2||0
+2015-11-09 07:36:28.686715||measurement||ad||2015-11-09 07:36:12.070106@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-09 07:36:33.187573||measurement||ad||2015-11-09 07:36:12.070106@|Rails Consulting@|www.quoininc.com@|Our teams can deliver sophisticated web  mobile apps in Ruby on Rails||0||0
+2015-11-09 07:36:33.411272||measurement||loadtime||0:00:51.253746||0||0
+2015-11-09 07:37:05.049619||measurement||ad||2015-11-09 07:36:35.417398@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||2||0
+2015-11-09 07:37:06.624732||measurement||ad||2015-11-09 07:36:35.417398@|Data Mining Courses@|stanford.edu/Data-Mining@|Online Data Mining Courses, earn World-Class Credentials. Learn More||2||0
+2015-11-09 07:37:06.669628||measurement||loadtime||0:01:14.927161||2||0
+2015-11-09 07:37:10.426558||measurement||ad||2015-11-09 07:37:05.202429@|Poll: You've been chosen@|www.civiqs.com@|Take a five question survey on Obama and the direction of the US.||0||0
+2015-11-09 07:37:10.727873||measurement||ad||2015-11-09 07:37:05.202429@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-09 07:37:10.759207||measurement||loadtime||0:00:32.346283||0||0
+2015-11-09 07:37:10.759535||event||progress-marker||measurement-end||0||0
+2015-11-09 07:37:14.832976||measurement||ad||2015-11-09 07:36:11.608977@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:37:15.303864||measurement||ad||2015-11-09 07:36:11.608977@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||4||0
+2015-11-09 07:37:15.316573||measurement||loadtime||0:01:34.558845||4||0
+2015-11-09 07:38:00.817673||measurement||ad||2015-11-09 07:37:43.860962@|Concealed Carry Mistakes:@|www.concealedcarryconfidence.org@|The Worst Thing a Permit Holder Can Do  More Concealed Carry Tips:||4||0
+2015-11-09 07:38:01.637278||measurement||ad||2015-11-09 07:37:31.509853@|Data Mining Courses@|stanford.edu/Data-Mining@|Online Data Mining Courses, earn World-Class Credentials. Learn More||2||0
+2015-11-09 07:38:06.592175||measurement||ad||2015-11-09 07:37:43.860962@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:38:07.195387||measurement||loadtime||0:00:46.877132||4||0
+2015-11-09 07:38:07.197250||event||progress-marker||measurement-end||4||0
+2015-11-09 07:38:08.723095||measurement||ad||2015-11-09 07:37:31.509853@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||0
+2015-11-09 07:38:08.741556||measurement||loadtime||0:00:57.071239||2||0
+2015-11-09 07:38:36.312388||measurement||ad||2015-11-09 07:38:33.748680@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||0
+2015-11-09 07:38:36.394149||measurement||ad||2015-11-09 07:38:33.748680@|Data Mining Courses@|stanford.edu/Data-Mining@|Online Data Mining Courses, earn World-Class Credentials. Learn More||2||0
+2015-11-09 07:38:36.400650||measurement||loadtime||0:00:22.654322||2||0
+2015-11-09 07:38:36.400939||event||progress-marker||measurement-end||2||0
+2015-11-09 07:38:37.069825||meta||block_id end||20
+2015-11-09 07:38:37.072435||meta||block_id start||21
+2015-11-09 07:38:37.072590||meta||assignment||0@|4@|5@|1@|3@|2
+2015-11-09 07:38:40.887129||event||progress-marker||training-start||5||0
+2015-11-09 07:38:41.292250||event||progress-marker||training-start||0||0
+2015-11-09 07:38:41.360204||event||progress-marker||training-start||4||0
+2015-11-09 07:38:45.954027||treatment||google search||Buy BMW||5||0
+2015-11-09 07:38:45.968727||event||progress-marker||training-start||2||1
+2015-11-09 07:38:46.056252||event||progress-marker||training-start||1||1
+2015-11-09 07:38:46.288001||event||progress-marker||training-start||3||1
+2015-11-09 07:38:46.475869||treatment||google search||Buy BMW||4||0
+2015-11-09 07:38:47.821939||treatment||google search||Buy BMW||0||0
+2015-11-09 07:38:48.028060||error||visiting||google searchresults||5||0
+2015-11-09 07:38:48.492110||error||visiting||google searchresults||4||0
+2015-11-09 07:38:49.106784||error||visiting||google searchresults||0||0
+2015-11-09 07:38:51.146235||treatment||google search||Buy BMW||1||1
+2015-11-09 07:38:51.476955||treatment||google search||Buy BMW||3||1
+2015-11-09 07:38:51.593708||treatment||google search||Buy BMW||2||1
+2015-11-09 07:39:02.085983||error||visiting||google searchresults||1||1
+2015-11-09 07:39:02.343890||error||visiting||google searchresults||3||1
+2015-11-09 07:39:02.445388||error||visiting||google searchresults||2||1
+2015-11-09 07:39:05.060363||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 07:39:05.144651||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 07:39:06.035598||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 07:39:17.038774||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 07:39:21.271690||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||0
+2015-11-09 07:39:21.495539||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 07:39:21.891639||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 07:39:21.901456||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 07:39:23.008738||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 07:39:31.301015||error||visiting||google searchresults||0||0
+2015-11-09 07:39:31.532825||error||visiting||google searchresults||4||0
+2015-11-09 07:39:32.339727||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 07:39:33.054820||error||visiting||google searchresults||5||0
+2015-11-09 07:39:35.166038||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 07:39:37.206146||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 07:39:46.509142||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||0||0
+2015-11-09 07:39:48.358639||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||5||0
+2015-11-09 07:39:48.563307||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||4||0
+2015-11-09 07:39:52.409056||error||visiting||google searchresults||2||1
+2015-11-09 07:39:55.284489||error||visiting||google searchresults||3||1
+2015-11-09 07:39:57.291052||error||visiting||google searchresults||1||1
+2015-11-09 07:39:58.162549||treatment||google search||BMW dealer||0||0
+2015-11-09 07:39:59.108633||error||visiting||google searchresults||0||0
+2015-11-09 07:40:00.362231||treatment||google search||BMW dealer||5||0
+2015-11-09 07:40:00.621984||treatment||google search||BMW dealer||4||0
+2015-11-09 07:40:01.104242||error||visiting||google searchresults||5||0
+2015-11-09 07:40:01.230743||error||visiting||google searchresults||4||0
+2015-11-09 07:40:07.682357||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||2||1
+2015-11-09 07:40:10.201262||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||3||1
+2015-11-09 07:40:10.820503||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/testdrive.aspx||1||1
+2015-11-09 07:40:18.142185||treatment||visit page||http://www.usautomart.com/?gclid=CPSf1qeug8kCFdgVgQodCWoF0w||4||0
+2015-11-09 07:40:19.673421||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CP7i0aaug8kCFdgYgQody_wFDQ||0||0
+2015-11-09 07:40:19.820238||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||5||0
+2015-11-09 07:40:20.247885||treatment||google search||BMW dealer||2||1
+2015-11-09 07:40:22.525911||treatment||google search||BMW dealer||3||1
+2015-11-09 07:40:23.130134||treatment||google search||BMW dealer||1||1
+2015-11-09 07:40:31.423460||error||visiting||google searchresults||2||1
+2015-11-09 07:40:33.152333||treatment||visit page||http://www.usautomart.com/?gclid=CJ6K2a-ug8kCFYcbgQodIbkOIw||4||0
+2015-11-09 07:40:33.771382||error||visiting||google searchresults||3||1
+2015-11-09 07:40:34.020540||error||visiting||google searchresults||1||1
+2015-11-09 07:40:35.816814||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810||5||0
+2015-11-09 07:40:35.927774||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CI3_t7Cug8kCFVY2gQodCsIKEQ||0||0
+2015-11-09 07:40:43.182433||error||visiting||google searchresults||4||0
+2015-11-09 07:40:45.509097||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||2||1
+2015-11-09 07:40:45.988536||error||visiting||google searchresults||0||0
+2015-11-09 07:40:46.018273||error||visiting||google searchresults||5||0
+2015-11-09 07:40:48.738459||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||1||1
+2015-11-09 07:40:52.343806||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CMe6mLeug8kCFZUlgQodkSENrQ||3||1
+2015-11-09 07:40:58.227721||treatment||visit page||http://dealers.car.com/dealers/bmw?ukwid=a504797f-59a0-42f3-847d-e88ad8efd72e&udv=c&gclid=CMXU0buug8kCFUkvgQod1qsDVQ||4||0
+2015-11-09 07:41:03.347884||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||0||0
+2015-11-09 07:41:04.829538||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=COny_7yug8kCFU06gQodJ08OJw||5||0
+2015-11-09 07:41:05.526586||error||visiting||google searchresults||2||1
+2015-11-09 07:41:07.841861||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIfohsCug8kCFRMjgQodg40D8w||3||1
+2015-11-09 07:41:08.757609||error||visiting||google searchresults||1||1
+2015-11-09 07:41:09.960547||treatment||google search||BMW||4||0
+2015-11-09 07:41:10.832791||error||visiting||google searchresults||4||0
+2015-11-09 07:41:14.974101||treatment||google search||BMW||0||0
+2015-11-09 07:41:15.852171||error||visiting||google searchresults||0||0
+2015-11-09 07:41:16.513770||treatment||google search||BMW||5||0
+2015-11-09 07:41:17.502342||error||visiting||google searchresults||5||0
+2015-11-09 07:41:25.542939||error||visiting||google searchresults||2||1
+2015-11-09 07:41:27.928300||error||visiting||google searchresults||3||1
+2015-11-09 07:41:28.779231||error||visiting||google searchresults||1||1
+2015-11-09 07:41:30.178969||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 07:41:33.810578||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 07:41:35.840528||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 07:41:45.853394||treatment||visit page||http://www.carsense.com/?gclid=CNv1gNGug8kCFdgPgQodEnsOlw||3||1
+2015-11-09 07:41:47.367060||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 07:41:50.277745||treatment||visit page||http://www.bmwusa.com/||0||0
+2015-11-09 07:41:52.257476||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 07:41:54.887049||error||visiting||google searchresults||2||1
+2015-11-09 07:41:57.394993||error||visiting||google searchresults||4||0
+2015-11-09 07:41:57.795229||treatment||google search||BMW||3||1
+2015-11-09 07:41:58.324632||error||visiting||google searchresults||1||1
+2015-11-09 07:42:00.313934||error||visiting||google searchresults||0||0
+2015-11-09 07:42:02.314964||error||visiting||google searchresults||5||0
+2015-11-09 07:42:09.090623||error||visiting||google searchresults||3||1
+2015-11-09 07:42:13.222184||treatment||visit page||http://www.bmwusa.com/Standard/Content/SalesandPrograms/Offers.aspx||4||0
+2015-11-09 07:42:14.982472||error||visiting||google searchresults||2||1
+2015-11-09 07:42:18.098611||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||0
+2015-11-09 07:42:18.360712||error||visiting||google searchresults||1||1
+2015-11-09 07:42:20.797532||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 07:42:23.223142||event||progress-marker||training-end||4||0
+2015-11-09 07:42:27.049914||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 07:42:28.099516||event||progress-marker||training-end||0||0
+2015-11-09 07:42:30.799470||event||progress-marker||training-end||5||0
+2015-11-09 07:42:35.249126||error||visiting||google searchresults||2||1
+2015-11-09 07:42:38.470766||error||visiting||google searchresults||1||1
+2015-11-09 07:42:43.316216||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 07:42:55.523132||error||visiting||google searchresults||2||1
+2015-11-09 07:42:58.536916||error||visiting||google searchresults||1||1
+2015-11-09 07:43:03.433863||error||visiting||google searchresults||3||1
+2015-11-09 07:43:07.577625||treatment||google search||BMW||2||1
+2015-11-09 07:43:18.316676||treatment||google search||BMW||1||1
+2015-11-09 07:43:18.668767||error||visiting||google searchresults||2||1
+2015-11-09 07:43:20.525999||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 07:43:29.424008||error||visiting||google searchresults||1||1
+2015-11-09 07:43:30.526706||event||progress-marker||training-end||3||1
+2015-11-09 07:43:38.954236||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 07:43:43.532268||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 07:43:54.319323||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 07:43:58.982254||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 07:44:14.446897||error||visiting||google searchresults||2||1
+2015-11-09 07:44:19.098721||error||visiting||google searchresults||1||1
+2015-11-09 07:44:33.695322||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 07:44:35.971713||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 07:44:43.697248||event||progress-marker||training-end||2||1
+2015-11-09 07:44:45.972414||event||progress-marker||training-end||1||1
+2015-11-09 07:44:45.987841||event||progress-marker||measurement-start||3||1
+2015-11-09 07:44:46.561739||event||progress-marker||measurement-start||5||0
+2015-11-09 07:44:48.744648||event||progress-marker||measurement-start||2||1
+2015-11-09 07:44:48.831163||event||progress-marker||measurement-start||0||0
+2015-11-09 07:44:49.032085||event||progress-marker||measurement-start||4||0
+2015-11-09 07:44:51.027449||event||progress-marker||measurement-start||1||1
+2015-11-09 07:45:54.030431||measurement||ad||2015-11-09 07:45:34.505906@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:45:55.445469||measurement||ad||2015-11-09 07:45:52.498725@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:45:56.801211||measurement||ad||2015-11-09 07:45:52.498725@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||1
+2015-11-09 07:45:56.832011||measurement||loadtime||0:01:03.086614||2||1
+2015-11-09 07:45:59.855966||measurement||ad||2015-11-09 07:45:34.505906@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:46:00.167480||measurement||loadtime||0:01:06.134844||4||0
+2015-11-09 07:46:02.047743||measurement||ad||2015-11-09 07:45:57.838091@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 07:46:03.534331||measurement||ad||2015-11-09 07:45:56.701259@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||3||1
+2015-11-09 07:46:05.671290||measurement||ad||2015-11-09 07:45:57.838091@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 07:46:05.930105||measurement||loadtime||0:01:09.901071||1||1
+2015-11-09 07:46:06.332051||measurement||ad||2015-11-09 07:45:56.701259@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 07:46:06.604399||measurement||loadtime||0:01:15.614407||3||1
+2015-11-09 07:46:20.631929||measurement||ad||2015-11-09 07:45:59.818703@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||0||0
+2015-11-09 07:46:28.973773||measurement||ad||2015-11-09 07:45:59.818703@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-09 07:46:29.403361||measurement||loadtime||0:01:35.571030||0||0
+2015-11-09 07:46:44.912417||measurement||ad||2015-11-09 07:45:54.698633@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||0
+2015-11-09 07:46:56.191533||measurement||ad||2015-11-09 07:46:35.102582@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:46:57.348474||measurement||ad||2015-11-09 07:46:52.790987@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:46:57.804717||measurement||ad||2015-11-09 07:45:54.698633@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:46:59.561708||measurement||ad||2015-11-09 07:46:35.102582@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:46:59.796348||measurement||loadtime||0:00:54.627967||4||0
+2015-11-09 07:46:59.804428||measurement||loadtime||0:02:08.241854||5||0
+2015-11-09 07:47:02.567894||measurement||ad||2015-11-09 07:46:52.790987@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||1
+2015-11-09 07:47:04.002093||measurement||loadtime||0:01:02.169422||2||1
+2015-11-09 07:47:06.510573||measurement||ad||2015-11-09 07:47:00.980536@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 07:47:10.176953||measurement||ad||2015-11-09 07:47:00.980536@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:47:10.488128||measurement||ad||2015-11-09 07:47:04.617845@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 07:47:10.882286||measurement||loadtime||0:00:59.277175||3||1
+2015-11-09 07:47:14.145130||measurement||ad||2015-11-09 07:47:04.617845@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 07:47:14.729962||measurement||loadtime||0:01:03.799317||1||1
+2015-11-09 07:47:45.851038||measurement||ad||2015-11-09 07:47:34.347381@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:47:51.232081||measurement||ad||2015-11-09 07:47:34.347381@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:47:51.349154||measurement||loadtime||0:00:46.551154||4||0
+2015-11-09 07:48:07.672929||measurement||ad||2015-11-09 07:47:25.764311@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||0||0
+2015-11-09 07:48:09.699757||error||collecting ads||Error||2||1
+2015-11-09 07:48:09.829542||measurement||ad||2015-11-09 07:47:25.764311@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-09 07:48:10.156007||measurement||loadtime||0:01:35.752005||0||0
+2015-11-09 07:48:19.769213||measurement||ad||2015-11-09 07:48:10.803345@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||3||1
+2015-11-09 07:48:20.046122||error||collecting ads||Error||1||1
+2015-11-09 07:48:20.332575||measurement||ad||2015-11-09 07:48:10.803345@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 07:48:20.564845||measurement||loadtime||0:01:04.681485||3||1
+2015-11-09 07:48:35.429501||measurement||ad||2015-11-09 07:48:01.775676@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||0
+2015-11-09 07:48:37.898328||measurement||ad||2015-11-09 07:48:01.775676@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:48:37.953283||measurement||loadtime||0:01:33.147205||5||0
+2015-11-09 07:48:40.938930||measurement||ad||2015-11-09 07:48:37.476435@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:48:43.525485||measurement||ad||2015-11-09 07:48:37.476435@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||2||1
+2015-11-09 07:48:43.945761||measurement||loadtime||0:00:29.243699||2||1
+2015-11-09 07:48:50.210688||measurement||ad||2015-11-09 07:48:32.453196@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:48:54.130032||measurement||ad||2015-11-09 07:48:32.453196@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:48:54.555883||measurement||loadtime||0:00:58.205653||4||0
+2015-11-09 07:49:06.493813||measurement||loadtime||0:00:41.443389||1||1
+2015-11-09 07:49:16.824260||error||collecting ads||Error||0||0
+2015-11-09 07:49:27.218718||error||collecting ads||Error||3||1
+2015-11-09 07:49:45.183767||measurement||ad||2015-11-09 07:49:38.786781@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:49:46.784602||measurement||ad||2015-11-09 07:49:38.786781@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||2||1
+2015-11-09 07:49:47.231274||measurement||loadtime||0:00:58.284687||2||1
+2015-11-09 07:50:00.100243||measurement||ad||2015-11-09 07:49:52.394370@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 07:50:00.691072||measurement||ad||2015-11-09 07:49:32.431621@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:50:01.748656||measurement||ad||2015-11-09 07:49:32.431621@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:50:01.805617||measurement||loadtime||0:01:02.248497||4||0
+2015-11-09 07:50:05.219610||measurement||ad||2015-11-09 07:49:52.394370@|Don't Invest in the Euro@|wallstreetdaily.com/Free-Report@|The Dollar And Euro Are Doomed. These 3 Currencies Will Take Over.||3||1
+2015-11-09 07:50:05.479895||measurement||loadtime||0:00:33.259129||3||1
+2015-11-09 07:50:16.326883||measurement||ad||2015-11-09 07:50:14.559622@|Want Rapid Weight Loss?@|thyroid-weight-loss.com@|Power-Boost Your Metabolism With A A Simple Thyroid Fix! Learn More.||1||1
+2015-11-09 07:50:17.420299||measurement||ad||2015-11-09 07:50:14.559622@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 07:50:17.652911||measurement||ad||2015-11-09 07:50:04.431372@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||0||0
+2015-11-09 07:50:17.754444||measurement||loadtime||0:01:06.259655||1||1
+2015-11-09 07:50:24.439909||measurement||ad||2015-11-09 07:50:04.431372@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-09 07:50:25.239892||measurement||loadtime||0:01:03.414340||0||0
+2015-11-09 07:50:29.636906||measurement||ad||2015-11-09 07:49:27.146959@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 07:50:32.503260||measurement||ad||2015-11-09 07:49:27.146959@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:50:32.602998||measurement||loadtime||0:01:49.649124||5||0
+2015-11-09 07:50:35.287866||measurement||ad||2015-11-09 07:50:29.836591@|Filing Taxes@|shopperstop.us/Filing-Taxes@|Find Filing Taxes  Save Big Get All Information Here !||2||1
+2015-11-09 07:50:38.890628||measurement||ad||2015-11-09 07:50:29.836591@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:50:39.164150||measurement||loadtime||0:00:46.931415||2||1
+2015-11-09 07:50:45.630397||measurement||ad||2015-11-09 07:50:33.133949@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:50:47.010135||measurement||ad||2015-11-09 07:50:33.133949@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:50:47.041968||measurement||loadtime||0:00:40.235846||4||0
+2015-11-09 07:51:07.226037||measurement||ad||2015-11-09 07:51:02.568093@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 07:51:07.356090||measurement||ad||2015-11-09 07:50:59.409278@|Top Selling Annuity@|advisorworld.com/Nov-Report@|Best Performing Annuities this Year November Report Now Available||3||1
+2015-11-09 07:51:07.643486||measurement||ad||2015-11-09 07:50:59.409278@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:51:08.054872||measurement||loadtime||0:00:57.573594||3||1
+2015-11-09 07:51:08.389632||measurement||ad||2015-11-09 07:51:02.568093@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 07:51:08.805402||measurement||loadtime||0:00:46.048682||1||1
+2015-11-09 07:51:31.824476||measurement||ad||2015-11-09 07:51:26.672408@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:51:35.315824||measurement||ad||2015-11-09 07:51:26.672408@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 07:51:35.498873||measurement||loadtime||0:00:51.333301||2||1
+2015-11-09 07:51:40.763613||measurement||ad||2015-11-09 07:51:14.069022@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||0||0
+2015-11-09 07:51:45.056899||measurement||ad||2015-11-09 07:51:14.069022@|Medicare Part D Plans@|medicare2015.org/Part-D-Options@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||0
+2015-11-09 07:51:45.635345||measurement||loadtime||0:01:15.394585||0||0
+2015-11-09 07:52:08.901067||measurement||ad||2015-11-09 07:51:41.366019@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 07:52:12.241704||measurement||ad||2015-11-09 07:51:41.366019@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:52:12.543427||measurement||loadtime||0:01:34.939681||5||0
+2015-11-09 07:52:15.166784||measurement||ad||2015-11-09 07:52:06.722102@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 07:52:15.464028||measurement||ad||2015-11-09 07:52:06.722102@|Free Meditation Audio@|omharmonics.com/Free-Meditation@|Experience Deep Meditation In Min Download Your Free Meditation Audio||1||1
+2015-11-09 07:52:15.476678||measurement||loadtime||0:01:01.670812||1||1
+2015-11-09 07:52:15.963271||measurement||ad||2015-11-09 07:52:09.531238@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 07:52:16.235344||measurement||ad||2015-11-09 07:51:28.506692@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:52:16.640156||measurement||ad||2015-11-09 07:51:28.506692@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:52:16.646448||measurement||loadtime||0:01:24.603882||4||0
+2015-11-09 07:52:16.769397||measurement||ad||2015-11-09 07:52:09.531238@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:52:16.782876||measurement||loadtime||0:01:03.726091||3||1
+2015-11-09 07:52:27.260249||measurement||ad||2015-11-09 07:52:24.583169@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 07:52:29.427430||measurement||ad||2015-11-09 07:52:24.583169@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:52:30.029967||measurement||loadtime||0:00:49.530264||2||1
+2015-11-09 07:52:48.144678||measurement||ad||2015-11-09 07:52:34.569826@|Treating Toenail Fungus@|www.treat-my-toenails.com@|Learn How To Treat Yellow Toenails With An Rx Toenail Fungus Treatment||0||0
+2015-11-09 07:52:55.653057||measurement||ad||2015-11-09 07:52:34.569826@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||0
+2015-11-09 07:52:56.416191||measurement||loadtime||0:01:05.779800||0||0
+2015-11-09 07:53:19.721327||measurement||ad||2015-11-09 07:53:10.763767@|3 Bureau Credit Scores@|freescore360.com@|View Your Latest Credit Scores From All 3 Bureaus in Just 60 Seconds!||3||1
+2015-11-09 07:53:20.092386||measurement||ad||2015-11-09 07:53:10.763767@|Understanding Options@|thestockmarketwatch.com/Options@|Learn Options Trading Basics with 11 Free Video Lessons.||3||1
+2015-11-09 07:53:20.112122||measurement||loadtime||0:00:58.327678||3||1
+2015-11-09 07:53:30.975516||measurement||ad||2015-11-09 07:52:51.174622@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||0
+2015-11-09 07:53:32.175517||measurement||ad||2015-11-09 07:52:51.174622@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:53:32.564636||measurement||loadtime||0:01:15.019734||5||0
+2015-11-09 07:53:32.917786||measurement||ad||2015-11-09 07:53:24.056828@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 07:53:34.453559||measurement||ad||2015-11-09 07:53:24.056828@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 07:53:35.143226||measurement||ad||2015-11-09 07:53:31.877769@|Filing Taxes@|shopperstop.us/Filing-Taxes@|Find Filing Taxes  Save Big Get All Information Here !||2||1
+2015-11-09 07:53:35.754254||measurement||loadtime||0:01:15.276052||1||1
+2015-11-09 07:53:37.166649||measurement||ad||2015-11-09 07:53:31.877769@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:53:37.253079||measurement||loadtime||0:01:02.222319||2||1
+2015-11-09 07:53:50.155212||measurement||ad||2015-11-09 07:53:01.944760@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 07:53:56.060729||measurement||ad||2015-11-09 07:53:01.944760@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 07:53:56.356215||measurement||loadtime||0:01:34.708275||4||0
+2015-11-09 07:54:03.378390||error||collecting ads||Error||0||0
+2015-11-09 07:54:33.093044||measurement||ad||2015-11-09 07:54:29.481218@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||1||1
+2015-11-09 07:54:33.573675||measurement||ad||2015-11-09 07:54:20.313726@|Don't Invest in the Dinar@|wallstreetdaily.com/Top-Currencies@|Major Revaluation Imminent… BUT It's Not Our Top Pick. This One Is…||3||1
+2015-11-09 07:54:33.940813||measurement||ad||2015-11-09 07:54:29.481218@|Want Rapid Weight Loss?@|thyroid-weight-loss.com@|Power-Boost Your Metabolism With A A Simple Thyroid Fix! Learn More.||1||1
+2015-11-09 07:54:34.155678||measurement||loadtime||0:00:53.400641||1||1
+2015-11-09 07:54:38.283733||measurement||ad||2015-11-09 07:54:20.313726@|Obamacare Plans@|www.individualhealthquotes.com@|Open Enrollment is Back! Get Covered For 2016 - Start Here.||3||1
+2015-11-09 07:54:39.068436||measurement||loadtime||0:01:13.955241||3||1
+2015-11-09 07:54:39.906079||measurement||ad||2015-11-09 07:54:34.695791@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 07:54:40.126152||measurement||ad||2015-11-09 07:54:34.695791@|Purva Bluemont Kochi@|puravankara.com/3_BHK_Flats_Kochi@|Buy 2/3BHK Flats @Purva Bluemont. Special Offer Price Start @65 lakh!||2||1
+2015-11-09 07:54:40.137875||measurement||loadtime||0:00:57.884142||2||1
+2015-11-09 07:54:40.145831||event||progress-marker||measurement-end||2||1
+2015-11-09 07:54:55.889849||measurement||ad||2015-11-09 07:54:27.954823@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||5||0
+2015-11-09 07:54:58.588627||measurement||ad||2015-11-09 07:54:27.954823@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:55:00.266655||measurement||loadtime||0:01:22.701462||5||0
+2015-11-09 07:55:05.239582||error||collecting ads||Error||4||0
+2015-11-09 07:55:23.996011||measurement||ad||2015-11-09 07:55:21.642650@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 07:55:25.232560||measurement||ad||2015-11-09 07:55:21.642650@|5 Foods That Hurt Liver@|perfectorigins.com/5Foods.php@|Watch and learn the 5 damaging foods for your liver  weight.||1||1
+2015-11-09 07:55:25.584472||measurement||loadtime||0:00:46.427450||1||1
+2015-11-09 07:55:25.587659||event||progress-marker||measurement-end||1||1
+2015-11-09 07:55:36.767930||measurement||ad||2015-11-09 07:55:01.984372@|Medicare Part D Plans@|medicare2015.org/Part-D-Options@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||0
+2015-11-09 07:55:37.796481||measurement||ad||2015-11-09 07:55:01.984372@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||0||0
+2015-11-09 07:55:37.910868||measurement||loadtime||0:01:29.531642||0||0
+2015-11-09 07:55:42.627632||measurement||ad||2015-11-09 07:55:36.779204@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||3||1
+2015-11-09 07:55:43.633435||measurement||ad||2015-11-09 07:55:36.779204@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||3||1
+2015-11-09 07:55:43.865674||measurement||loadtime||0:00:59.796461||3||1
+2015-11-09 07:55:43.867101||event||progress-marker||measurement-end||3||1
+2015-11-09 07:55:51.088568||measurement||ad||2015-11-09 07:55:42.568927@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||4||0
+2015-11-09 07:55:51.395951||measurement||ad||2015-11-09 07:55:42.568927@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 07:55:51.485272||measurement||loadtime||0:00:41.244790||4||0
+2015-11-09 07:55:51.485618||event||progress-marker||measurement-end||4||0
+2015-11-09 07:56:04.698973||measurement||ad||2015-11-09 07:55:55.072375@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:56:05.042901||measurement||ad||2015-11-09 07:55:55.072375@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 07:56:05.062894||measurement||loadtime||0:00:59.795322||5||0
+2015-11-09 07:56:13.011846||measurement||ad||2015-11-09 07:56:09.117990@|Medicare Part D Plans@|medicare2015.org/Part-D-Options@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||0
+2015-11-09 07:56:13.131422||measurement||ad||2015-11-09 07:56:09.117990@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||0||0
+2015-11-09 07:56:13.145731||measurement||loadtime||0:00:30.233565||0||0
+2015-11-09 07:56:31.491969||measurement||ad||2015-11-09 07:56:27.358606@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:56:31.654547||measurement||ad||2015-11-09 07:56:27.358606@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 07:56:31.688208||measurement||loadtime||0:00:21.624450||5||0
+2015-11-09 07:56:40.696316||measurement||ad||2015-11-09 07:56:37.056396@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||0
+2015-11-09 07:56:40.845722||measurement||ad||2015-11-09 07:56:37.056396@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||0||0
+2015-11-09 07:56:40.850881||measurement||loadtime||0:00:22.704020||0||0
+2015-11-09 07:56:40.851314||event||progress-marker||measurement-end||0||0
+2015-11-09 07:57:02.093475||measurement||ad||2015-11-09 07:56:56.715421@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 07:57:02.421185||measurement||ad||2015-11-09 07:56:56.715421@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:57:02.442166||measurement||loadtime||0:00:25.753182||5||0
+2015-11-09 07:57:33.819048||measurement||ad||2015-11-09 07:57:28.020320@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 07:57:33.923061||measurement||ad||2015-11-09 07:57:28.020320@|Win $25,000 Sweepstakes@|www.bhg.com/Sweepstakes@|$25,000 Home Sweepstakes - Contest Ends Soon - Enter Daily!||5||0
+2015-11-09 07:57:33.930930||measurement||loadtime||0:00:26.487325||5||0
+2015-11-09 07:57:33.931150||event||progress-marker||measurement-end||5||0
+2015-11-09 07:57:34.702503||meta||block_id end||21
+2015-11-09 07:57:34.704394||meta||block_id start||22
+2015-11-09 07:57:34.704495||meta||assignment||4@|5@|1@|0@|2@|3
+2015-11-09 07:57:38.711611||event||progress-marker||training-start||5||0
+2015-11-09 07:57:38.785246||event||progress-marker||training-start||1||0
+2015-11-09 07:57:38.868328||event||progress-marker||training-start||4||0
+2015-11-09 07:57:43.454407||event||progress-marker||training-start||3||1
+2015-11-09 07:57:43.510379||event||progress-marker||training-start||2||1
+2015-11-09 07:57:44.064891||treatment||google search||Buy BMW||4||0
+2015-11-09 07:57:44.196022||treatment||google search||Buy BMW||5||0
+2015-11-09 07:57:44.431879||event||progress-marker||training-start||0||1
+2015-11-09 07:57:45.267640||treatment||google search||Buy BMW||1||0
+2015-11-09 07:57:46.130730||error||visiting||google searchresults||4||0
+2015-11-09 07:57:46.187282||error||visiting||google searchresults||5||0
+2015-11-09 07:57:47.044963||error||visiting||google searchresults||1||0
+2015-11-09 07:57:49.239273||treatment||google search||Buy BMW||3||1
+2015-11-09 07:57:49.565281||treatment||google search||Buy BMW||0||1
+2015-11-09 07:57:49.717496||treatment||google search||Buy BMW||2||1
+2015-11-09 07:58:00.375041||error||visiting||google searchresults||3||1
+2015-11-09 07:58:00.502152||error||visiting||google searchresults||0||1
+2015-11-09 07:58:00.659771||error||visiting||google searchresults||2||1
+2015-11-09 07:58:02.921156||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 07:58:03.145319||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 07:58:05.488028||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 07:58:15.003276||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 07:58:15.200335||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 07:58:18.965675||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 07:58:19.265037||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||0
+2015-11-09 07:58:19.947915||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 07:58:20.755049||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 07:58:28.637774||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 07:58:29.315849||error||visiting||google searchresults||1||0
+2015-11-09 07:58:30.000739||error||visiting||google searchresults||5||0
+2015-11-09 07:58:30.443220||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 07:58:30.808028||error||visiting||google searchresults||4||0
+2015-11-09 07:58:32.273325||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||1
+2015-11-09 07:58:44.721165||treatment||visit page||http://www.bmwpittsburgh.com/Dealer/default.aspx||1||0
+2015-11-09 07:58:45.137571||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||5||0
+2015-11-09 07:58:46.200242||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||4||0
+2015-11-09 07:58:48.708728||error||visiting||google searchresults||2||1
+2015-11-09 07:58:50.495179||error||visiting||google searchresults||0||1
+2015-11-09 07:58:52.372424||error||visiting||google searchresults||3||1
+2015-11-09 07:58:56.858131||treatment||google search||BMW dealer||1||0
+2015-11-09 07:58:56.917968||treatment||google search||BMW dealer||5||0
+2015-11-09 07:58:57.729656||error||visiting||google searchresults||1||0
+2015-11-09 07:58:57.777521||error||visiting||google searchresults||5||0
+2015-11-09 07:58:58.374294||treatment||google search||BMW dealer||4||0
+2015-11-09 07:58:59.130690||error||visiting||google searchresults||4||0
+2015-11-09 07:59:04.012114||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||0||1
+2015-11-09 07:59:05.856376||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||3||1
+2015-11-09 07:59:06.347851||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 07:59:15.800202||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||1||0
+2015-11-09 07:59:16.757934||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||4||0
+2015-11-09 07:59:17.972173||treatment||google search||BMW dealer||0||1
+2015-11-09 07:59:19.217775||treatment||google search||BMW dealer||3||1
+2015-11-09 07:59:19.572652||treatment||google search||BMW dealer||2||1
+2015-11-09 07:59:29.058384||error||visiting||google searchresults||0||1
+2015-11-09 07:59:29.821828||error||visiting||google searchresults||3||1
+2015-11-09 07:59:30.433566||error||visiting||google searchresults||2||1
+2015-11-09 07:59:31.601660||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810||1||0
+2015-11-09 07:59:32.303315||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810||4||0
+2015-11-09 07:59:41.679873||error||visiting||google searchresults||1||0
+2015-11-09 07:59:42.357047||error||visiting||google searchresults||4||0
+2015-11-09 07:59:43.619722||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||0||1
+2015-11-09 07:59:45.117733||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||2||1
+2015-11-09 07:59:46.618787||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CKjh99Syg8kCFRMjgQodg40D8w||3||1
+2015-11-09 07:59:47.862260||error||visiting||google searchresults||5||0
+2015-11-09 07:59:56.492035||treatment||visit page||https://www.usaa.com/inet/pages/auto_maintain_main?adid=icgsch88584437-VQ16-c-VQ14-73306263-VQ6-71531483810||1||0
+2015-11-09 07:59:57.661616||treatment||visit page||https://www.usaa.com/inet/pages/auto_maintain_main?adid=icgsch88584437-VQ16-c-VQ14-73306263-VQ6-71531483810||4||0
+2015-11-09 08:00:00.692591||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CIGa89yyg8kCFRMjgQodg40D8w||3||1
+2015-11-09 08:00:03.639187||error||visiting||google searchresults||0||1
+2015-11-09 08:00:05.140044||error||visiting||google searchresults||2||1
+2015-11-09 08:00:07.903132||error||visiting||google searchresults||5||0
+2015-11-09 08:00:08.196613||treatment||google search||BMW||1||0
+2015-11-09 08:00:09.251382||error||visiting||google searchresults||1||0
+2015-11-09 08:00:09.621229||treatment||google search||BMW||4||0
+2015-11-09 08:00:10.536828||error||visiting||google searchresults||4||0
+2015-11-09 08:00:20.762476||error||visiting||google searchresults||3||1
+2015-11-09 08:00:23.649945||error||visiting||google searchresults||0||1
+2015-11-09 08:00:25.155297||error||visiting||google searchresults||2||1
+2015-11-09 08:00:27.388733||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 08:00:27.927074||error||visiting||google searchresults||5||0
+2015-11-09 08:00:29.566895||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 08:00:35.072141||treatment||visit page||https://www.usaa.com/inet/pages/car_buying_services_products?adid=icgsch88584437-VQ16-c-VQ6-71531483810&akredirect=true||3||1
+2015-11-09 08:00:43.669499||error||visiting||google searchresults||0||1
+2015-11-09 08:00:43.818392||treatment||visit page||http://www.bmwusa.com/||1||0
+2015-11-09 08:00:45.853584||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 08:00:47.334812||treatment||google search||BMW||3||1
+2015-11-09 08:00:47.962915||error||visiting||google searchresults||5||0
+2015-11-09 08:00:53.882123||error||visiting||google searchresults||1||0
+2015-11-09 08:00:54.468699||error||visiting||google searchresults||2||1
+2015-11-09 08:00:55.890792||error||visiting||google searchresults||4||0
+2015-11-09 08:00:58.546171||error||visiting||google searchresults||3||1
+2015-11-09 08:01:03.682929||error||visiting||google searchresults||0||1
+2015-11-09 08:01:07.973463||error||visiting||google searchresults||5||0
+2015-11-09 08:01:12.080174||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||0
+2015-11-09 08:01:14.752402||error||visiting||google searchresults||2||1
+2015-11-09 08:01:15.232045||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 08:01:16.334387||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 08:01:19.760972||treatment||google search||BMW||5||0
+2015-11-09 08:01:20.769475||error||visiting||google searchresults||5||0
+2015-11-09 08:01:22.081909||event||progress-marker||training-end||1||0
+2015-11-09 08:01:23.709246||error||visiting||google searchresults||0||1
+2015-11-09 08:01:25.233796||event||progress-marker||training-end||4||0
+2015-11-09 08:01:32.021959||treatment||visit page||http://www.bmwusa.com/||3||1
+2015-11-09 08:01:35.013421||error||visiting||google searchresults||2||1
+2015-11-09 08:01:39.700307||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 08:01:43.720924||error||visiting||google searchresults||0||1
+2015-11-09 08:01:52.149589||error||visiting||google searchresults||3||1
+2015-11-09 08:01:55.744018||treatment||google search||BMW||0||1
+2015-11-09 08:01:55.774787||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 08:02:03.224964||error||visiting||google searchresults||2||1
+2015-11-09 08:02:05.827722||error||visiting||google searchresults||5||0
+2015-11-09 08:02:06.720907||error||visiting||google searchresults||0||1
+2015-11-09 08:02:09.218971||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||1
+2015-11-09 08:02:16.506220||treatment||google search||BMW||2||1
+2015-11-09 08:02:19.219610||event||progress-marker||training-end||3||1
+2015-11-09 08:02:24.134014||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 08:02:25.357649||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 08:02:28.470434||error||visiting||google searchresults||2||1
+2015-11-09 08:02:35.359262||event||progress-marker||training-end||5||0
+2015-11-09 08:02:39.704504||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 08:02:46.996229||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 08:02:59.837162||error||visiting||google searchresults||0||1
+2015-11-09 08:03:02.959441||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 08:03:18.294328||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 08:03:23.040244||error||visiting||google searchresults||2||1
+2015-11-09 08:03:28.295576||event||progress-marker||training-end||0||1
+2015-11-09 08:03:38.359244||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 08:03:48.361083||event||progress-marker||training-end||2||1
+2015-11-09 08:03:48.439797||event||progress-marker||measurement-start||0||1
+2015-11-09 08:03:49.776003||event||progress-marker||measurement-start||3||1
+2015-11-09 08:03:50.804437||event||progress-marker||measurement-start||5||0
+2015-11-09 08:03:51.111980||event||progress-marker||measurement-start||4||0
+2015-11-09 08:03:52.972794||event||progress-marker||measurement-start||1||0
+2015-11-09 08:03:53.411146||event||progress-marker||measurement-start||2||1
+2015-11-09 08:04:42.337540||measurement||ad||2015-11-09 08:04:35.175167@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 08:04:45.168022||measurement||ad||2015-11-09 08:04:35.175167@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 08:04:45.201686||measurement||loadtime||0:00:51.760060||0||1
+2015-11-09 08:04:54.928148||measurement||ad||2015-11-09 08:04:51.366297@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:04:55.220579||measurement||ad||2015-11-09 08:04:51.366297@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:04:55.238196||measurement||loadtime||0:00:56.825964||2||1
+2015-11-09 08:05:02.355261||measurement||ad||2015-11-09 08:04:56.872176@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:05:05.133449||measurement||ad||2015-11-09 08:04:56.872176@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 08:05:06.090591||measurement||loadtime||0:01:11.314002||3||1
+2015-11-09 08:05:16.872264||measurement||ad||2015-11-09 08:04:52.575576@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 08:05:20.607656||measurement||ad||2015-11-09 08:04:52.575576@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||1||0
+2015-11-09 08:05:20.861830||measurement||loadtime||0:01:22.887839||1||0
+2015-11-09 08:05:29.979069||measurement||ad||2015-11-09 08:05:00.796228@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 08:05:31.521759||measurement||ad||2015-11-09 08:05:00.796228@|Custom Villa in Bangalore@|qvcrealty.bestindiaproperties.com@|Less than 3 homes per acre Prices starting at 2.15 crore||4||0
+2015-11-09 08:05:31.689841||measurement||loadtime||0:01:35.576967||4||0
+2015-11-09 08:05:48.258168||measurement||ad||2015-11-09 08:05:02.204386@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 08:05:49.269146||measurement||ad||2015-11-09 08:05:42.751021@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 08:05:50.637626||measurement||ad||2015-11-09 08:05:42.751021@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||0||1
+2015-11-09 08:05:50.676611||measurement||loadtime||0:01:00.472863||0||1
+2015-11-09 08:05:50.746115||measurement||ad||2015-11-09 08:05:02.204386@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:05:50.803397||measurement||loadtime||0:01:54.997438||5||0
+2015-11-09 08:06:04.590348||measurement||ad||2015-11-09 08:06:03.434907@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:06:05.002855||measurement||ad||2015-11-09 08:06:03.434907@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||1
+2015-11-09 08:06:05.019680||measurement||loadtime||0:00:53.927300||3||1
+2015-11-09 08:06:08.213311||measurement||ad||2015-11-09 08:05:59.378817@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||1||0
+2015-11-09 08:06:08.505096||measurement||ad||2015-11-09 08:05:59.378817@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 08:06:08.509957||measurement||loadtime||0:00:42.646569||1||0
+2015-11-09 08:06:09.758980||measurement||ad||2015-11-09 08:06:08.682965@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 08:06:10.389771||measurement||ad||2015-11-09 08:06:08.682965@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:06:10.587908||measurement||loadtime||0:01:10.347952||2||1
+2015-11-09 08:06:46.118078||measurement||ad||2015-11-09 08:06:44.080153@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 08:06:46.751362||measurement||ad||2015-11-09 08:06:44.080153@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 08:06:46.874161||measurement||loadtime||0:00:51.196081||0||1
+2015-11-09 08:06:52.782209||measurement||ad||2015-11-09 08:06:49.638112@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:06:53.217895||measurement||ad||2015-11-09 08:06:49.638112@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:06:53.725640||measurement||loadtime||0:00:43.705461||3||1
+2015-11-09 08:06:55.890332||measurement||ad||2015-11-09 08:06:53.731488@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:06:55.997924||measurement||ad||2015-11-09 08:06:53.731488@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:06:56.149088||measurement||loadtime||0:00:40.560454||2||1
+2015-11-09 08:06:58.307620||measurement||ad||2015-11-09 08:06:44.175678@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 08:06:59.058068||measurement||ad||2015-11-09 08:06:44.175678@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||1||0
+2015-11-09 08:06:59.074520||measurement||loadtime||0:00:45.562730||1||0
+2015-11-09 08:07:02.633798||measurement||ad||2015-11-09 08:06:47.535161@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:07:04.063296||measurement||ad||2015-11-09 08:06:26.138213@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 08:07:05.374228||measurement||ad||2015-11-09 08:06:26.138213@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:07:05.570668||measurement||loadtime||0:01:28.879782||4||0
+2015-11-09 08:07:11.023547||measurement||ad||2015-11-09 08:06:47.535161@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:07:11.527597||measurement||loadtime||0:01:15.723385||5||0
+2015-11-09 08:07:36.372563||measurement||ad||2015-11-09 08:07:26.076359@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 08:07:36.891916||measurement||ad||2015-11-09 08:07:26.076359@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 08:07:36.939397||measurement||loadtime||0:00:32.863503||1||0
+2015-11-09 08:07:37.797240||measurement||ad||2015-11-09 08:07:36.724865@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 08:07:38.043548||measurement||ad||2015-11-09 08:07:36.724865@|5 Foods That Hurt Liver@|perfectorigins.com/5Foods.php@|Watch and learn the 5 damaging foods for your liver  weight.||0||1
+2015-11-09 08:07:38.110545||measurement||loadtime||0:00:46.235887||0||1
+2015-11-09 08:07:40.508157||measurement||ad||2015-11-09 08:07:39.504741@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:07:40.888045||measurement||ad||2015-11-09 08:07:39.504741@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:07:41.134188||measurement||loadtime||0:00:42.407153||3||1
+2015-11-09 08:07:48.949629||measurement||ad||2015-11-09 08:07:47.709255@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||2||1
+2015-11-09 08:07:49.335860||measurement||ad||2015-11-09 08:07:47.709255@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:07:49.461517||measurement||loadtime||0:00:48.311722||2||1
+2015-11-09 08:08:01.637193||measurement||ad||2015-11-09 08:07:45.581191@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 08:08:03.415305||measurement||ad||2015-11-09 08:07:45.581191@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:08:03.430209||measurement||loadtime||0:00:52.856944||4||0
+2015-11-09 08:08:10.030603||measurement||ad||2015-11-09 08:07:56.018112@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:08:15.194933||measurement||ad||2015-11-09 08:08:04.685712@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||1||0
+2015-11-09 08:08:15.547716||measurement||ad||2015-11-09 08:08:04.685712@|Data Mining Courses@|stanford.edu/Data-Mining@|Online Data Mining Courses, earn World-Class Credentials. Learn More||1||0
+2015-11-09 08:08:15.553052||measurement||loadtime||0:00:33.612614||1||0
+2015-11-09 08:08:18.025667||measurement||ad||2015-11-09 08:07:56.018112@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:08:18.098891||measurement||loadtime||0:01:01.570678||5||0
+2015-11-09 08:08:38.463757||measurement||ad||2015-11-09 08:08:35.497136@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:08:39.445071||measurement||ad||2015-11-09 08:08:35.497136@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:08:39.466556||measurement||loadtime||0:00:53.331562||3||1
+2015-11-09 08:08:40.678317||measurement||ad||2015-11-09 08:08:36.364400@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 08:08:41.165725||measurement||ad||2015-11-09 08:08:36.364400@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 08:08:41.329717||measurement||loadtime||0:00:58.217716||0||1
+2015-11-09 08:08:48.695471||measurement||ad||2015-11-09 08:08:42.813427@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 08:08:48.862850||measurement||ad||2015-11-09 08:08:42.813427@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||1||0
+2015-11-09 08:08:48.870855||measurement||loadtime||0:00:28.317032||1||0
+2015-11-09 08:08:52.101690||measurement||ad||2015-11-09 08:08:46.854754@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:08:52.397120||measurement||ad||2015-11-09 08:08:46.854754@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:08:52.442885||measurement||loadtime||0:00:57.980845||2||1
+2015-11-09 08:09:28.161323||measurement||ad||2015-11-09 08:08:56.384001@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:09:29.929032||measurement||ad||2015-11-09 08:09:02.750878@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 08:09:30.705786||measurement||ad||2015-11-09 08:08:56.384001@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:09:30.721225||measurement||loadtime||0:01:07.620751||5||0
+2015-11-09 08:09:35.145597||measurement||ad||2015-11-09 08:09:02.750878@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:09:35.153305||measurement||loadtime||0:01:26.722477||4||0
+2015-11-09 08:09:43.105157||measurement||ad||2015-11-09 08:09:42.378236@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||0||1
+2015-11-09 08:09:43.432762||measurement||ad||2015-11-09 08:09:42.378236@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 08:09:43.634721||measurement||loadtime||0:00:57.303218||0||1
+2015-11-09 08:09:47.235875||measurement||ad||2015-11-09 08:09:45.778838@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:09:47.431634||measurement||ad||2015-11-09 08:09:45.778838@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:09:47.445505||measurement||loadtime||0:01:02.978410||3||1
+2015-11-09 08:09:50.037798||measurement||ad||2015-11-09 08:09:48.829341@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||2||1
+2015-11-09 08:09:50.660318||measurement||ad||2015-11-09 08:09:48.829341@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:09:50.686551||measurement||loadtime||0:00:53.243019||2||1
+2015-11-09 08:10:04.689915||measurement||ad||2015-11-09 08:09:39.977367@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 08:10:08.751832||measurement||ad||2015-11-09 08:09:39.977367@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||1||0
+2015-11-09 08:10:08.780908||measurement||loadtime||0:01:14.908544||1||0
+2015-11-09 08:10:38.393014||error||collecting ads||Error||5||0
+2015-11-09 08:10:48.326226||measurement||ad||2015-11-09 08:10:46.844377@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:10:48.546250||measurement||ad||2015-11-09 08:10:46.844377@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:10:48.560037||measurement||loadtime||0:00:56.113669||3||1
+2015-11-09 08:10:48.800579||error||collecting ads||Error||0||1
+2015-11-09 08:10:56.147203||error||collecting ads||Error||2||1
+2015-11-09 08:10:56.535237||measurement||ad||2015-11-09 08:10:25.802802@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 08:10:59.254598||measurement||ad||2015-11-09 08:10:25.802802@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 08:10:59.581064||measurement||loadtime||0:01:19.427165||4||0
+2015-11-09 08:11:14.247508||measurement||ad||2015-11-09 08:11:13.288809@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 08:11:14.415449||measurement||ad||2015-11-09 08:11:13.288809@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:11:14.432827||measurement||loadtime||0:00:13.284130||2||1
+2015-11-09 08:11:16.657629||error||collecting ads||Error||1||0
+2015-11-09 08:11:30.313859||measurement||ad||2015-11-09 08:11:18.171468@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:11:33.129916||measurement||ad||2015-11-09 08:11:31.494062@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||3||1
+2015-11-09 08:11:33.671450||measurement||ad||2015-11-09 08:11:31.494062@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:11:33.691927||measurement||loadtime||0:00:40.131100||3||1
+2015-11-09 08:11:36.860461||measurement||ad||2015-11-09 08:11:18.171468@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:11:37.120094||measurement||loadtime||0:00:53.723672||5||0
+2015-11-09 08:11:45.218331||error||collecting ads||Error||0||1
+2015-11-09 08:12:00.869358||measurement||ad||2015-11-09 08:11:59.790224@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||2||1
+2015-11-09 08:12:01.849925||measurement||ad||2015-11-09 08:11:59.790224@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:12:01.881048||measurement||loadtime||0:00:42.447035||2||1
+2015-11-09 08:12:14.447501||measurement||ad||2015-11-09 08:11:45.901511@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 08:12:17.942116||measurement||ad||2015-11-09 08:11:45.901511@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||4||0
+2015-11-09 08:12:18.348670||measurement||loadtime||0:01:13.766674||4||0
+2015-11-09 08:12:18.552114||measurement||ad||2015-11-09 08:12:04.646732@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 08:12:21.684707||measurement||ad||2015-11-09 08:12:19.896558@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:12:22.073749||measurement||ad||2015-11-09 08:12:19.896558@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:12:22.107345||measurement||loadtime||0:00:43.414318||3||1
+2015-11-09 08:12:23.378509||measurement||ad||2015-11-09 08:12:04.646732@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||1||0
+2015-11-09 08:12:23.430658||measurement||loadtime||0:01:01.770956||1||0
+2015-11-09 08:12:32.491733||measurement||ad||2015-11-09 08:12:31.356075@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||0||1
+2015-11-09 08:12:32.629041||measurement||ad||2015-11-09 08:12:31.356075@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||0||1
+2015-11-09 08:12:32.801727||measurement||loadtime||0:00:42.582140||0||1
+2015-11-09 08:12:41.661154||measurement||ad||2015-11-09 08:12:28.519509@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:12:50.842550||measurement||ad||2015-11-09 08:12:50.169102@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||2||1
+2015-11-09 08:12:51.182347||measurement||ad||2015-11-09 08:12:50.169102@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:12:51.213502||measurement||loadtime||0:00:44.331087||2||1
+2015-11-09 08:12:51.223378||event||progress-marker||measurement-end||2||1
+2015-11-09 08:12:55.441398||measurement||ad||2015-11-09 08:12:28.519509@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:12:55.771691||measurement||loadtime||0:01:13.649983||5||0
+2015-11-09 08:13:02.375841||measurement||ad||2015-11-09 08:12:53.189587@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||0
+2015-11-09 08:13:02.534202||measurement||ad||2015-11-09 08:12:53.189587@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||1||0
+2015-11-09 08:13:02.540666||measurement||loadtime||0:00:34.108790||1||0
+2015-11-09 08:13:02.546261||event||progress-marker||measurement-end||1||0
+2015-11-09 08:13:08.368916||measurement||ad||2015-11-09 08:12:57.272416@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 08:13:08.534949||measurement||ad||2015-11-09 08:12:57.272416@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:13:08.547212||measurement||loadtime||0:00:45.197558||4||0
+2015-11-09 08:13:24.988674||measurement||ad||2015-11-09 08:13:22.450408@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||3||1
+2015-11-09 08:13:26.559107||measurement||ad||2015-11-09 08:13:22.450408@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||3||1
+2015-11-09 08:13:26.686784||measurement||loadtime||0:00:59.578391||3||1
+2015-11-09 08:13:26.687106||event||progress-marker||measurement-end||3||1
+2015-11-09 08:13:34.140007||measurement||ad||2015-11-09 08:13:29.169722@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:13:34.285489||measurement||ad||2015-11-09 08:13:29.169722@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:13:34.289634||measurement||loadtime||0:00:33.517028||5||0
+2015-11-09 08:13:37.298385||measurement||ad||2015-11-09 08:13:36.410832@|5 Foods That Hurt Liver@|perfectorigins.com/5Foods.php@|Watch and learn the 5 damaging foods for your liver  weight.||0||1
+2015-11-09 08:13:37.433767||measurement||ad||2015-11-09 08:13:36.410832@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||0||1
+2015-11-09 08:13:37.441918||measurement||loadtime||0:00:59.639418||0||1
+2015-11-09 08:13:37.443242||event||progress-marker||measurement-end||0||1
+2015-11-09 08:13:54.826925||measurement||ad||2015-11-09 08:13:49.430419@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 08:13:54.946531||measurement||ad||2015-11-09 08:13:49.430419@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:13:54.953683||measurement||loadtime||0:00:41.405335||4||0
+2015-11-09 08:13:59.783384||measurement||ad||2015-11-09 08:13:56.317580@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:13:59.874367||measurement||ad||2015-11-09 08:13:56.317580@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:13:59.879136||measurement||loadtime||0:00:20.588664||5||0
+2015-11-09 08:14:23.765735||measurement||ad||2015-11-09 08:14:18.126380@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||4||0
+2015-11-09 08:14:23.958439||measurement||ad||2015-11-09 08:14:18.126380@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:14:23.963073||measurement||loadtime||0:00:24.007808||4||0
+2015-11-09 08:14:57.184069||measurement||ad||2015-11-09 08:14:45.863126@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 08:14:59.062543||measurement||ad||2015-11-09 08:14:45.863126@|Oxide Design Co.@|oxidedesign.com/civic-design@|Election and civic design. Clear ballot interfaces for voters.||4||0
+2015-11-09 08:14:59.084825||measurement||loadtime||0:00:30.120296||4||0
+2015-11-09 08:14:59.085129||event||progress-marker||measurement-end||4||0
+2015-11-09 08:15:04.976577||error||collecting ads||Error||5||0
+2015-11-09 08:15:04.977027||event||progress-marker||measurement-end||5||0
+2015-11-09 08:15:05.699229||meta||block_id end||22
+2015-11-09 08:15:05.701102||meta||block_id start||23
+2015-11-09 08:15:05.701381||meta||assignment||4@|3@|5@|0@|2@|1
+2015-11-09 08:15:09.689747||event||progress-marker||training-start||4||0
+2015-11-09 08:15:09.883687||event||progress-marker||training-start||5||0
+2015-11-09 08:15:10.103493||event||progress-marker||training-start||3||0
+2015-11-09 08:15:14.502605||event||progress-marker||training-start||0||1
+2015-11-09 08:15:14.840521||event||progress-marker||training-start||1||1
+2015-11-09 08:15:15.355756||treatment||google search||Buy BMW||4||0
+2015-11-09 08:15:15.380143||treatment||google search||Buy BMW||5||0
+2015-11-09 08:15:15.451412||event||progress-marker||training-start||2||1
+2015-11-09 08:15:16.241542||treatment||google search||Buy BMW||3||0
+2015-11-09 08:15:17.408347||error||visiting||google searchresults||4||0
+2015-11-09 08:15:17.460442||error||visiting||google searchresults||5||0
+2015-11-09 08:15:17.923424||error||visiting||google searchresults||3||0
+2015-11-09 08:15:20.075440||treatment||google search||Buy BMW||0||1
+2015-11-09 08:15:20.308579||treatment||google search||Buy BMW||1||1
+2015-11-09 08:15:20.373330||treatment||google search||Buy BMW||2||1
+2015-11-09 08:15:31.147255||error||visiting||google searchresults||0||1
+2015-11-09 08:15:31.252972||error||visiting||google searchresults||1||1
+2015-11-09 08:15:31.278068||error||visiting||google searchresults||2||1
+2015-11-09 08:15:35.916555||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 08:15:36.110010||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 08:15:38.120326||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 08:15:45.110938||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 08:15:45.219972||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 08:15:47.422096||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 08:15:50.731605||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||4||0
+2015-11-09 08:15:51.488376||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||5||0
+2015-11-09 08:15:52.987737||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||3||0
+2015-11-09 08:16:00.401591||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||1||1
+2015-11-09 08:16:00.809204||error||visiting||google searchresults||4||0
+2015-11-09 08:16:00.886681||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||0||1
+2015-11-09 08:16:01.236027||treatment||visit page||http://www.bmwpittsburgh.com/Finance/default.aspx||2||1
+2015-11-09 08:16:01.533951||error||visiting||google searchresults||5||0
+2015-11-09 08:16:03.023615||error||visiting||google searchresults||3||0
+2015-11-09 08:16:18.635763||treatment||visit page||http://www.bmwpittsburgh.com/Finance/Default.aspx||5||0
+2015-11-09 08:16:19.153487||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 08:16:19.159413||treatment||visit page||http://www.bmwpittsburgh.com/Finance/financeoffers.aspx||3||0
+2015-11-09 08:16:20.464587||error||visiting||google searchresults||1||1
+2015-11-09 08:16:20.921829||error||visiting||google searchresults||0||1
+2015-11-09 08:16:21.331216||error||visiting||google searchresults||2||1
+2015-11-09 08:16:30.501978||treatment||google search||BMW dealer||5||0
+2015-11-09 08:16:31.880954||treatment||google search||BMW dealer||3||0
+2015-11-09 08:16:32.075160||treatment||google search||BMW dealer||4||0
+2015-11-09 08:16:32.324006||error||visiting||google searchresults||5||0
+2015-11-09 08:16:33.237197||error||visiting||google searchresults||3||0
+2015-11-09 08:16:33.431758||error||visiting||google searchresults||4||0
+2015-11-09 08:16:35.308164||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||0||1
+2015-11-09 08:16:35.646630||treatment||visit page||http://www.bmwpittsburgh.com/Finance/LeaseOffers.aspx||2||1
+2015-11-09 08:16:36.846992||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 08:16:51.434738||treatment||visit page||http://www.usautomart.com/?gclid=CJ7nuby2g8kCFdgUgQod7XIEQg||5||0
+2015-11-09 08:16:51.581022||treatment||google search||BMW dealer||0||1
+2015-11-09 08:16:52.269811||treatment||visit page||http://www.usautomart.com/?gclid=CPGb-Ly2g8kCFcUlgQodKCwN8A||3||0
+2015-11-09 08:16:52.412049||treatment||google search||BMW dealer||2||1
+2015-11-09 08:16:53.189747||treatment||google search||BMW dealer||1||1
+2015-11-09 08:16:55.995452||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CLn6_by2g8kCFdc9gQodIHYKDg||4||0
+2015-11-09 08:17:03.100941||error||visiting||google searchresults||0||1
+2015-11-09 08:17:03.579247||error||visiting||google searchresults||2||1
+2015-11-09 08:17:04.576918||error||visiting||google searchresults||1||1
+2015-11-09 08:17:06.579567||treatment||visit page||http://www.usautomart.com/?gclid=CMuNxsW2g8kCFU06gQodJ08OJw||5||0
+2015-11-09 08:17:07.551789||treatment||visit page||http://www.usautomart.com/?gclid=CPOP-sW2g8kCFUo6gQodotYFog||3||0
+2015-11-09 08:17:11.806935||treatment||visit page||http://www.pandwbmw.com/schedule-service.htm?gclid=CNSA3se2g8kCFdgJgQodmYkNDA||4||0
+2015-11-09 08:17:16.623770||error||visiting||google searchresults||5||0
+2015-11-09 08:17:17.606688||error||visiting||google searchresults||3||0
+2015-11-09 08:17:19.160246||treatment||visit page||http://www.usautomart.com/?gclid=COLF7cu2g8kCFZAkgQodbqcDvw||1||1
+2015-11-09 08:17:20.017280||treatment||visit page||http://www.usautomart.com/?gclid=CMm_kMu2g8kCFUUlgQodxcoKZQ||0||1
+2015-11-09 08:17:21.868364||error||visiting||google searchresults||4||0
+2015-11-09 08:17:22.183071||treatment||visit page||http://www.carsense.com/?gclid=CILFscu2g8kCFU82gQodctkLuw||2||1
+2015-11-09 08:17:33.404228||treatment||visit page||http://www.auto-price-finder.com/new/car_branded_make?kw=BMW+&land=y||5||0
+2015-11-09 08:17:34.506234||treatment||visit page||http://www.usautomart.com/?gclid=CKjvmdO2g8kCFdgagQodCK4AMg||0||1
+2015-11-09 08:17:34.552874||treatment||visit page||http://www.auto-price-finder.com/new/car_branded_make?kw=BMW+&land=y||3||0
+2015-11-09 08:17:34.665882||treatment||visit page||http://www.usautomart.com/?gclid=CMTT5NK2g8kCFVY2gQodCsIKEQ||1||1
+2015-11-09 08:17:38.951434||treatment||visit page||http://www.carsense.com/?gclid=CMSqr9S2g8kCFdgPgQodEnsOlw||2||1
+2015-11-09 08:17:41.415905||treatment||visit page||http://www.carsense.com/?gclid=CKvCidS2g8kCFY49gQodmmkLMA||4||0
+2015-11-09 08:17:45.126025||treatment||google search||BMW||5||0
+2015-11-09 08:17:46.439037||treatment||google search||BMW||3||0
+2015-11-09 08:17:46.883230||error||visiting||google searchresults||5||0
+2015-11-09 08:17:47.287314||error||visiting||google searchresults||3||0
+2015-11-09 08:17:53.034500||treatment||google search||BMW||4||0
+2015-11-09 08:17:54.028841||error||visiting||google searchresults||4||0
+2015-11-09 08:17:54.572287||error||visiting||google searchresults||0||1
+2015-11-09 08:17:54.699702||error||visiting||google searchresults||1||1
+2015-11-09 08:17:59.058469||error||visiting||google searchresults||2||1
+2015-11-09 08:18:10.298735||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 08:18:10.405736||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 08:18:11.415463||treatment||visit page||http://www.auto-price-finder.com/new/car_branded_make?kw=BMW+&land=y||0||1
+2015-11-09 08:18:11.658873||treatment||visit page||http://www.auto-price-finder.com/new/car_branded_make?kw=BMW+&land=y||1||1
+2015-11-09 08:18:12.457985||treatment||visit page||http://www.towerautosales.com/index.shtml||2||1
+2015-11-09 08:18:13.878062||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 08:18:25.962668||treatment||google search||BMW||0||1
+2015-11-09 08:18:27.132566||treatment||google search||BMW||1||1
+2015-11-09 08:18:27.702833||treatment||google search||BMW||2||1
+2015-11-09 08:18:29.265341||treatment||visit page||http://www.bmwusa.com/||5||0
+2015-11-09 08:18:29.345503||treatment||visit page||http://www.bmwusa.com/||3||0
+2015-11-09 08:18:31.394513||treatment||visit page||http://www.bmwusa.com/||4||0
+2015-11-09 08:18:37.777757||error||visiting||google searchresults||0||1
+2015-11-09 08:18:39.140967||error||visiting||google searchresults||1||1
+2015-11-09 08:18:39.304974||error||visiting||google searchresults||5||0
+2015-11-09 08:18:39.380691||error||visiting||google searchresults||3||0
+2015-11-09 08:18:39.401421||error||visiting||google searchresults||2||1
+2015-11-09 08:18:41.431241||error||visiting||google searchresults||4||0
+2015-11-09 08:19:03.867513||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||3||0
+2015-11-09 08:19:04.341807||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||5||0
+2015-11-09 08:19:05.839862||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||4||0
+2015-11-09 08:19:07.241789||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 08:19:10.844736||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 08:19:13.700788||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 08:19:13.870568||event||progress-marker||training-end||3||0
+2015-11-09 08:19:14.343495||event||progress-marker||training-end||5||0
+2015-11-09 08:19:15.841599||event||progress-marker||training-end||4||0
+2015-11-09 08:19:23.100659||treatment||visit page||http://www.bmwusa.com/||2||1
+2015-11-09 08:19:26.888525||treatment||visit page||http://www.bmwusa.com/||0||1
+2015-11-09 08:19:28.441085||treatment||visit page||http://www.bmwusa.com/||1||1
+2015-11-09 08:19:43.231980||error||visiting||google searchresults||2||1
+2015-11-09 08:19:46.944047||error||visiting||google searchresults||0||1
+2015-11-09 08:19:48.498165||error||visiting||google searchresults||1||1
+2015-11-09 08:20:00.164439||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||2||1
+2015-11-09 08:20:00.814363||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||0||1
+2015-11-09 08:20:02.579042||treatment||visit page||http://www.bmwusa.com/standard/content/byo/default.aspx||1||1
+2015-11-09 08:20:10.165881||event||progress-marker||training-end||2||1
+2015-11-09 08:20:10.816099||event||progress-marker||training-end||0||1
+2015-11-09 08:20:12.580869||event||progress-marker||training-end||1||1
+2015-11-09 08:20:14.296104||event||progress-marker||measurement-start||3||0
+2015-11-09 08:20:14.766411||event||progress-marker||measurement-start||5||0
+2015-11-09 08:20:15.219007||event||progress-marker||measurement-start||2||1
+2015-11-09 08:20:15.876928||event||progress-marker||measurement-start||0||1
+2015-11-09 08:20:16.226575||event||progress-marker||measurement-start||4||0
+2015-11-09 08:20:17.633849||event||progress-marker||measurement-start||1||1
+2015-11-09 08:21:12.280171||measurement||ad||2015-11-09 08:21:11.093489@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:21:12.761332||measurement||ad||2015-11-09 08:21:11.093489@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||2||1
+2015-11-09 08:21:12.889349||measurement||loadtime||0:00:52.669085||2||1
+2015-11-09 08:21:21.054382||measurement||ad||2015-11-09 08:21:03.845679@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 08:21:21.712860||measurement||ad||2015-11-09 08:21:03.845679@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 08:21:21.721009||measurement||loadtime||0:01:02.423286||3||0
+2015-11-09 08:21:26.724837||measurement||ad||2015-11-09 08:21:24.568021@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 08:21:27.065700||measurement||ad||2015-11-09 08:21:24.334168@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||0||1
+2015-11-09 08:21:27.915987||measurement||ad||2015-11-09 08:21:24.568021@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 08:21:28.287421||measurement||loadtime||0:01:05.652937||1||1
+2015-11-09 08:21:28.331010||measurement||ad||2015-11-09 08:21:24.334168@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 08:21:28.450004||measurement||loadtime||0:01:07.571741||0||1
+2015-11-09 08:21:31.762578||measurement||ad||2015-11-09 08:21:13.653204@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||0
+2015-11-09 08:21:40.584189||measurement||ad||2015-11-09 08:21:18.658191@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||4||0
+2015-11-09 08:21:41.056300||measurement||ad||2015-11-09 08:21:13.653204@|Medicare Open Enrollment@|www.medicare-providers.net@|#1 Medicare Site for Seniors 65+. Find the Right Medicare Plan Now.||5||0
+2015-11-09 08:21:41.388454||measurement||loadtime||0:01:21.621148||5||0
+2015-11-09 08:21:46.891606||measurement||ad||2015-11-09 08:21:18.658191@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:21:47.395434||measurement||loadtime||0:01:26.167987||4||0
+2015-11-09 08:22:04.151106||measurement||ad||2015-11-09 08:22:02.761404@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 08:22:04.706139||measurement||ad||2015-11-09 08:22:02.761404@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:22:04.767567||measurement||loadtime||0:00:46.877582||2||1
+2015-11-09 08:22:20.353039||measurement||ad||2015-11-09 08:22:19.109976@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||0||1
+2015-11-09 08:22:20.850266||measurement||ad||2015-11-09 08:22:19.109976@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:22:20.872625||measurement||loadtime||0:00:47.422067||0||1
+2015-11-09 08:22:23.103294||measurement||ad||2015-11-09 08:22:19.299185@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 08:22:24.563165||measurement||ad||2015-11-09 08:22:19.299185@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||1||1
+2015-11-09 08:22:25.321099||measurement||loadtime||0:00:52.032838||1||1
+2015-11-09 08:22:29.796963||measurement||ad||2015-11-09 08:22:03.424658@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 08:22:33.304696||measurement||ad||2015-11-09 08:22:03.424658@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 08:22:33.366587||measurement||loadtime||0:01:06.644461||3||0
+2015-11-09 08:22:46.718016||measurement||ad||2015-11-09 08:22:31.055864@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 08:22:47.161626||error||collecting ads||Error||5||0
+2015-11-09 08:22:48.916852||measurement||ad||2015-11-09 08:22:31.055864@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:22:49.085932||measurement||loadtime||0:00:56.689814||4||0
+2015-11-09 08:22:56.028719||measurement||ad||2015-11-09 08:22:53.383865@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 08:22:56.666724||measurement||ad||2015-11-09 08:22:53.383865@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:22:56.826110||measurement||loadtime||0:00:47.058005||2||1
+2015-11-09 08:23:00.847281||measurement||ad||2015-11-09 08:22:59.938134@|H-1B Fast Processing@|www.lawimm.com@|1000s of visas approved: Trust our Experienced lawyers, rest assured.||0||1
+2015-11-09 08:23:01.082572||measurement||ad||2015-11-09 08:22:59.938134@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:23:01.100393||measurement||loadtime||0:00:35.226430||0||1
+2015-11-09 08:23:12.174822||measurement||ad||2015-11-09 08:23:11.503570@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 08:23:12.873029||measurement||ad||2015-11-09 08:23:11.503570@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||1||1
+2015-11-09 08:23:12.903557||measurement||loadtime||0:00:42.581696||1||1
+2015-11-09 08:23:39.879891||measurement||ad||2015-11-09 08:23:20.564733@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||3||0
+2015-11-09 08:23:40.526599||measurement||loadtime||0:01:02.159160||3||0
+2015-11-09 08:23:43.333990||measurement||ad||2015-11-09 08:23:41.781741@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:23:43.677639||measurement||ad||2015-11-09 08:23:41.781741@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:23:43.694692||measurement||loadtime||0:00:41.866777||2||1
+2015-11-09 08:23:44.372177||measurement||ad||2015-11-09 08:23:31.513774@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||4||0
+2015-11-09 08:23:44.713755||measurement||ad||2015-11-09 08:23:31.513774@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:23:44.773026||measurement||loadtime||0:00:50.686376||4||0
+2015-11-09 08:23:50.824205||measurement||ad||2015-11-09 08:23:34.036790@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||0
+2015-11-09 08:23:55.991540||measurement||ad||2015-11-09 08:23:34.036790@|Medicare Open Enrollment@|www.medicare-providers.net@|#1 Medicare Site for Seniors 65+. Find the Right Medicare Plan Now.||5||0
+2015-11-09 08:23:56.183460||measurement||loadtime||0:01:04.020221||5||0
+2015-11-09 08:23:57.156426||measurement||ad||2015-11-09 08:23:55.487166@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||0||1
+2015-11-09 08:23:57.453158||measurement||ad||2015-11-09 08:23:55.487166@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||0||1
+2015-11-09 08:23:57.472782||measurement||loadtime||0:00:51.370910||0||1
+2015-11-09 08:23:58.840427||measurement||ad||2015-11-09 08:23:58.359260@|5 Foods To Never Eat@|perfectorigins.com/5BadFoods.php@|Here are 5 foods you should never eat if You want to lose belly fat.||1||1
+2015-11-09 08:23:59.123243||measurement||ad||2015-11-09 08:23:58.359260@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 08:23:59.159239||measurement||loadtime||0:00:41.254166||1||1
+2015-11-09 08:24:25.339930||measurement||ad||2015-11-09 08:24:24.692946@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:24:25.913967||measurement||ad||2015-11-09 08:24:24.692946@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:24:25.933399||measurement||loadtime||0:00:37.237823||2||1
+2015-11-09 08:24:37.353569||measurement||ad||2015-11-09 08:24:36.178703@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 15-Yr, 30-Yr Rates, 3.3 APR*. Calculate New Rate/Payment 30 Secs!||0||1
+2015-11-09 08:24:38.622079||measurement||ad||2015-11-09 08:24:36.178703@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:24:39.002322||measurement||loadtime||0:00:36.527310||0||1
+2015-11-09 08:24:39.915009||measurement||ad||2015-11-09 08:24:25.980139@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 08:24:41.272145||measurement||ad||2015-11-09 08:24:40.598058@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 08:24:42.414408||measurement||ad||2015-11-09 08:24:40.598058@|Business Plan Template@|businessplantemplate.growthink.com@|Personalize, Print and You're Done! With My Fill-In-The-Blanks Template||1||1
+2015-11-09 08:24:42.453859||measurement||loadtime||0:00:38.293223||1||1
+2015-11-09 08:24:45.285484||measurement||ad||2015-11-09 08:24:25.980139@|Medicare Open Enrollment@|www.medicare-providers.net@|#1 Medicare Site for Seniors 65+. Find the Right Medicare Plan Now.||3||0
+2015-11-09 08:24:45.707484||measurement||loadtime||0:01:00.179357||3||0
+2015-11-09 08:24:52.930051||measurement||ad||2015-11-09 08:24:35.866719@|Email Spam Filter in@|www.gfi.com/MailEssentials@|High Gear. Eliminate 99% of Email Threats, Download 30 Day Free Trial||5||0
+2015-11-09 08:24:56.771257||measurement||ad||2015-11-09 08:24:22.826657@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||4||0
+2015-11-09 08:24:59.735299||measurement||ad||2015-11-09 08:24:22.826657@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:24:59.740670||measurement||loadtime||0:01:09.967014||4||0
+2015-11-09 08:25:02.148195||measurement||ad||2015-11-09 08:24:35.866719@|Apply for Medicare Online@|www.medicare-providers.net@|America's #1 Medicare Site. Compare Multiple Plans and Save!||5||0
+2015-11-09 08:25:02.252739||measurement||loadtime||0:01:01.067699||5||0
+2015-11-09 08:25:13.171826||measurement||ad||2015-11-09 08:25:12.291473@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||2||1
+2015-11-09 08:25:13.625807||measurement||ad||2015-11-09 08:25:12.291473@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:25:13.642084||measurement||loadtime||0:00:42.707751||2||1
+2015-11-09 08:25:29.264668||measurement||ad||2015-11-09 08:25:28.567560@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||0||1
+2015-11-09 08:25:29.763908||measurement||ad||2015-11-09 08:25:28.567560@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:25:29.778704||measurement||loadtime||0:00:45.775640||0||1
+2015-11-09 08:25:33.991962||measurement||ad||2015-11-09 08:25:33.371153@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 08:25:34.259600||measurement||ad||2015-11-09 08:25:33.371153@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||1||1
+2015-11-09 08:25:34.272636||measurement||loadtime||0:00:46.817289||1||1
+2015-11-09 08:25:56.571137||measurement||ad||2015-11-09 08:25:45.544051@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 08:26:00.830882||measurement||ad||2015-11-09 08:25:57.684190@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:26:01.047881||measurement||ad||2015-11-09 08:25:38.446689@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||3||0
+2015-11-09 08:26:01.318039||measurement||ad||2015-11-09 08:25:57.684190@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:26:01.336216||measurement||loadtime||0:00:42.692583||2||1
+2015-11-09 08:26:01.877029||measurement||loadtime||0:01:11.167820||3||0
+2015-11-09 08:26:02.650757||measurement||ad||2015-11-09 08:25:45.544051@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:26:02.833077||measurement||loadtime||0:00:58.091717||4||0
+2015-11-09 08:26:14.775692||measurement||ad||2015-11-09 08:25:50.456663@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||5||0
+2015-11-09 08:26:17.621469||measurement||ad||2015-11-09 08:25:50.456663@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||0
+2015-11-09 08:26:17.819509||measurement||loadtime||0:01:10.566170||5||0
+2015-11-09 08:26:22.875986||measurement||ad||2015-11-09 08:26:22.213642@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 08:26:23.084928||measurement||ad||2015-11-09 08:26:22.213642@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||0||1
+2015-11-09 08:26:23.095229||measurement||loadtime||0:00:48.315819||0||1
+2015-11-09 08:26:23.809048||measurement||ad||2015-11-09 08:26:21.813574@|Jail Arrest Records@|instantcheckmate.com@|Find The Truth About Anyone. View Jail Records In Seconds.||1||1
+2015-11-09 08:26:24.169549||measurement||ad||2015-11-09 08:26:21.813574@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||1||1
+2015-11-09 08:26:24.808679||measurement||loadtime||0:00:45.534822||1||1
+2015-11-09 08:26:51.862640||measurement||ad||2015-11-09 08:26:45.550827@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||2||1
+2015-11-09 08:26:52.661072||measurement||ad||2015-11-09 08:26:45.550827@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 08:26:52.856196||measurement||loadtime||0:00:46.519383||2||1
+2015-11-09 08:26:59.299428||measurement||ad||2015-11-09 08:26:42.583094@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||3||0
+2015-11-09 08:27:02.392342||measurement||loadtime||0:00:55.514404||3||0
+2015-11-09 08:27:12.591089||measurement||ad||2015-11-09 08:27:12.111165@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||1||1
+2015-11-09 08:27:12.823849||measurement||ad||2015-11-09 08:27:12.111165@|Silversea Senior Cruises@|www.silversea.com/Official_Site@|More Choices Than Any Luxury Line. The Ultimate Luxury Cruise Vacation||1||1
+2015-11-09 08:27:12.853970||measurement||loadtime||0:00:43.044791||1||1
+2015-11-09 08:27:17.604028||measurement||ad||2015-11-09 08:26:46.174691@|Not Above the Law@|www.empowerpa.org@|Time to Close Union Loopholes in PA's Stalking and Harassment Laws||4||0
+2015-11-09 08:27:21.889761||measurement||ad||2015-11-09 08:27:19.737502@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||0||1
+2015-11-09 08:27:22.972358||measurement||ad||2015-11-09 08:27:19.737502@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:27:23.000310||measurement||loadtime||0:00:54.904505||0||1
+2015-11-09 08:27:23.300521||measurement||ad||2015-11-09 08:26:46.174691@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||4||0
+2015-11-09 08:27:24.204025||measurement||loadtime||0:01:16.370080||4||0
+2015-11-09 08:27:35.967220||measurement||ad||2015-11-09 08:27:06.553191@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:27:37.934341||measurement||ad||2015-11-09 08:27:06.553191@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||5||0
+2015-11-09 08:27:37.945063||measurement||loadtime||0:01:15.124518||5||0
+2015-11-09 08:27:42.410269||error||collecting ads||Error||1||1
+2015-11-09 08:27:46.934777||measurement||ad||2015-11-09 08:27:44.797978@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||2||1
+2015-11-09 08:27:47.415608||error||collecting ads||Error||1||1
+2015-11-09 08:27:47.416151||event||progress-marker||measurement-end||1||1
+2015-11-09 08:27:48.674338||measurement||ad||2015-11-09 08:27:44.797978@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||2||1
+2015-11-09 08:27:48.825287||measurement||loadtime||0:00:50.967723||2||1
+2015-11-09 08:28:09.089508||measurement||ad||2015-11-09 08:27:49.772803@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 08:28:11.301576||measurement||ad||2015-11-09 08:27:49.772803@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 08:28:11.322923||measurement||loadtime||0:01:03.929760||3||0
+2015-11-09 08:28:19.473105||measurement||ad||2015-11-09 08:28:11.684681@|Filing Taxes@|shopperstop.us/Filing-Taxes@|Find Filing Taxes  Save Big Get All Information Here !||0||1
+2015-11-09 08:28:20.948500||measurement||ad||2015-11-09 08:28:11.684681@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:28:22.396657||measurement||loadtime||0:00:54.394684||0||1
+2015-11-09 08:28:33.562674||error||collecting ads||Error||4||0
+2015-11-09 08:28:50.182423||measurement||ad||2015-11-09 08:28:45.643398@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||2||1
+2015-11-09 08:28:50.399544||measurement||ad||2015-11-09 08:28:29.150451@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 08:28:51.017247||measurement||ad||2015-11-09 08:28:45.643398@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||2||1
+2015-11-09 08:28:51.264063||measurement||loadtime||0:00:57.437516||2||1
+2015-11-09 08:28:51.265385||event||progress-marker||measurement-end||2||1
+2015-11-09 08:28:55.566769||measurement||ad||2015-11-09 08:28:29.150451@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Locate a physician near you.||5||0
+2015-11-09 08:28:55.705994||measurement||loadtime||0:01:12.759762||5||0
+2015-11-09 08:29:14.607399||measurement||ad||2015-11-09 08:29:13.108987@|Sample Job Descriptions@|hr.blr.com/job_descriptions@|Download 1000's of job descriptions Online state HR library. Save time!||0||1
+2015-11-09 08:29:15.418879||measurement||ad||2015-11-09 08:29:13.108987@|Medicare Enrollment 2015@|medicare2015.org@|Compare Open Enrollment Options. Top Advantage, Part D,  Gap Plans!||0||1
+2015-11-09 08:29:15.543734||measurement||loadtime||0:00:48.145793||0||1
+2015-11-09 08:29:15.544981||event||progress-marker||measurement-end||0||1
+2015-11-09 08:29:21.027527||measurement||ad||2015-11-09 08:29:10.294875@|Obamacare Under $50/Month@|obamacareusa.org@|Open Enrollment is Right Now. Top Obamacare Plans Under $50/Month!||3||0
+2015-11-09 08:29:21.714667||measurement||ad||2015-11-09 08:29:10.294875@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||3||0
+2015-11-09 08:29:21.742269||measurement||loadtime||0:01:05.418503||3||0
+2015-11-09 08:29:56.061888||measurement||ad||2015-11-09 08:29:43.283927@|2.7% Fixed Mortgage Rate@|mortgagerates.freerateupdate.com@|Low 10 15-Yr, 30-Yr Rates 3.3 APR*. Calculate New Rate/Payment Fast!||4||0
+2015-11-09 08:29:56.968955||measurement||ad||2015-11-09 08:29:43.283927@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||4||0
+2015-11-09 08:29:57.000656||measurement||loadtime||0:01:18.434758||4||0
+2015-11-09 08:29:58.530539||measurement||ad||2015-11-09 08:29:39.254375@|New Nissans From $11,990@|reply.com/Nissan@|Dealers Are Slashing Prices! Everything Must Go.||5||0
+2015-11-09 08:30:01.946431||measurement||ad||2015-11-09 08:29:39.254375@|SUBOXONE® Sublingual Film@|www.suboxone.com@|(buprenorphine and naloxone) CIII. Find a doctor.||5||0
+2015-11-09 08:30:02.196192||measurement||loadtime||0:01:01.489144||5||0
+2015-11-09 08:30:25.426892||measurement||ad||2015-11-09 08:30:13.353569@|5 Foods Hurting The Liver@|perfectorigins.com/5Foods.php@|Here are 5 foods you should never eat if you want to lose belly fat.||3||0
+2015-11-09 08:30:28.096461||measurement||ad||2015-11-09 08:30:13.353569@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||3||0
+2015-11-09 08:30:28.131970||measurement||loadtime||0:01:01.389129||3||0
+2015-11-09 08:31:07.517508||error||collecting ads||Error||5||0
+2015-11-09 08:31:08.711197||measurement||ad||2015-11-09 08:30:59.769375@|Unique Bridal Necklaces@|Ads by Google@|Order Unique Neckalces For You  Your Braidemaids. Custom Made.||3||0
+2015-11-09 08:31:08.715515||measurement||loadtime||0:00:35.582095||3||0
+2015-11-09 08:31:08.717044||event||progress-marker||measurement-end||3||0
+2015-11-09 08:31:14.837513||measurement||ad||2015-11-09 08:30:51.678149@|STAT@|statnews.com@|Hard hitting journalism in science, health, business and politics.||4||0
+2015-11-09 08:31:15.244065||measurement||ad||2015-11-09 08:30:51.678149@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:31:15.533566||measurement||loadtime||0:01:13.532291||4||0
+2015-11-09 08:31:40.738141||measurement||ad||2015-11-09 08:31:32.695953@|Run Windows on Mac@|parallels.com/Windows-on-Mac@|Windows + Mac = Easy  Powerful. Mac Features in Windows. Try Free!||5||0
+2015-11-09 08:31:44.321916||measurement||ad||2015-11-09 08:31:40.187632@|Medicare Open Enrollment@|medicare2015.org@|Open Enrollment is Now. Compare the Top 2015 Advantage  Medigap Plans!||4||0
+2015-11-09 08:31:44.446568||measurement||ad||2015-11-09 08:31:40.187632@|Parkinson's Treatment@|www.healthcentral.com/ParkinsonsDBS@|Receive Free Information Now on DBS Therapy for Parkinson's||4||0
+2015-11-09 08:31:44.452562||measurement||loadtime||0:00:23.917669||4||0
+2015-11-09 08:31:44.454207||event||progress-marker||measurement-end||4||0
+2015-11-09 08:31:45.833838||measurement||ad||2015-11-09 08:31:32.695953@|Medicare Open Enrollment@|www.medicare-providers.net@|#1 Medicare Site for Seniors 65+. Find the Right Medicare Plan Now.||5||0
+2015-11-09 08:31:45.837326||measurement||loadtime||0:00:33.317490||5||0
+2015-11-09 08:31:45.837530||event||progress-marker||measurement-end||5||0
+2015-11-09 08:31:46.558622||meta||block_id end||23


### PR DESCRIPTION
I add several files to complete this project.
1. The amazon_prices.py can catch the price of first two products in the last row of Amazon's homepage.
2. In the statistics.py, I add a function called print_mean to ouput the mean and std of price in different groups. In the reader.py, I add a function called read_log_amazon, which is basically as same as read_log function, except I collect all the prices information and save them into a dictionary. Maybe this is not the most efficient way to calculate the means, but it does work.
3. In the price.py, basically I didn't change anything. I just created it and eventually I find that I don't need this part.